### PR TITLE
Add framework integration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ See [`docs/verified-badge.md`](docs/verified-badge.md) for variants (flat, plast
 - **Code of Conduct:** [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — Contributor Covenant 2.1.
 - **Pages demo:** Preview locally with `python3 -m http.server 8000 --directory site`. When Pages is enabled on this repo, the rendered site will be at https://md-mt.github.io/termproof/.
 - **Examples:** [`examples/generic`](examples/generic) — portable TUI; `examples/pi_workflow_*.recipe.json` — Pi agent showcase.
-- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md)
+- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md)
 
 ## Upgrading from tui-verifier
 

--- a/docs/guides/bubbletea.md
+++ b/docs/guides/bubbletea.md
@@ -1,0 +1,76 @@
+# Bubble Tea Integration Guide
+
+Bubble Tea apps are straightforward to verify when the command starts in a
+known model state and accepts normal keyboard input.
+
+## Recipe Setup
+
+Run either a built binary or `go run`:
+
+```json
+{
+  "recipe_version": 1,
+  "name": "bubbletea-smoke",
+  "command": {
+    "argv": ["go", "run", "./cmd/my-tui"],
+    "env": {"TERM": "xterm-256color"},
+    "pty": true
+  },
+  "cols": 100,
+  "rows": 30,
+  "steps": [
+    {"action": "wait_for_text", "text": "Tasks", "timeout_seconds": 10},
+    {"action": "press", "key": "down"},
+    {"action": "press", "key": "enter"},
+    {"action": "wait_for_text", "text": "Task details", "timeout_seconds": 5}
+  ],
+  "assertions": [
+    {"type": "screen_contains", "value": "Task details"},
+    {"type": "exit_code", "value": 0}
+  ]
+}
+```
+
+For faster CI, build the binary first and point `command.argv` at the compiled
+artifact.
+
+## Common Patterns
+
+- Seed the Bubble Tea model with fixture data instead of live services.
+- Prefer text that users actually see: titles, selected rows, prompts, and
+  status messages.
+- Use `wait_for_regex` for dynamic counters or generated identifiers.
+- Keep terminal dimensions fixed so viewport and list rendering stay stable.
+
+## CI Configuration
+
+```yaml
+jobs:
+  termproof:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go build -o ./bin/my-tui ./cmd/my-tui
+      - uses: astral-sh/setup-uv@v5
+      - run: uvx --from git+https://github.com/md-mt/termproof.git termproof run .termproof/recipes/bubbletea --out .termproof/runs
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: termproof-bubbletea-evidence
+          path: .termproof/runs
+```
+
+## Example Repo
+
+```text
+my-bubbletea-app/
+  cmd/my-tui/main.go
+  internal/tui/
+  .termproof/recipes/bubbletea/smoke.recipe.json
+```
+
+Use [`examples/generic`](../../examples/generic) as the recipe-pack reference
+until the first-party Bubble Tea example repo is published.

--- a/docs/guides/ratatui.md
+++ b/docs/guides/ratatui.md
@@ -1,0 +1,74 @@
+# Ratatui Integration Guide
+
+Ratatui apps should expose a deterministic fixture mode for TermProof so CI can
+drive the same terminal flow on every run.
+
+## Recipe Setup
+
+Run with `cargo run` for early adoption or a prebuilt binary for faster CI:
+
+```json
+{
+  "recipe_version": 1,
+  "name": "ratatui-smoke",
+  "command": {
+    "argv": ["cargo", "run", "--bin", "my-tui", "--", "--fixture", "termproof"],
+    "env": {"TERM": "xterm-256color", "RUST_BACKTRACE": "1"},
+    "pty": true
+  },
+  "cols": 100,
+  "rows": 30,
+  "steps": [
+    {"action": "wait_for_text", "text": "Overview", "timeout_seconds": 15},
+    {"action": "press", "key": "tab"},
+    {"action": "wait_for_text", "text": "Logs", "timeout_seconds": 5},
+    {"action": "press", "key": "q"}
+  ],
+  "assertions": [
+    {"type": "output_not_contains", "value": "panicked at"},
+    {"type": "screen_contains", "value": "Logs"}
+  ]
+}
+```
+
+Use a fixture flag or feature gate to provide stable data and to skip external
+I/O during the recipe.
+
+## Common Patterns
+
+- Wait on panel titles, focused tab labels, status bars, and command prompts.
+- Use `press` for navigation and quit keys; avoid sleeps except for animations
+  that have no stable text boundary.
+- Assert `output_not_contains` for panic strings and backtraces.
+- Capture PNG screenshots when future visual-diff checks need pixel artifacts.
+
+## CI Configuration
+
+```yaml
+jobs:
+  termproof:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --locked --bin my-tui
+      - uses: astral-sh/setup-uv@v5
+      - run: uvx --from git+https://github.com/md-mt/termproof.git termproof run .termproof/recipes/ratatui --out .termproof/runs --screen-renderer png
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: termproof-ratatui-evidence
+          path: .termproof/runs
+```
+
+## Example Repo
+
+```text
+my-ratatui-app/
+  Cargo.toml
+  src/bin/my-tui.rs
+  .termproof/recipes/ratatui/smoke.recipe.json
+```
+
+Use [`examples/generic`](../../examples/generic) as the recipe-pack reference
+until the first-party Ratatui example repo is published.

