### PR TITLE
Phase 2: Reporter + Screen Renderer plugin registries

### DIFF
--- a/tui_verifier/builtin_renderers.py
+++ b/tui_verifier/builtin_renderers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 from pathlib import Path
 from typing import Protocol
 
@@ -20,7 +21,7 @@ class ScreenRenderer(Protocol):
 
 
 class SvgRenderer:
-    """SVG screen renderer (current behavior)."""
+    """SVG screen renderer."""
 
     name = "svg"
 
@@ -31,6 +32,21 @@ class SvgRenderer:
         cols: int,
         rows: int,
     ) -> None:
-        from .screen import render_svg
+        line_height = 20
+        char_width = 9
+        padding = 18
+        width = max(320, cols * char_width + padding * 2)
+        height = max(160, rows * line_height + padding * 2)
+        visible_lines = text.splitlines()[:rows] or [""]
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        render_svg(text, output_path, cols, rows)
+        parts = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+            '<rect width="100%" height="100%" fill="#101418"/>',
+            '<style>text{font:14px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;fill:#e6edf3;white-space:pre}</style>',
+        ]
+        for index, line in enumerate(visible_lines):
+            y = padding + line_height * (index + 1)
+            parts.append(f'<text x="{padding}" y="{y}">{html.escape(line)}</text>')
+        parts.append("</svg>")
+        output_path.write_text("\n".join(parts) + "\n", encoding="utf-8")

--- a/tui_verifier/builtin_reporters.py
+++ b/tui_verifier/builtin_reporters.py
@@ -22,7 +22,7 @@ class Reporter(Protocol):
 
 
 class MarkdownReporter:
-    """Markdown report (current behavior)."""
+    """Markdown report generator."""
 
     name = "markdown"
 
@@ -32,6 +32,75 @@ class MarkdownReporter:
         build_info: BuildInfo | None = None,
         before_after: BeforeAfterResult | None = None,
     ) -> str:
-        from .report import ReportGenerator
+        passed = sum(1 for result in results if result.passed)
+        lines = [
+            f"# TUI Verification - {passed}/{len(results)} Passed",
+            "",
+        ]
+        if build_info is not None:
+            lines.extend(_build_info_lines(build_info))
+        if before_after is not None:
+            lines.extend(["", before_after.to_markdown().rstrip(), ""])
+        lines.extend(
+            [
+                "| Recipe | Renderer | Priority | Execution | Result | Score | Evidence |",
+                "| --- | --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for result in results:
+            status = "PASS" if result.passed else "FAIL"
+            evidence = _evidence_links(result)
+            lines.append(
+                f"| `{result.recipe_name}` | `{result.renderer}` | `{result.priority}` | "
+                f"`{result.execution}` | {status} | {result.score:.2f} | {evidence} |"
+            )
+        for result in results:
+            lines.extend(["", _detail(result).rstrip()])
+        return "\n".join(lines) + "\n"
 
-        return ReportGenerator().generate_markdown(results, build_info, before_after)
+
+def _build_info_lines(build_info: BuildInfo) -> list[str]:
+    verified = "yes" if build_info.verify_provenance() else "no"
+    return [
+        "## Build Provenance",
+        "",
+        f"- Mode: `{build_info.mode}`",
+        f"- Command: `{_one_line(' '.join(build_info.command))}`",
+        f"- Binary: `{_one_line(str(build_info.binary_path))}`",
+        f"- Version: `{_one_line(build_info.version)}`",
+        f"- Git commit: `{_one_line(str(build_info.git_commit))}`",
+        f"- Verified: `{verified}`",
+        "",
+    ]
+
+
+def _evidence_links(result: RunResult) -> str:
+    links: list[str] = []
+    for key in ("screenshot", "video", "cast", "screen_text", "step_screenshots"):
+        value = result.artifacts.get(key)
+        if value:
+            links.append(f"[{key}]({value})")
+    return " / ".join(links) if links else "-"
+
+
+def _detail(result: RunResult) -> str:
+    status = "PASS" if result.passed else "FAIL"
+    lines = [
+        f"<details><summary>{status} {result.recipe_name} [{result.renderer}]</summary>",
+        "",
+        "### Assertions",
+        "",
+    ]
+    for assertion in result.assertions:
+        mark = "PASS" if assertion.passed else "FAIL"
+        lines.append(f"- {mark} `{assertion.name}` - {assertion.detail}")
+    lines.extend(["", "### Steps", ""])
+    for step in result.steps:
+        mark = "PASS" if step.passed else "FAIL"
+        lines.append(f"- {mark} `{step.name}` - {step.detail}")
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
+
+
+def _one_line(value: str) -> str:
+    return " / ".join(part.strip() for part in value.splitlines() if part.strip())

--- a/tui_verifier/cli.py
+++ b/tui_verifier/cli.py
@@ -9,7 +9,6 @@ from .build_info import BuildInfo
 from .config import VerifierConfig, load_config
 from .registry import load_recipes, select_recipes
 from .renderer import selected_renderers
-from .report import ReportGenerator
 from .runner import VerificationRunner
 from .scaffold import write_recipe_pack
 
@@ -29,6 +28,10 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--operator-command")
     run_parser.add_argument("--config", type=Path, default=None,
                             help="path to a tui-verifier config YAML file")
+    run_parser.add_argument("--reporter", default="markdown",
+                            help="reporter to use (default: markdown)")
+    run_parser.add_argument("--screen-renderer", default="svg",
+                            help="screen renderer to use (default: svg)")
     list_parser = subparsers.add_parser("list", help="list recipes")
     list_parser.add_argument("recipes", nargs="+", type=Path)
     list_parser.add_argument("--priority")
@@ -65,10 +68,12 @@ def main(argv: list[str] | None = None) -> int:
                         video_fps=args.video_fps,
                         renderer=renderer_name,
                         renderer_argv=renderer_argv,
+                        screen_renderer_name=args.screen_renderer,
                     )
                 )
         build_info = BuildInfo.from_command(recipes[0].command.argv) if recipes else None
