### PR TITLE
Add recipe v1 validation

### DIFF
--- a/docs/recipe-format-v1.md
+++ b/docs/recipe-format-v1.md
@@ -1,0 +1,71 @@
+# Recipe format v1
+
+TermProof recipe files are JSON files ending in `.recipe.json`.
+
+## Versioning
+
+New recipes should set:
+
+```json
+{
+  "recipe_version": 1
+}
+```
+
+Recipes without `recipe_version` are treated as legacy v0.x recipes and remain loadable. `termproof validate` reports that as a warning so maintainers can migrate incrementally.
+
+Breaking recipe format changes require a future major `recipe_version`.
+
+## Required fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `recipe_version` | integer | Stable value is `1`; omitted legacy recipes still run. |
+| `name` | string | Human-readable recipe identifier. |
+| `command.argv` | string array | Target command and arguments. |
+
+## Common optional fields
+
+| Field | Type | Default |
+| --- | --- | --- |
+| `description` | string | `""` |
+| `intent` | string | `""` |
+| `priority` | string | `"P2"` |
+| `execution` | string | `"scripted"` |
+| `determinism` | string | `"deterministic"` |
+| `command.cwd` | string or null | `null` |
+| `command.env` | object of string values | `{}` |
+| `command.pty` | boolean | `true` |
+| `steps` | object array | `[]` |
+| `assertions` | object array | `[]` |
+| `expect_exit_code` | integer or null | `0` |
+| `timeout_seconds` | positive number | `30` |
+| `cols` | positive integer | `100` |
+| `rows` | positive integer | `30` |
+| `renderers` | object of string arrays | `{ "default": [] }` |
+
+## Validation
+
+Run:
+
+```bash
+termproof validate .termproof/recipes
+```
+
+The validator checks JSON shape, required fields, configured step/action names, configured assertion names, and basic timeout/dimension sanity. It accepts `--config` with the same config cascade behavior as `termproof run`.
+
+The formal JSON Schema is published at [`recipe-schema-v1.json`](recipe-schema-v1.json).
+
+## Migrating v0.x recipes
+
+Existing recipes usually need only one edit:
+
+```json
+{
+  "recipe_version": 1,
+  "name": "existing-recipe",
+  "command": {"argv": ["my-tui"]}
+}
+```
+
+After adding `recipe_version`, run `termproof validate` and fix any plugin-name or type-shape errors it reports.

--- a/docs/recipe-packs.md
+++ b/docs/recipe-packs.md
@@ -18,6 +18,12 @@ Run a pack with:
 termproof run .termproof/recipes --video
 ```
 
+Validate a pack with:
+
+```bash
+termproof validate .termproof/recipes
+```
+
 Create a starter pack with:
 
 ```bash
@@ -27,6 +33,7 @@ termproof init .termproof/recipes --name my-tui --command "my-tui"
 ## Package Contract
 
 - Recipes are JSON and can be checked into any repository.
+- New recipes should declare `recipe_version: 1`; legacy recipes without it remain loadable.
 - Discovery is recursive, so larger projects can group recipes by feature.
 - Helper scripts are project-owned and can launch any TUI, CLI, or test fixture.
 - `command.argv` is the target process.
@@ -36,6 +43,8 @@ termproof init .termproof/recipes --name my-tui --command "my-tui"
 - `reporters` include `markdown` and `junit_xml` (JUnit XML consumable by Jenkins, GitLab CI, CircleCI, etc).
 - `termproof demo` provides a self-contained demo TUI that exercises all step and assertion types without external dependencies.
 - `renderers` let one recipe fan out across multiple frontend implementations.
+
+See [`recipe-format-v1.md`](recipe-format-v1.md) for the stable field reference and migration policy.
 
 ## Recommended Layout
 

