### PR TITLE
Add plugins CLI

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -48,6 +48,13 @@ termproof run .termproof/recipes --screen-renderer png
 | --- | --- | --- | --- |
 | _Be the first_ | Show us your step/assertion/session/reporter | `pip install <your-package>` | you |
 
+Search or install from this manual directory with:
+
+```bash
+termproof plugins search textual
+termproof plugins install termproof-textual
+```
+
 To list your plugin here, open a PR editing this file with:
 
 - Name — package or plugin identifier.
@@ -66,10 +73,8 @@ To list your plugin here, open a PR editing this file with:
 
 From open issues:
 
-- **WaitForRegex** (`wait_for_regex`) — see [#14](https://github.com/md-mt/termproof/issues/14)
-- **JsonSchema assertion** (`json_schema`) — see [#20](https://github.com/md-mt/termproof/issues/20)
-- **JunitXml reporter** (`junit_xml`) — see [#15](https://github.com/md-mt/termproof/issues/15)
-- **Plugins CLI** (`termproof plugins`) — see [#21](https://github.com/md-mt/termproof/issues/21)
+- **Framework helpers** for Textual, Bubble Tea, and Ratatui recipes — see [#24](https://github.com/md-mt/termproof/issues/24)
+- **First-party example integrations** that can graduate into separate plugin repos — see [#23](https://github.com/md-mt/termproof/issues/23)
 
 ## Publishing
 

--- a/termproof/cli.py
+++ b/termproof/cli.py
@@ -44,6 +44,18 @@ def main(argv: list[str] | None = None) -> int:
     validate_parser.add_argument("recipes", nargs="+", type=Path)
     validate_parser.add_argument("--config", type=Path, default=None,
                                  help="path to a termproof config YAML file")
+    plugins_parser = subparsers.add_parser("plugins", help="manage TermProof plugins")
+    plugins_subparsers = plugins_parser.add_subparsers(dest="plugins_command", required=True)
+    plugins_list = plugins_subparsers.add_parser("list", help="list configured plugins")
+    plugins_list.add_argument("--config", type=Path, default=None,
+                              help="path to a termproof config YAML file")
+    plugins_search = plugins_subparsers.add_parser("search", help="search community plugins")
+    plugins_search.add_argument("query")
+    plugins_search.add_argument("--registry", type=Path, default=Path("docs/plugins.md"))
+    plugins_install = plugins_subparsers.add_parser("install", help="install a community plugin")
+    plugins_install.add_argument("name")
+    plugins_install.add_argument("--registry", type=Path, default=Path("docs/plugins.md"))
+    plugins_install.add_argument("--dry-run", action="store_true")
     init_parser = subparsers.add_parser("init", help="create a reusable recipe pack")
     init_parser.add_argument("path", type=Path)
     init_parser.add_argument("--name", required=True)
@@ -146,6 +158,35 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"{label} {path}:{issue.path}: {issue.message}")
             failed = failed or has_errors(issues)
         return 1 if failed else 0
+    if args.command == "plugins":
+        from .plugins_cli import (
+            install_community_plugin,
+            installed_plugins,
+            search_community_plugins,
+        )
+
+        if args.plugins_command == "list":
+            for plugin in installed_plugins(_resolve_config(args)):
+                print(f"{plugin.category}\t{plugin.name}\t{plugin.target}")
+            return 0
+        if args.plugins_command == "search":
+            matches = search_community_plugins(args.query, args.registry)
+            if not matches:
+                print("no plugins found")
+                return 0
+            for plugin in matches:
+                print(
+                    f"{plugin.name}\t{plugin.description}\t{plugin.install}\t{plugin.author}"
+                )
+            return 0
+        if args.plugins_command == "install":
+            code, detail = install_community_plugin(
+                args.name,
+                args.registry,
+                dry_run=args.dry_run,
+            )
+            print(detail)
+            return code
     if args.command == "init":
         try:
             recipe_path = write_recipe_pack(

--- a/termproof/plugins_cli.py
+++ b/termproof/plugins_cli.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from .config import VerifierConfig
+
+
+DEFAULT_REGISTRY_PATH = Path("docs/plugins.md")
+
+
+@dataclass(frozen=True)
+class InstalledPlugin:
+    category: str
+    name: str
+    target: str
+
+
+@dataclass(frozen=True)
+class CommunityPlugin:
+    name: str
+    description: str
+    install: str
+    author: str
+
+
+def installed_plugins(config: VerifierConfig) -> list[InstalledPlugin]:
+    rows: list[InstalledPlugin] = []
+    registries = [
+        ("steps", config.steps),
+        ("assertions", config.assertions),
+        ("agent_runners", config.agent_runners),
+        ("execution_modes", config.execution_modes),
+        ("reporters", config.reporters),
+        ("screen_renderers", config.screen_renderers),
+        ("video_backends", config.video_backends),
+    ]
+    for category, mapping in registries:
+        for name, target in sorted(mapping.items()):
+            rows.append(InstalledPlugin(category, name, target))
+    rows.append(InstalledPlugin("session_backend", "active", config.session_backend))
+    return rows
+
+
+def load_community_plugins(path: Path = DEFAULT_REGISTRY_PATH) -> list[CommunityPlugin]:
+    if not path.exists():
+        return []
+    rows: list[CommunityPlugin] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 4 or cells[0] == "Name" or set(cells[0]) <= {"-", ":"}:
+            continue
+        if cells[0].startswith("_"):
+            continue
+        rows.append(
+            CommunityPlugin(
+                _plain(cells[0]),
+                _plain(cells[1]),
+                _plain(cells[2]),
+                _plain(cells[3]),
+            )
+        )
+    return rows
+
+
+def search_community_plugins(
+    query: str,
+    path: Path = DEFAULT_REGISTRY_PATH,
+) -> list[CommunityPlugin]:
+    needle = query.lower()
+    matches = []
+    for plugin in load_community_plugins(path):
+        haystack = " ".join(
+            [plugin.name, plugin.description, plugin.install, plugin.author]
+        ).lower()
+        if needle in haystack:
+            matches.append(plugin)
+    return matches
+
+
+def install_community_plugin(
+    name: str,
+    path: Path = DEFAULT_REGISTRY_PATH,
+    dry_run: bool = False,
+) -> tuple[int, str]:
+    plugin = next(
+        (item for item in load_community_plugins(path) if item.name == name),
+        None,
+    )
+    if plugin is None:
+        return 1, f"unknown plugin: {name}"
+    package = _install_package(plugin.install)
+    if package is None:
+        return 1, f"plugin {name!r} has no supported install command"
+    command = [sys.executable, "-m", "pip", "install", package]
+    if dry_run:
+        return 0, shlex.join(command)
+    return subprocess.call(command), shlex.join(command)
+
+
+def _plain(value: str) -> str:
+    value = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", value)
+    return value.replace("`", "").strip()
+
+
+def _install_package(value: str) -> str | None:
+    tokens = shlex.split(value)
+    if not tokens:
+        return None
+    if len(tokens) >= 3 and tokens[0] == "pip" and tokens[1] == "install":
+        candidates = tokens[2:]
+    elif len(tokens) >= 3 and tokens[0] == "uv" and tokens[1] == "add":
+        candidates = tokens[2:]
+    elif len(tokens) >= 4 and tokens[0] == "uv" and tokens[1:3] == ["pip", "install"]:
+        candidates = tokens[3:]
+    else:
+        candidates = tokens
+    for token in candidates:
+        if not token.startswith("-"):
+            return token
+    return None

--- a/tests/test_plugins_cli.py
+++ b/tests/test_plugins_cli.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+from termproof.cli import main
+from termproof.plugins_cli import load_community_plugins
+
+
+REGISTRY = """# Community plugins
+
+| Name | Description | Install | Author |
+| --- | --- | --- | --- |
+| termproof-textual | Textual helpers | `pip install termproof-textual` | [@you](https://github.com/you) |
+"""
+
+
+class PluginsCliTest(unittest.TestCase):
+    def test_plugins_list_shows_configured_plugins(self) -> None:
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            code = main(["plugins", "list"])
+
+        self.assertEqual(0, code)
+        text = output.getvalue()
+        self.assertIn("steps\twait_for_text\ttermproof.builtin_steps:WaitForText", text)
+        self.assertIn("assertions\tjson_schema\ttermproof.builtin_assertions:JsonSchema", text)
+        self.assertIn(
+            "session_backend\tactive\ttermproof.builtin_session:PexpectAsciinemaBackend",
+            text,
+        )
+
+    def test_load_community_plugins_reads_markdown_table(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = Path(tmp) / "plugins.md"
+            registry.write_text(REGISTRY, encoding="utf-8")
+
+            plugins = load_community_plugins(registry)
+
+        self.assertEqual("termproof-textual", plugins[0].name)
+        self.assertEqual("pip install termproof-textual", plugins[0].install)
+        self.assertEqual("@you", plugins[0].author)
+
+    def test_plugins_search_finds_registry_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = Path(tmp) / "plugins.md"
+            registry.write_text(REGISTRY, encoding="utf-8")
+            output = io.StringIO()
+
+            with contextlib.redirect_stdout(output):
+                code = main(["plugins", "search", "textual", "--registry", str(registry)])
+
+        self.assertEqual(0, code)
+        self.assertIn("termproof-textual", output.getvalue())
+
+    def test_plugins_install_supports_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = Path(tmp) / "plugins.md"
+            registry.write_text(REGISTRY, encoding="utf-8")
+            output = io.StringIO()
+
+            with contextlib.redirect_stdout(output):
+                code = main(
+                    [
+                        "plugins",
+                        "install",
+                        "termproof-textual",
+                        "--registry",
+                        str(registry),
+                        "--dry-run",
+                    ]
+                )
+
+        self.assertEqual(0, code)
+        self.assertIn("pip install termproof-textual", output.getvalue())
+
+    def test_plugins_install_unknown_returns_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = Path(tmp) / "plugins.md"
+            registry.write_text(REGISTRY, encoding="utf-8")
+            output = io.StringIO()
+
+            with contextlib.redirect_stdout(output):
+                code = main(
+                    [
+                        "plugins",
+                        "install",
+                        "missing",
+                        "--registry",
+                        str(registry),
+                    ]
+                )
+
+        self.assertEqual(1, code)
+        self.assertIn("unknown plugin", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- adds `termproof plugins list` for configured/built-in plugin registries
- adds `termproof plugins search <query>` over the manual Markdown community registry
- adds `termproof plugins install <name>` with registry lookup and `--dry-run` support
- documents the plugin directory commands, cleans up shipped items from the sought-plugin list, and adds focused CLI/registry tests

Closes #21
Closes #22

## Verification
- `uv run python -m unittest tests.test_plugins_cli -v`
- `uv run termproof plugins list | head -20`
- `uv run python -m unittest discover -s tests`
- `uv build`
- `git diff --check`