-        report = ReportGenerator().generate_markdown(results, build_info=build_info)
+        reporter = runner.reporter_registry.get(args.reporter)
+        report = reporter.generate(results, build_info=build_info)
         args.out.mkdir(parents=True, exist_ok=True)
         report_path = args.out / "latest-report.md"
         report_path.write_text(report, encoding="utf-8")

--- a/tui_verifier/evidence.py
+++ b/tui_verifier/evidence.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from .models import RunResult, StepResult
 from .screen import render_svg, replay_cast
@@ -24,13 +25,17 @@ def render_artifacts(
     steps: list[StepResult] | None = None,
     cols: int | None = None,
     rows: int | None = None,
+    screen_renderer: Any = None,
 ) -> dict[str, str]:
     cast_path = run_dir / "session.cast"
     final_text, cols, rows = replay_cast(cast_path)
     final_txt = run_dir / "final.txt"
     final_svg = run_dir / "final.svg"
     final_txt.write_text(final_text + "\n", encoding="utf-8")
-    render_svg(final_text, final_svg, cols, rows)
+    if screen_renderer is not None:
+        screen_renderer.render(final_text, final_svg, cols, rows)
+    else:
+        render_svg(final_text, final_svg, cols, rows)
     artifacts = {
         "cast": str(cast_path),
         "screenshot": str(final_svg),
@@ -39,7 +44,7 @@ def render_artifacts(
     exit_code_path = run_dir / "session.exitcode"
     if exit_code_path.exists():
         artifacts["exit_code_file"] = str(exit_code_path)
-    step_dir = _render_step_screens(run_dir, steps or [], cols, rows)
+    step_dir = _render_step_screens(run_dir, steps or [], cols, rows, screen_renderer)
     if step_dir is not None:
         artifacts["step_screenshots"] = str(step_dir)
     for name in ("agent_prompt.md", "agent_transcript.md", "agent_outcome.json"):
@@ -58,6 +63,7 @@ def _render_step_screens(
     steps: list[StepResult],
     cols: int,
     rows: int,
+    screen_renderer: Any = None,
 ) -> Path | None:
     if not steps:
         return None
@@ -67,7 +73,10 @@ def _render_step_screens(
         safe_name = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in step.name)
         path_base = step_dir / f"{index:02d}-{safe_name}"
         (path_base.with_suffix(".txt")).write_text(step.screen + "\n", encoding="utf-8")
-        render_svg(step.screen, path_base.with_suffix(".svg"), cols, rows)
+        if screen_renderer is not None:
+            screen_renderer.render(step.screen, path_base.with_suffix(".svg"), cols, rows)
+        else:
+            render_svg(step.screen, path_base.with_suffix(".svg"), cols, rows)
     return step_dir
 
 

--- a/tui_verifier/runner.py
+++ b/tui_verifier/runner.py
@@ -40,6 +40,22 @@ def _build_assertion_registry(config: VerifierConfig) -> Registry[Any]:
     return registry
 
 
+def _build_reporter_registry(config: VerifierConfig) -> Registry[Any]:
+    registry: Registry[Any] = Registry()
+    for name, qualname in config.reporters.items():
+        cls = _import_class(qualname)
+        registry.register(name, lambda c=cls: c())
+    return registry
+
+
+def _build_renderer_registry(config: VerifierConfig) -> Registry[Any]:
+    registry: Registry[Any] = Registry()
+    for name, qualname in config.screen_renderers.items():
+        cls = _import_class(qualname)
+        registry.register(name, lambda c=cls: c())
+    return registry
+
+
 def _import_class(qualname: str) -> type:
     """Import a class from 'module.path:ClassName' string."""
     if ":" not in qualname:
@@ -63,6 +79,8 @@ class VerificationRunner:
         self.config = config or VerifierConfig.builtin()
         self.step_registry = _build_step_registry(self.config)
         self.assertion_registry = _build_assertion_registry(self.config)
+        self.reporter_registry = _build_reporter_registry(self.config)
+        self.screen_renderer_registry = _build_renderer_registry(self.config)
 
     def run(
         self,
@@ -72,6 +90,7 @@ class VerificationRunner:
         video_fps: int = 60,
         renderer: str = "default",
         renderer_argv: list[str] | None = None,
+        screen_renderer_name: str = "svg",
     ) -> RunResult:
         start = time.monotonic()
         runnable_recipe = _with_renderer_argv(recipe, renderer_argv or [])
@@ -89,6 +108,7 @@ class VerificationRunner:
         else:
             steps, raw_output, exit_code, screen = self._run_process(runnable_recipe, run_dir)
             assertions = self._evaluate_assertions(recipe, screen, raw_output, exit_code)
+        screen_renderer = self.screen_renderer_registry.get(screen_renderer_name)
         artifacts = render_artifacts(
             run_dir,
             render_video,
@@ -96,6 +116,7 @@ class VerificationRunner:
             steps=steps,
             cols=recipe.cols,
             rows=recipe.rows,
+            screen_renderer=screen_renderer,
         )
         score = score_from_assertions(assertions)
         passed = all(step.passed for step in steps) and all(a.passed for a in assertions)


### PR DESCRIPTION
- Convert MarkdownReporter from thin wrapper to full implementation
- Convert SvgRenderer from thin wrapper to full implementation
- Add reporter_registry and screen_renderer_registry to VerificationRunner
- Add --reporter and --screen-renderer CLI flags
- Wire screen renderer through render_artifacts/evidence pipeline
- Backward compatible: defaults match original behavior