--- a/docs/recipe-schema-v1.json
+++ b/docs/recipe-schema-v1.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/md-mt/termproof/docs/recipe-schema-v1.json",
+  "title": "TermProof recipe v1",
+  "type": "object",
+  "required": ["name", "command"],
+  "properties": {
+    "recipe_version": {"const": 1},
+    "name": {"type": "string", "minLength": 1},
+    "description": {"type": "string"},
+    "intent": {"type": "string"},
+    "priority": {"type": "string"},
+    "execution": {"type": "string"},
+    "determinism": {"type": "string"},
+    "ci_paths": {"type": "array", "items": {"type": "string"}},
+    "checks": {"type": "array", "items": {"type": "string"}},
+    "operator": {"type": "object"},
+    "renderers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["argv"],
+      "properties": {
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string"}
+        },
+        "cwd": {"type": ["string", "null"]},
+        "env": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "pty": {"type": "boolean"}
+      },
+      "additionalProperties": true
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["action"],
+        "properties": {
+          "action": {"type": "string"},
+          "name": {"type": "string"},
+          "timeout_seconds": {"type": "number", "exclusiveMinimum": 0}
+        },
+        "additionalProperties": true
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {"type": "string"},
+          "name": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "expect_exit_code": {"type": ["integer", "null"]},
+    "timeout_seconds": {"type": "number", "exclusiveMinimum": 0},
+    "cols": {"type": "integer", "minimum": 1},
+    "rows": {"type": "integer", "minimum": 1}
+  },
+  "additionalProperties": true
+}

--- a/termproof/cli.py
+++ b/termproof/cli.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from .agent_driven import CodexCliAgentRunner
 from .build_info import BuildInfo
 from .config import VerifierConfig, load_config
-from .registry import load_recipes, select_recipes
+from .recipe_schema import has_errors, validate_recipe_file
+from .registry import find_recipe_files, load_recipes, select_recipes
 from .renderer import selected_renderers
 from .runner import VerificationRunner
 from .scaffold import write_recipe_pack
@@ -39,6 +40,10 @@ def main(argv: list[str] | None = None) -> int:
     list_parser = subparsers.add_parser("list", help="list recipes")
     list_parser.add_argument("recipes", nargs="+", type=Path)
     list_parser.add_argument("--priority")
+    validate_parser = subparsers.add_parser("validate", help="validate recipe files")
+    validate_parser.add_argument("recipes", nargs="+", type=Path)
+    validate_parser.add_argument("--config", type=Path, default=None,
+                                 help="path to a termproof config YAML file")
     init_parser = subparsers.add_parser("init", help="create a reusable recipe pack")
     init_parser.add_argument("path", type=Path)
     init_parser.add_argument("--name", required=True)
@@ -124,6 +129,23 @@ def main(argv: list[str] | None = None) -> int:
         for recipe in recipes:
             print(f"{recipe.name}\t{recipe.priority}\t{recipe.execution}\t{recipe.description}")
         return 0