--- a/docs/guides/textual.md
+++ b/docs/guides/textual.md
@@ -1,0 +1,75 @@
+# Textual Integration Guide
+
+Textual apps work best with TermProof when the recipe drives a deterministic
+screen: seed data, fixed terminal dimensions, and a command that exits cleanly
+after the verified flow.
+
+## Recipe Setup
+
+Use the same command you use locally, usually a module or app entry point:
+
+```json
+{
+  "recipe_version": 1,
+  "name": "textual-smoke",
+  "command": {
+    "argv": ["python", "-m", "my_app"],
+    "env": {"TERM": "xterm-256color"},
+    "pty": true
+  },
+  "cols": 100,
+  "rows": 30,
+  "steps": [
+    {"action": "wait_for_text", "text": "Dashboard", "timeout_seconds": 5},
+    {"action": "press", "key": "tab"},
+    {"action": "send_line", "text": "alice"},
+    {"action": "wait_for_text", "text": "Results for alice", "timeout_seconds": 5}
+  ],
+  "assertions": [
+    {"type": "screen_contains", "value": "Results for alice"},
+    {"type": "output_not_contains", "value": "Traceback"}
+  ]
+}
+```
+
+Prefer a test fixture mode in the app that disables network calls, clocks, and
+random data.
+
+## Common Patterns
+
+- Wait for visible widget labels or stable screen text, not internal Textual
+  object names.
+- Use `press` for navigation keys and `send_text` or `send_line` for form input.
+- Assert both final screen state and absence of Python tracebacks.
+- Use `--screen-renderer png` when visual-diff workflows need raster artifacts.
+
+## CI Configuration
+
+```yaml
+jobs:
+  termproof:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: uv run termproof run .termproof/recipes/textual --out .termproof/runs
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: termproof-textual-evidence
+          path: .termproof/runs
+```
+
+## Example Repo
+
+Until first-party framework repos are split out, use this layout:
+
+```text
+my-textual-app/
+  pyproject.toml
+  src/my_app/__main__.py
+  .termproof/recipes/textual/smoke.recipe.json
+```
+
+The portable reference pack is [`examples/generic`](../../examples/generic).

--- a/tests/test_framework_guides.py
+++ b/tests/test_framework_guides.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class FrameworkGuidesTest(unittest.TestCase):
+    def test_framework_guides_cover_required_sections(self) -> None:
+        for name in ("textual", "bubbletea", "ratatui"):
+            with self.subTest(name=name):
+                text = (ROOT / "docs" / "guides" / f"{name}.md").read_text(
+                    encoding="utf-8"
+                )
+                for heading in (
+                    "## Recipe Setup",
+                    "## Common Patterns",
+                    "## CI Configuration",
+                    "## Example Repo",
+                ):
+                    self.assertIn(heading, text)
+                self.assertIn("termproof run", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- adds Textual, Bubble Tea, and Ratatui integration guides under `docs/guides/`
- covers recipe setup, common verification patterns, CI snippets, and example repo layouts for each framework
- links the guides from the README docs list
- adds a regression test that each guide keeps the required sections

Closes #24

## Verification
- `uv run python -m unittest tests.test_framework_guides -v`
- `uv run python -m unittest discover -s tests`
- `uv build`
- `git diff --check`