### PR TITLE
Stabilize plugin protocol API

### DIFF
--- a/docs/plugin-protocols.md
+++ b/docs/plugin-protocols.md
@@ -1,0 +1,36 @@
+# Plugin protocol stability
+
+TermProof exposes stable plugin protocols from `termproof.protocols`.
+
+## Stable protocols
+
+| Protocol | Required method |
+| --- | --- |
+| `StepAction` | `execute(session, step, index) -> StepResult` |
+| `AssertionType` | `evaluate(recipe, assertion, screen, raw_output, exit_code) -> AssertionResult` |
+| `ExecutionMode` | `execute(runner, recipe, run_dir) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]` |
+| `Reporter` | `generate(results, build_info=None, before_after=None) -> str` |
+| `ScreenRenderer` | `render(text, output_path, cols, rows) -> None` |
+| `VideoBackend` | `render(cast_path, output_path, fps) -> None` |
+| `AgentRunner` | `run(recipe, prompt, run_dir) -> AgentOutcome` |
+| `SessionBackend` | `create_session(argv, cast_path, cwd, env, cols, rows) -> TerminalSession` |
+
+`StepAction`, `AssertionType`, `ExecutionMode`, `Reporter`, `ScreenRenderer`, and `VideoBackend` also require a `name: str` class attribute. `AgentRunner` and `SessionBackend` are selected by config keys and do not require a `name`.
+
+## Import policy
+
+New plugins should import protocols from `termproof.protocols`:
+
+```python
+from termproof.protocols import StepAction, AssertionType, Reporter
+```
+
+The older import locations, such as `termproof.builtin_steps.StepAction`, remain compatibility re-exports.
+
+## Version and deprecation policy
+
+- The signatures above are stable for TermProof `0.x` and `1.x`.
+- Additive changes are allowed when existing plugins keep working without source changes.
+- Breaking protocol changes require a major version bump and a migration guide.
+- Deprecated protocol behavior must stay available for at least one minor release after the deprecation is documented.
+- Legacy `tui_verifier.*:Class` config references are still remapped to `termproof.*:Class`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -12,13 +12,12 @@ steps:
   wait_for_regex: my_org.termproof_steps:WaitForRegexStep
 assertions:
   json_schema: my_org.termproof_assertions:JsonSchemaAssertion