+    if args.command == "validate":
+        config = _resolve_config(args)
+        paths = find_recipe_files(args.recipes)
+        if not paths:
+            print("no recipe files found")
+            return 1
+        failed = False
+        for path in paths:
+            issues = validate_recipe_file(path, config)
+            if not issues:
+                print(f"PASS {path}")
+                continue
+            for issue in issues:
+                label = issue.severity.upper()
+                print(f"{label} {path}:{issue.path}: {issue.message}")
+            failed = failed or has_errors(issues)
+        return 1 if failed else 0
     if args.command == "init":
         try:
             recipe_path = write_recipe_pack(

--- a/termproof/models.py
+++ b/termproof/models.py
@@ -17,6 +17,7 @@ class CommandSpec:
 class Recipe:
     name: str
     command: CommandSpec
+    recipe_version: int = 1
     description: str = ""
     intent: str = ""
     priority: str = "P2"
@@ -89,6 +90,7 @@ def recipe_from_mapping(data: dict[str, Any]) -> Recipe:
     )
     return Recipe(
         name=data["name"],
+        recipe_version=int(data.get("recipe_version", 1)),
         description=data.get("description", ""),
         intent=data.get("intent", ""),
         command=command,

--- a/termproof/models.py
+++ b/termproof/models.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+RECIPE_VERSION = 1
+
 
 @dataclass(frozen=True)
 class CommandSpec:
@@ -81,6 +83,13 @@ class RunResult:
 
 
 def recipe_from_mapping(data: dict[str, Any]) -> Recipe:
+    recipe_version = data.get("recipe_version", RECIPE_VERSION)
+    if (
+        not isinstance(recipe_version, int)
+        or isinstance(recipe_version, bool)
+        or recipe_version != RECIPE_VERSION
+    ):
+        raise ValueError(f"unsupported recipe_version: {recipe_version!r}")
     command_data = data["command"]
     command = CommandSpec(
         argv=list(command_data["argv"]),
@@ -90,7 +99,7 @@ def recipe_from_mapping(data: dict[str, Any]) -> Recipe:
     )
     return Recipe(
         name=data["name"],
-        recipe_version=int(data.get("recipe_version", 1)),
+        recipe_version=recipe_version,
         description=data.get("description", ""),
         intent=data.get("intent", ""),
         command=command,

--- a/termproof/recipe_schema.py
+++ b/termproof/recipe_schema.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .config import VerifierConfig
+
+RECIPE_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    path: str
+    message: str
+    severity: str = "error"
+
+
+def has_errors(issues: list[ValidationIssue]) -> bool:
+    return any(issue.severity == "error" for issue in issues)
+
+
+def validate_recipe_file(path: Path, config: VerifierConfig) -> list[ValidationIssue]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        return [ValidationIssue("$", f"invalid JSON: {error.msg}")]
+    if not isinstance(data, dict):
+        return [ValidationIssue("$", "recipe must be a JSON object")]
+    return validate_recipe_mapping(data, config)
+
+
+def validate_recipe_mapping(
+    data: dict[str, Any],
+    config: VerifierConfig,
+) -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    version = data.get("recipe_version")
+    if version is None:
+        issues.append(
+            ValidationIssue(
+                "recipe_version",
+                "missing recipe_version; treating recipe as legacy v0.x",
+                "warning",
+            )
+        )
+    elif not isinstance(version, int) or isinstance(version, bool) or version != RECIPE_VERSION:
+        issues.append(ValidationIssue("recipe_version", "must be 1"))
+
+    _require_str(data, "name", issues)
+    _validate_command(data.get("command"), issues)
+    _validate_positive_number(data, "timeout_seconds", issues)
+    _validate_positive_int(data, "cols", issues)
+    _validate_positive_int(data, "rows", issues)
+    _validate_expect_exit_code(data.get("expect_exit_code"), issues)
+    _validate_optional_string(data, "priority", issues)
+    _validate_optional_string(data, "execution", issues)
+    _validate_optional_string(data, "determinism", issues)
+    _validate_string_list(data, "checks", issues)
+    _validate_string_list(data, "ci_paths", issues)
+    _validate_object(data, "operator", issues)
+    _validate_renderers(data.get("renderers"), issues)
+    _validate_steps(data.get("steps", []), config, issues)
+    _validate_assertions(data.get("assertions", []), config, issues)
+    return issues
+
+
+def _require_str(data: dict[str, Any], key: str, issues: list[ValidationIssue]) -> None:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        issues.append(ValidationIssue(key, "must be a non-empty string"))
+
+
+def _validate_optional_string(
+    data: dict[str, Any],
+    key: str,
+    issues: list[ValidationIssue],
+) -> None:
+    value = data.get(key)
+    if value is not None and not isinstance(value, str):
+        issues.append(ValidationIssue(key, "must be a string"))
+
+
+def _validate_command(value: Any, issues: list[ValidationIssue]) -> None:
+    if not isinstance(value, dict):
+        issues.append(ValidationIssue("command", "must be an object"))
+        return
+    argv = value.get("argv")
+    if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+        issues.append(ValidationIssue("command.argv", "must be a non-empty list of strings"))
+    if value.get("cwd") is not None and not isinstance(value.get("cwd"), str):
+        issues.append(ValidationIssue("command.cwd", "must be a string"))
+    env = value.get("env", {})
+    if not isinstance(env, dict) or not all(
+        isinstance(key, str) and isinstance(item, str) for key, item in env.items()
+    ):
+        issues.append(ValidationIssue("command.env", "must be an object of string values"))
+    if value.get("pty") is not None and not isinstance(value.get("pty"), bool):
+        issues.append(ValidationIssue("command.pty", "must be true or false"))
+
+
+def _validate_positive_number(
+    data: dict[str, Any],
+    key: str,
+    issues: list[ValidationIssue],
+) -> None:
+    value = data.get(key)
+    if value is not None and (
+        not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0
+    ):
+        issues.append(ValidationIssue(key, "must be a positive number"))
+
+
+def _validate_positive_int(
+    data: dict[str, Any],
+    key: str,
+    issues: list[ValidationIssue],
+) -> None:
+    value = data.get(key)
+    if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
+        issues.append(ValidationIssue(key, "must be a positive integer"))
+
+
+def _validate_expect_exit_code(value: Any, issues: list[ValidationIssue]) -> None:
+    if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+        issues.append(ValidationIssue("expect_exit_code", "must be an integer or null"))
+
+
+def _validate_string_list(
+    data: dict[str, Any],
+    key: str,
+    issues: list[ValidationIssue],
+) -> None:
+    value = data.get(key)
+    if value is not None and (
+        not isinstance(value, list) or not all(isinstance(item, str) for item in value)
+    ):
+        issues.append(ValidationIssue(key, "must be a list of strings"))
+
+
+def _validate_object(data: dict[str, Any], key: str, issues: list[ValidationIssue]) -> None:
+    value = data.get(key)
+    if value is not None and not isinstance(value, dict):
+        issues.append(ValidationIssue(key, "must be an object"))
+
+
+def _validate_renderers(value: Any, issues: list[ValidationIssue]) -> None:
+    if value is None:
+        return
+    if not isinstance(value, dict):
+        issues.append(ValidationIssue("renderers", "must be an object"))
+        return
+    for name, argv in value.items():
+        if not isinstance(name, str) or not isinstance(argv, list) or not all(
+            isinstance(item, str) for item in argv
+        ):
+            issues.append(ValidationIssue(f"renderers.{name}", "must be a list of strings"))
+
+
+def _validate_steps(
+    value: Any,
+    config: VerifierConfig,
+    issues: list[ValidationIssue],
+) -> None:
+    if not isinstance(value, list):
+        issues.append(ValidationIssue("steps", "must be a list"))
+        return
+    for index, step in enumerate(value):
+        path = f"steps[{index}]"
+        if not isinstance(step, dict):
+            issues.append(ValidationIssue(path, "must be an object"))
+            continue
+        action = step.get("action")
+        if not isinstance(action, str):
+            issues.append(ValidationIssue(f"{path}.action", "must be a string"))
+        elif action not in config.steps:
+            issues.append(ValidationIssue(f"{path}.action", f"unknown step action {action!r}"))
+        _validate_step_timeout(step, path, issues)
+
+
+def _validate_step_timeout(
+    step: dict[str, Any],
+    path: str,
+    issues: list[ValidationIssue],
+) -> None:
+    value = step.get("timeout_seconds")
+    if value is not None and (
+        not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0
+    ):
+        issues.append(ValidationIssue(f"{path}.timeout_seconds", "must be a positive number"))
+
+
+def _validate_assertions(
+    value: Any,
+    config: VerifierConfig,
+    issues: list[ValidationIssue],
+) -> None:
+    if not isinstance(value, list):
+        issues.append(ValidationIssue("assertions", "must be a list"))
+        return
+    for index, assertion in enumerate(value):
+        path = f"assertions[{index}]"
+        if not isinstance(assertion, dict):
+            issues.append(ValidationIssue(path, "must be an object"))
+            continue
+        kind = assertion.get("type")
+        if not isinstance(kind, str):
+            issues.append(ValidationIssue(f"{path}.type", "must be a string"))
+        elif kind not in config.assertions:
+            issues.append(ValidationIssue(f"{path}.type", f"unknown assertion type {kind!r}"))

--- a/termproof/recipe_schema.py
+++ b/termproof/recipe_schema.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import VerifierConfig
-
-RECIPE_VERSION = 1
+from .models import RECIPE_VERSION
 
 
 @dataclass(frozen=True)

--- a/tests/test_recipe_validation.py
+++ b/tests/test_recipe_validation.py
@@ -34,6 +34,16 @@ class RecipeValidationTest(unittest.TestCase):
         )
         self.assertEqual(1, recipe.recipe_version)
 
+    def test_recipe_loader_rejects_unsupported_recipe_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported recipe_version"):
+            recipe_from_mapping(
+                {
+                    "recipe_version": True,
+                    "name": "bad",
+                    "command": {"argv": ["echo", "ok"]},
+                }
+            )
+
     def test_valid_recipe_has_no_errors(self) -> None:
         issues = validate_recipe_mapping(_recipe(), VerifierConfig.builtin())
         self.assertEqual([], issues)

--- a/tests/test_recipe_validation.py
+++ b/tests/test_recipe_validation.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+from termproof.cli import main
+from termproof.config import VerifierConfig
+from termproof.models import recipe_from_mapping
+from termproof.recipe_schema import has_errors, validate_recipe_mapping
+
+
+def _recipe(**overrides):
+    data = {
+        "recipe_version": 1,
+        "name": "valid",
+        "command": {"argv": ["python3", "-c", "print('ok')"], "pty": False},
+        "steps": [{"action": "wait_for_text", "text": "ok"}],
+        "assertions": [{"type": "output_contains", "value": "ok"}],
+    }
+    data.update(overrides)
+    return data
+
+
+class RecipeValidationTest(unittest.TestCase):
+    def test_recipe_version_defaults_to_one_for_legacy_recipes(self) -> None:
+        recipe = recipe_from_mapping(
+            {
+                "name": "legacy",
+                "command": {"argv": ["echo", "ok"]},
+            }
+        )
+        self.assertEqual(1, recipe.recipe_version)
+
+    def test_valid_recipe_has_no_errors(self) -> None:
+        issues = validate_recipe_mapping(_recipe(), VerifierConfig.builtin())
+        self.assertEqual([], issues)
+
+    def test_missing_recipe_version_warns_without_failing(self) -> None:
+        data = _recipe()
+        data.pop("recipe_version")
+        issues = validate_recipe_mapping(data, VerifierConfig.builtin())
+        self.assertFalse(has_errors(issues))
+        self.assertEqual(["warning"], [issue.severity for issue in issues])
+
+    def test_unknown_plugin_names_are_errors(self) -> None:
+        issues = validate_recipe_mapping(
+            _recipe(
+                steps=[{"action": "missing_step"}],
+                assertions=[{"type": "missing_assertion"}],
+            ),
+            VerifierConfig.builtin(),
+        )
+        self.assertTrue(has_errors(issues))
+        messages = "\n".join(issue.message for issue in issues)
+        self.assertIn("unknown step action", messages)
+        self.assertIn("unknown assertion type", messages)
+
+    def test_boolean_recipe_version_is_invalid(self) -> None:
+        issues = validate_recipe_mapping(
+            _recipe(recipe_version=True),
+            VerifierConfig.builtin(),
+        )
+        self.assertTrue(has_errors(issues))
+
+    def test_validate_cli_returns_nonzero_for_invalid_recipe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.recipe.json"
+            path.write_text(
+                '{"recipe_version": 1, "name": "bad", "command": {"argv": []}}',
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                code = main(["validate", str(path)])
+        self.assertEqual(1, code)
+        self.assertIn("ERROR", output.getvalue())
+
+    def test_validate_cli_accepts_recipe_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ok.recipe.json"
+            path.write_text(
+                """{
+  "recipe_version": 1,
+  "name": "ok",
+  "command": {"argv": ["python3", "-c", "print('ok')"], "pty": false}
+}
+""",
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                code = main(["validate", tmp])
+        self.assertEqual(0, code)
+        self.assertIn("PASS", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- adds `recipe_version` to the recipe model with legacy defaulting to v1
- adds `termproof validate` for recipe files/directories
- validates JSON shape, required fields, plugin names, timeouts, dimensions, and exit-code types
- publishes the v1 field reference and JSON Schema

Closes #31
Closes #29

## Verification
- `uv run python -m unittest tests.test_recipe_validation -v`
- `uv run termproof validate examples`
- `python3 -m json.tool docs/recipe-schema-v1.json >/dev/null`
- `uv run python -m unittest discover -s tests`
- `uv build`