### PR TITLE
Add Docker session backend

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -19,6 +19,23 @@ reporters:
 
 See [`plugin-protocols.md`](plugin-protocols.md) for the stable protocol contract and `termproof/config.py` for built-ins.
 
+TermProof also ships a built-in Docker session backend:
+
+```yaml
+session_backend: docker
+docker:
+  image: python:3.12-slim
+  workdir: /workspace
+  volumes:
+    - host: .
+      container: /workspace
+  env:
+    PYTHONUNBUFFERED: "1"
+```
+
+The backend runs each recipe command with `docker run --rm --interactive --tty`.
+Recipe `command.env` values are passed into the container alongside `docker.env`.
+
 ## Listing
 
 | Name | Description | Install | Author |
@@ -47,7 +64,6 @@ From open issues:
 - **JsonSchema assertion** (`json_schema`) — see [#20](https://github.com/md-mt/termproof/issues/20)
 - **JunitXml reporter** (`junit_xml`) — see [#15](https://github.com/md-mt/termproof/issues/15)
 - **PNG renderer** for pixel-level screenshots — see [#19](https://github.com/md-mt/termproof/issues/19)
-- **Docker session backend** — see [#18](https://github.com/md-mt/termproof/issues/18)
 - **Plugins CLI** (`termproof plugins`) — see [#21](https://github.com/md-mt/termproof/issues/21)
 
 ## Publishing

--- a/termproof/builtin_session.py
+++ b/termproof/builtin_session.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
+from .config import DockerBackendConfig
 from .protocols import SessionBackend
 from .session import TerminalSession
 
@@ -19,3 +21,68 @@ class PexpectAsciinemaBackend:
         rows: int,
     ) -> TerminalSession:
         return TerminalSession(argv, cast_path, cwd, env, cols, rows)
+
+
+class DockerSessionBackend:
+    name = "docker"
+
+    def __init__(
+        self,
+        config: DockerBackendConfig | None = None,
+        docker_bin: str = "docker",
+    ) -> None:
+        self.config = config or DockerBackendConfig()
+        self.docker_bin = docker_bin
+
+    def create_session(
+        self,
+        argv: list[str],
+        cast_path: Path,
+        cwd: str | None,
+        env: dict[str, str],
+        cols: int,
+        rows: int,
+    ) -> TerminalSession:
+        if not self.config.image:
+            raise RuntimeError("docker session backend requires docker.image in config")
+        return TerminalSession(
+            self._docker_argv(argv, cwd, env),
+            cast_path,
+            None,
+            {},
+            cols,
+            rows,
+        )
+
+    def _docker_argv(
+        self,
+        argv: list[str],
+        cwd: str | None,
+        env: dict[str, str],
+    ) -> list[str]:
+        command = [self.docker_bin, "run", "--rm", "--interactive", "--tty"]
+        for item in self.config.volumes:
+            command.extend(_volume_args(item, cwd))
+        for key, value in {**self.config.env, **env}.items():
+            command.extend(["--env", f"{key}={value}"])
+        if self.config.workdir:
+            command.extend(["--workdir", self.config.workdir])
+        command.append(self.config.image)
+        command.extend(argv)
+        return command
+
+
+def _volume_args(volume: Any, cwd: str | None) -> list[str]:
+    if isinstance(volume, str):
+        return ["--volume", volume]
+    host = _host_path(str(volume["host"]), cwd)
+    container = str(volume.get("container", volume.get("target")))
+    suffix = ":ro" if bool(volume.get("read_only", False)) else ""
+    return ["--volume", f"{host}:{container}{suffix}"]
+
+
+def _host_path(value: str, cwd: str | None) -> str:
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return str(path)
+    return str((Path(cwd or ".") / path).resolve())

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -51,6 +51,12 @@ BUILTIN_DEFAULTS: dict[str, Any] = {
         "agg_ffmpeg": "termproof.builtin_video:AggFfmpegBackend",
     },
     "session_backend": "termproof.builtin_session:PexpectAsciinemaBackend",
+    "docker": {
+        "image": "",
+        "workdir": "/workspace",
+        "volumes": [{"host": ".", "container": "/workspace"}],
+        "env": {},
+    },
     "defaults": {
         "timeout_seconds": 30.0,
         "cols": 100,
@@ -73,6 +79,16 @@ class GlobalDefaults:
 
 
 @dataclass(frozen=True)
+class DockerBackendConfig:
+    image: str = ""
+    workdir: str = "/workspace"
+    volumes: list[Any] = field(
+        default_factory=lambda: [{"host": ".", "container": "/workspace"}]
+    )
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class VerifierConfig:
     steps: dict[str, str]
     assertions: dict[str, str]
@@ -82,6 +98,7 @@ class VerifierConfig:
     screen_renderers: dict[str, str]
     video_backends: dict[str, str]
     session_backend: str
+    docker: DockerBackendConfig
     defaults: GlobalDefaults
 
     @classmethod
@@ -144,6 +161,8 @@ def load_config(
 
 def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
     defaults_raw = data.get("defaults", {})
+    docker_raw = data.get("docker", {})
+    docker_volumes = docker_raw.get("volumes", [{"host": ".", "container": "/workspace"}])
     return VerifierConfig(
         steps=dict(data.get("steps", {})),
         assertions=dict(data.get("assertions", {})),
@@ -153,6 +172,15 @@ def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
         screen_renderers=dict(data.get("screen_renderers", {})),
         video_backends=dict(data.get("video_backends", {})),
         session_backend=str(data.get("session_backend", "")),
+        docker=DockerBackendConfig(
+            image=str(docker_raw.get("image", "")),
+            workdir=str(docker_raw.get("workdir", "/workspace")),
+            volumes=list(docker_volumes) if isinstance(docker_volumes, list) else [],
+            env={
+                str(key): str(value)
+                for key, value in dict(docker_raw.get("env", {})).items()
+            },
+        ),
         defaults=GlobalDefaults(
             timeout_seconds=float(defaults_raw.get("timeout_seconds", 30.0)),
             cols=int(defaults_raw.get("cols", 100)),

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -28,6 +28,11 @@ from .session import TerminalSession
 
 # -- registry builders -------------------------------------------------------
 
+SESSION_BACKEND_ALIASES = {
+    "pexpect": "termproof.builtin_session:PexpectAsciinemaBackend",
+    "docker": "termproof.builtin_session:DockerSessionBackend",
+}
+
 
 def _build_step_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
@@ -86,7 +91,10 @@ def _build_video_backend_registry(config: VerifierConfig) -> Registry[Any]:
 
 
 def _resolve_session_backend(config: VerifierConfig) -> SessionBackend:
-    cls = _import_class(config.session_backend)
+    qualname = SESSION_BACKEND_ALIASES.get(config.session_backend, config.session_backend)
+    cls = _import_class(qualname)
+    if qualname == "termproof.builtin_session:DockerSessionBackend":
+        return cls(config.docker)  # type: ignore[return-value]
     return cls()  # type: ignore[return-value]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from termproof.config import (
     BUILTIN_DEFAULTS,
+    DockerBackendConfig,
     GlobalDefaults,
     VerifierConfig,
     load_config,
@@ -21,6 +22,7 @@ class ConfigTest(unittest.TestCase):
         self.assertIn("output_contains", config.assertions)
         self.assertIn("exit_code", config.assertions)
         self.assertIsInstance(config.defaults, GlobalDefaults)
+        self.assertIsInstance(config.docker, DockerBackendConfig)
         self.assertEqual(config.defaults.timeout_seconds, 30.0)
         self.assertEqual(config.defaults.cols, 100)
 
@@ -87,6 +89,38 @@ class ConfigTest(unittest.TestCase):
                 config.steps["my_custom"],
                 "termproof.builtin_steps:Sleep",
             )
+
+    def test_docker_backend_config_loads_from_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp) / "project"
+            project_dir.mkdir()
+            config_dir = project_dir / ".termproof"
+            config_dir.mkdir()
+            (config_dir / "config.yaml").write_text(
+                """session_backend: docker
+docker:
+  image: python:3.12-slim
+  workdir: /app
+  volumes:
+    - host: .
+      container: /app
+      read_only: true
+  env:
+    PYTHONUNBUFFERED: "1"
+""",
+                encoding="utf-8",
+            )
+
+            config = load_config(project_path=project_dir)
+
+        self.assertEqual("docker", config.session_backend)
+        self.assertEqual("python:3.12-slim", config.docker.image)
+        self.assertEqual("/app", config.docker.workdir)
+        self.assertEqual(
+            [{"host": ".", "container": "/app", "read_only": True}],
+            config.docker.volumes,
+        )
+        self.assertEqual({"PYTHONUNBUFFERED": "1"}, config.docker.env)
 
 
 class RegistryTest(unittest.TestCase):

--- a/tests/test_docker_session_backend.py
+++ b/tests/test_docker_session_backend.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from termproof.builtin_session import DockerSessionBackend
+from termproof.config import DockerBackendConfig, VerifierConfig
+from termproof.runner import VerificationRunner
+
+
+class DockerSessionBackendTest(unittest.TestCase):
+    def test_create_session_wraps_command_in_docker_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = DockerSessionBackend(
+                DockerBackendConfig(
+                    image="python:3.12-slim",
+                    workdir="/app",
+                    volumes=[
+                        {
+                            "host": ".",
+                            "container": "/app",
+                            "read_only": True,
+                        }
+                    ],
+                    env={"BASE_ENV": "1"},
+                )
+            )
+            session = backend.create_session(
+                ["python", "-V"],
+                Path(tmp) / "session.cast",
+                cwd=tmp,
+                env={"RUN_ENV": "2"},
+                cols=80,
+                rows=24,
+            )
+            expected_volume = f"{Path(tmp).resolve()}:/app:ro"
+
+        self.assertEqual("docker", session.argv[0])
+        self.assertIn("--rm", session.argv)
+        self.assertIn("--interactive", session.argv)
+        self.assertIn("--tty", session.argv)
+        self.assertIn("--env", session.argv)
+        self.assertIn("BASE_ENV=1", session.argv)
+        self.assertIn("RUN_ENV=2", session.argv)
+        self.assertIn("--workdir", session.argv)
+        self.assertIn("/app", session.argv)
+        self.assertIn(expected_volume, session.argv)
+        self.assertEqual(["python:3.12-slim", "python", "-V"], session.argv[-3:])
+        self.assertIsNone(session.cwd)
+
+    def test_string_volume_specs_pass_through(self) -> None:
+        backend = DockerSessionBackend(
+            DockerBackendConfig(
+                image="alpine:3.20",
+                volumes=["/host/cache:/cache:ro"],
+            )
+        )
+        session = backend.create_session(
+            ["echo", "ok"],
+            Path(tempfile.mkdtemp()) / "session.cast",
+            cwd=None,
+            env={},
+            cols=80,
+            rows=24,
+        )
+
+        self.assertIn("/host/cache:/cache:ro", session.argv)
+
+    def test_runner_resolves_docker_session_backend_alias(self) -> None:
+        config = replace(
+            VerifierConfig.builtin(),
+            session_backend="docker",
+            docker=DockerBackendConfig(image="alpine:3.20"),
+        )
+
+        runner = VerificationRunner(config=config)
+
+        self.assertIsInstance(runner.session_backend, DockerSessionBackend)
+
+    def test_docker_backend_requires_image(self) -> None:
+        backend = DockerSessionBackend(DockerBackendConfig())
+
+        with self.assertRaisesRegex(RuntimeError, "docker.image"):
+            backend.create_session(
+                ["echo", "ok"],
+                Path(tempfile.mkdtemp()) / "session.cast",
+                cwd=None,
+                env={},
+                cols=80,
+                rows=24,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- adds a built-in `docker` session backend alias selected with `session_backend: docker`
- adds Docker backend config for image, workdir, volume mounts, and environment
- wraps recipe commands in `docker run --rm --interactive --tty` while passing recipe env into the container
- documents the config shape and adds tests for command generation, alias resolution, and config loading

Closes #18

## Verification
- `uv run python -m unittest tests.test_docker_session_backend tests.test_config -v`
- `uv run python -m unittest discover -s tests`
- `uv build`
- `git diff --check`