-session_backends:
-  docker: my_org.termproof_session:DockerSessionBackend
+session_backend: my_org.termproof_session:DockerSessionBackend
 reporters:
   junit_xml: my_org.termproof_reporters:JunitReporter
 ```
 
-See [`docs/recipe-packs.md`](recipe-packs.md) for the contract and `termproof/config.py` for built-ins.
+See [`plugin-protocols.md`](plugin-protocols.md) for the stable protocol contract and `termproof/config.py` for built-ins.
 
 ## Listing
 
@@ -63,4 +62,4 @@ If you publish a first-party example as a separate repo (per [#23](https://githu
 ## Registry roadmap
 
 - Manual list (now, this file) → automated registry when >30 entries (see [#22](https://github.com/md-mt/termproof/issues/22)).
-- Protocol stability guarantee (see [#32](https://github.com/md-mt/termproof/issues/32)) and recipe format v1.0 (see [#31](https://github.com/md-mt/termproof/issues/31)) will precede a stable external plugin API.
+- Protocol stability is documented in [`plugin-protocols.md`](plugin-protocols.md). Recipe format v1.0 remains tracked in [#31](https://github.com/md-mt/termproof/issues/31).

--- a/plugin-template/README.md
+++ b/plugin-template/README.md
@@ -80,7 +80,8 @@ termproof run .termproof/recipes --reporter json_summary
 
 | TermProof version | Supported | Notes |
 |-------------------|-----------|-------|
-| >=0.1.0           | yes       | Current plugin protocols (StepAction, AssertionType, Reporter, ScreenRenderer, VideoBackend, SessionBackend, ExecutionMode, AgentRunner) |
+| >=0.2.1           | yes       | Stable plugin protocols exported from `termproof.protocols` |
+| >=0.1.0           | yes       | Legacy protocol import locations remain compatibility re-exports |
 | legacy tui_verifier prefix | yes via compat shim | tui_verifier.*:Cls auto-remapped |
 
 Guard version requirement in pyproject.toml: `termproof>=0.1.0`.

--- a/plugin-template/docs/protocol.md
+++ b/plugin-template/docs/protocol.md
@@ -1,6 +1,6 @@
 # Protocol compatibility
 
-## Current protocols (TermProof >=0.1.0)
+## Stable protocols (TermProof >=0.2.1)
 
 | Extension point | Config key | Example qualname |
 |-----------------|------------|-------------------|
@@ -13,7 +13,9 @@
 | Execution mode | execution_modes | my_plugin.modes:MyMode |
 | Agent runner | agent_runners | my_plugin.agents:MyRunner |
 
-Each protocol requires a name class attribute and a single method:
+Import protocols from `termproof.protocols`. Older module locations still re-export the same protocol objects for compatibility.
+
+Most protocols require a `name` class attribute and a single method:
 
 - Step: execute(session, step, index) -> StepResult
 - Assertion: evaluate(recipe, assertion, screen, raw_output, exit_code) -> AssertionResult
@@ -23,6 +25,8 @@ Each protocol requires a name class attribute and a single method:
 - SessionBackend: create_session(argv, cast_path, cwd, env, cols, rows) -> TerminalSession
 - ExecutionMode: execute(runner, recipe, run_dir) -> (steps, assertions, raw_output, exit_code, screen)
 - AgentRunner: run(recipe, prompt, run_dir) -> AgentOutcome
+
+AgentRunner and SessionBackend are selected by config keys and do not require a `name`.
 
 ## Context availability for assertions
 
@@ -42,10 +46,12 @@ timing constraints, use TermProof core features (e.g. recipe-level
 `timeout_seconds`). For counting and content checks, the `screen` and
 `raw_output` strings are the correct inputs.
 
-## Version policy
+## Version and deprecation policy
 
-- Plugin declares termproof>=0.1.0 in dependencies.
-- Breaking protocol changes will be accompanied by major version bump and noted in issue 32.
+- Plugin declares `termproof>=0.2.1` in dependencies when using the stable `termproof.protocols` imports.
+- Additive changes are allowed when existing plugins keep working without source changes.
+- Breaking protocol changes require a major version bump and migration guide.
+- Deprecated protocol behavior remains available for at least one minor release after documentation.
 
 ## Legacy prefix
 

--- a/termproof/__init__.py
+++ b/termproof/__init__.py
@@ -2,17 +2,35 @@
 
 from .config import VerifierConfig, load_config
 from .models import AssertionResult, Recipe, RunResult, StepResult
+from .protocols import (
+    AgentRunner,
+    AssertionType,
+    ExecutionMode,
+    Reporter,
+    ScreenRenderer,
+    SessionBackend,
+    StepAction,
+    VideoBackend,
+)
 from .registry import Registry
 from .report import ReportGenerator
 from .runner import VerificationRunner, load_recipe
 
 __all__ = [
+    "AgentRunner",
     "AssertionResult",
+    "AssertionType",
+    "ExecutionMode",
     "Recipe",
     "Registry",
+    "Reporter",
     "ReportGenerator",
     "RunResult",
+    "ScreenRenderer",
+    "SessionBackend",
+    "StepAction",
     "StepResult",
+    "VideoBackend",
     "VerificationRunner",
     "VerifierConfig",
     "load_config",

--- a/termproof/agent_driven.py
+++ b/termproof/agent_driven.py
@@ -6,10 +6,11 @@ import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any
 
 from .cast import CastRecorder
 from .models import AssertionResult, Recipe, StepResult
+from .protocols import AgentRunner
 from .screen import replay_cast
 from .session import TerminalSession
 
@@ -21,11 +22,6 @@ class AgentOutcome:
     raw_output: str
     exit_code: int | None
     metadata: dict[str, Any] = field(default_factory=dict)
-
-
-class AgentRunner(Protocol):
-    def run(self, recipe: Recipe, prompt: str, run_dir: Path) -> AgentOutcome:
-        ...
 
 
 @dataclass

--- a/termproof/builtin_assertions.py
+++ b/termproof/builtin_assertions.py
@@ -1,25 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any
 
 from .models import AssertionResult, Recipe
-
-
-class AssertionType(Protocol):
-    """Protocol for pluggable assertion evaluators."""
-
-    name: str  # matches recipe assertion "type" field
-
-    def evaluate(
-        self,
-        recipe: Recipe,
-        assertion: dict[str, Any],
-        screen: str,
-        raw_output: str,
-        exit_code: int | None,
-    ) -> AssertionResult:
-        ...
+from .protocols import AssertionType
 
 
 def _contains(

--- a/termproof/builtin_modes.py
+++ b/termproof/builtin_modes.py
@@ -1,23 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any
 
 from .models import AssertionResult, Recipe, StepResult
-
-
-class ExecutionMode(Protocol):
-    """Protocol for pluggable execution strategies."""
-
-    name: str
-
-    def execute(
-        self,
-        runner: Any,  # VerificationRunner
-        recipe: Recipe,
-        run_dir: Path,
-    ) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]:
-        ...
+from .protocols import ExecutionMode
 
 
 class ScriptedPtyMode:

--- a/termproof/builtin_renderers.py
+++ b/termproof/builtin_renderers.py
@@ -2,22 +2,7 @@ from __future__ import annotations
 
 import html
 from pathlib import Path
-from typing import Protocol
-
-
-class ScreenRenderer(Protocol):
-    """Protocol for pluggable screen renderers."""
-
-    name: str
-
-    def render(
-        self,
-        text: str,
-        output_path: Path,
-        cols: int,
-        rows: int,
-    ) -> None:
-        ...
+from .protocols import ScreenRenderer
 
 
 class SvgRenderer:

--- a/termproof/builtin_reporters.py
+++ b/termproof/builtin_reporters.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import re
 import xml.etree.ElementTree as ET
-from typing import Protocol
 
 from .before_after import BeforeAfterResult
 from .build_info import BuildInfo
 from .models import RunResult
+from .protocols import Reporter
 
 
 # XML 1.0 spec: allowed characters are:
@@ -40,20 +40,6 @@ def _xml_sanitize(text: str) -> str:
     and surrogates (#xD800-#xDFFF) which are invalid in XML 1.0.
     """
     return _XML_FORBIDDEN_RE.sub("", text)
-
-
-class Reporter(Protocol):
-    """Protocol for pluggable report generators."""
-
-    name: str
-
-    def generate(
-        self,
-        results: list[RunResult],
-        build_info: BuildInfo | None = None,
-        before_after: BeforeAfterResult | None = None,
-    ) -> str:
-        ...
 
 
 class MarkdownReporter:

--- a/termproof/builtin_session.py
+++ b/termproof/builtin_session.py
@@ -1,24 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
 
+from .protocols import SessionBackend
 from .session import TerminalSession
-
-
-class SessionBackend(Protocol):
-    """Protocol for pluggable session/terminal backends."""
-
-    def create_session(
-        self,
-        argv: list[str],
-        cast_path: Path,
-        cwd: str | None,
-        env: dict[str, str],
-        cols: int,
-        rows: int,
-    ) -> TerminalSession:
-        ...
 
 
 class PexpectAsciinemaBackend:

--- a/termproof/builtin_steps.py
+++ b/termproof/builtin_steps.py
@@ -3,24 +3,11 @@ from __future__ import annotations
 import math
 import re
 import time
-from typing import Any, Protocol
+from typing import Any
 
 from .models import StepResult
+from .protocols import StepAction
 from .session import TerminalSession
-
-
-class StepAction(Protocol):
-    """Protocol for pluggable step actions."""
-
-    name: str  # class-level identifier matching recipe "action" field
-
-    def execute(
-        self,
-        session: TerminalSession,
-        step: dict[str, Any],
-        index: int,
-    ) -> StepResult:
-        ...
 
 
 class WaitForText:

--- a/termproof/builtin_video.py
+++ b/termproof/builtin_video.py
@@ -1,21 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
-
-
-class VideoBackend(Protocol):
-    """Protocol for pluggable video renderers."""
-
-    name: str
-
-    def render(
-        self,
-        cast_path: Path,
-        output_path: Path,
-        fps: int,
-    ) -> None:
-        ...
+from .protocols import VideoBackend
 
 
 class AggFfmpegBackend:

--- a/termproof/protocols.py
+++ b/termproof/protocols.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+from .before_after import BeforeAfterResult
+from .build_info import BuildInfo
+from .models import AssertionResult, Recipe, RunResult, StepResult
+from .session import TerminalSession
+
+if TYPE_CHECKING:
+    from .agent_driven import AgentOutcome
+    from .runner import VerificationRunner
+
+
+class StepAction(Protocol):
+    name: str
+
+    def execute(
+        self,
+        session: TerminalSession,
+        step: dict[str, Any],
+        index: int,
+    ) -> StepResult:
+        ...
+
+
+class AssertionType(Protocol):
+    name: str
+
+    def evaluate(
+        self,
+        recipe: Recipe,
+        assertion: dict[str, Any],
+        screen: str,
+        raw_output: str,
+        exit_code: int | None,
+    ) -> AssertionResult:
+        ...
+
+
+class ExecutionMode(Protocol):
+    name: str
+
+    def execute(
+        self,
+        runner: VerificationRunner,
+        recipe: Recipe,
+        run_dir: Path,
+    ) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]:
+        ...
+
+
+class Reporter(Protocol):
+    name: str
+
+    def generate(
+        self,
+        results: list[RunResult],
+        build_info: BuildInfo | None = None,
+        before_after: BeforeAfterResult | None = None,
+    ) -> str:
+        ...
+
+
+class ScreenRenderer(Protocol):
+    name: str
+
+    def render(
+        self,
+        text: str,
+        output_path: Path,
+        cols: int,
+        rows: int,
+    ) -> None:
+        ...
+
+
+class VideoBackend(Protocol):
+    name: str
+
+    def render(
+        self,
+        cast_path: Path,
+        output_path: Path,
+        fps: int,
+    ) -> None:
+        ...
+
+
+class AgentRunner(Protocol):
+    def run(self, recipe: Recipe, prompt: str, run_dir: Path) -> AgentOutcome:
+        ...
+
+
+class SessionBackend(Protocol):
+    def create_session(
+        self,
+        argv: list[str],
+        cast_path: Path,
+        cwd: str | None,
+        env: dict[str, str],
+        cols: int,
+        rows: int,
+    ) -> TerminalSession:
+        ...
+
+
+__all__ = [
+    "AgentRunner",
+    "AssertionType",
+    "ExecutionMode",
+    "Reporter",
+    "ScreenRenderer",
+    "SessionBackend",
+    "StepAction",
+    "VideoBackend",
+]

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -20,36 +20,10 @@ from .models import (
     load_recipe,
     score_from_assertions,
 )
+from .protocols import SessionBackend
 from .registry import Registry
 from .screen import replay_cast
 from .session import TerminalSession
-
-# Protocol types for session/video backends
-from typing import Protocol as _Protocol
-from pathlib import Path as _Path
-
-
-class _SessionBackend(_Protocol):
-    def create_session(
-        self,
-        argv: list[str],
-        cast_path: _Path,
-        cwd: str | None,
-        env: dict[str, str],
-        cols: int,
-        rows: int,
-    ) -> TerminalSession: ...
-
-
-class _VideoBackend(_Protocol):
-    name: str
-
-    def render(
-        self,
-        cast_path: _Path,
-        output_path: _Path,
-        fps: int,
-    ) -> None: ...
 
 
 # -- registry builders -------------------------------------------------------
@@ -111,7 +85,7 @@ def _build_video_backend_registry(config: VerifierConfig) -> Registry[Any]:
     return registry
 
 
-def _resolve_session_backend(config: VerifierConfig) -> _SessionBackend:
+def _resolve_session_backend(config: VerifierConfig) -> SessionBackend:
     cls = _import_class(config.session_backend)
     return cls()  # type: ignore[return-value]
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import inspect
+import unittest
+
+import termproof
+from termproof import protocols
+
+
+class ProtocolApiTests(unittest.TestCase):
+    def test_public_protocol_exports_are_stable(self) -> None:
+        self.assertEqual(
+            [
+                "AgentRunner",
+                "AssertionType",
+                "ExecutionMode",
+                "Reporter",
+                "ScreenRenderer",
+                "SessionBackend",
+                "StepAction",
+                "VideoBackend",
+            ],
+            protocols.__all__,
+        )
+        for name in protocols.__all__:
+            self.assertIs(getattr(termproof, name), getattr(protocols, name))
+
+    def test_protocol_signatures_are_locked(self) -> None:
+        cases = {
+            protocols.StepAction.execute: (
+                ["self", "session", "step", "index"],
+                "StepResult",
+            ),
+            protocols.AssertionType.evaluate: (
+                ["self", "recipe", "assertion", "screen", "raw_output", "exit_code"],
+                "AssertionResult",
+            ),
+            protocols.ExecutionMode.execute: (
+                ["self", "runner", "recipe", "run_dir"],
+                "tuple[list[StepResult], list[AssertionResult], str, int | None, str]",
+            ),
+            protocols.Reporter.generate: (
+                ["self", "results", "build_info", "before_after"],
+                "str",
+            ),
+            protocols.ScreenRenderer.render: (
+                ["self", "text", "output_path", "cols", "rows"],
+                "None",
+            ),
+            protocols.VideoBackend.render: (
+                ["self", "cast_path", "output_path", "fps"],
+                "None",
+            ),
+            protocols.AgentRunner.run: (
+                ["self", "recipe", "prompt", "run_dir"],
+                "AgentOutcome",
+            ),
+            protocols.SessionBackend.create_session: (
+                ["self", "argv", "cast_path", "cwd", "env", "cols", "rows"],
+                "TerminalSession",
+            ),
+        }
+        for method, (parameters, return_annotation) in cases.items():
+            signature = inspect.signature(method)
+            self.assertEqual(parameters, list(signature.parameters))
+            self.assertEqual(return_annotation, signature.return_annotation)
+
+    def test_legacy_protocol_import_locations_reexport_public_protocols(self) -> None:
+        from termproof.agent_driven import AgentRunner
+        from termproof.builtin_assertions import AssertionType
+        from termproof.builtin_modes import ExecutionMode
+        from termproof.builtin_renderers import ScreenRenderer
+        from termproof.builtin_reporters import Reporter
+        from termproof.builtin_session import SessionBackend
+        from termproof.builtin_steps import StepAction
+        from termproof.builtin_video import VideoBackend
+
+        self.assertIs(AgentRunner, protocols.AgentRunner)
+        self.assertIs(AssertionType, protocols.AssertionType)
+        self.assertIs(ExecutionMode, protocols.ExecutionMode)
+        self.assertIs(Reporter, protocols.Reporter)
+        self.assertIs(ScreenRenderer, protocols.ScreenRenderer)
+        self.assertIs(SessionBackend, protocols.SessionBackend)
+        self.assertIs(StepAction, protocols.StepAction)
+        self.assertIs(VideoBackend, protocols.VideoBackend)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- adds stable public plugin protocol imports in `termproof.protocols`
- re-exports the same protocol objects from legacy built-in modules for compatibility
- documents protocol signatures, import policy, and deprecation policy
- adds signature-lock tests for all 8 plugin protocols

Closes #32

## Verification
- `uv run python -m unittest tests.test_protocols -v`
- `uv run python -m unittest discover -s tests`
- `uv build`