### PR TITLE
Add GitLab CI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ See [`docs/verified-badge.md`](docs/verified-badge.md) for variants (flat, plast
 - **Code of Conduct:** [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — Contributor Covenant 2.1.
 - **Pages demo:** Preview locally with `python3 -m http.server 8000 --directory site`. When Pages is enabled on this repo, the rendered site will be at https://md-mt.github.io/termproof/.
 - **Examples:** [`examples/generic`](examples/generic) — portable TUI; `examples/pi_workflow_*.recipe.json` — Pi agent showcase.
-- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md)
+- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md) · [`docs/ci/gitlab.md`](docs/ci/gitlab.md)
 
 ## Upgrading from tui-verifier
 

--- a/docs/ci/gitlab.md
+++ b/docs/ci/gitlab.md
@@ -1,0 +1,46 @@
+# GitLab CI
+
+TermProof can run in GitLab CI by installing the CLI, executing a recipe pack, uploading the evidence directory, and optionally posting the Markdown report back to a merge request.
+
+Use [`templates/gitlab/.gitlab-ci.yml`](../../templates/gitlab/.gitlab-ci.yml) as a starting point:
+
+```bash
+curl -L https://raw.githubusercontent.com/md-mt/termproof/main/templates/gitlab/.gitlab-ci.yml -o .gitlab-ci.yml
+```
+
+The template runs:
+
+```bash
+uvx --from git+https://github.com/md-mt/termproof.git termproof run "$TERMPROOF_RECIPES" --out .termproof/runs $TERMPROOF_ARGS
+```
+
+By default it records video evidence for `.termproof/recipes`. Override these variables in your project or pipeline:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TERMPROOF_RECIPES` | `.termproof/recipes` | Recipe file or recipe pack directory to run. |
+| `TERMPROOF_ARGS` | `--video --video-fps 60 --xml-path .termproof/runs/latest-report.xml` | Extra `termproof run` flags. |
+| `GITLAB_TOKEN` | unset | Optional project/group variable with `api` scope for merge request comments. |
+
+## Evidence Artifacts
+
+The `termproof` job uploads `.termproof/runs` with `when: always`, so failed runs still include `session.cast`, screenshots, text snapshots, videos, JSON results, and Markdown reports.
+
+GitLab keeps the evidence for 14 days by default. Adjust `artifacts.expire_in` to match your review and compliance window.
+
+## Merge Request Comments
+
+The `termproof:mr-comment` job runs only for merge request pipelines. When `GITLAB_TOKEN` is available, it posts `.termproof/runs/latest-report.md` to the merge request notes API. Without a token, the job prints setup guidance and exits successfully.
+
+Set `GITLAB_TOKEN` as a masked CI/CD variable with `api` scope. Protected variables are only available to protected branches, so use an unprotected project access token if merge request pipelines from feature branches need comments.
+
+## JUnit Reports
+
+GitLab can show TermProof results in the pipeline test report when the run writes JUnit XML:
+
+```yaml
+variables:
+  TERMPROOF_ARGS: --xml-path .termproof/runs/latest-report.xml
+```
+
+The template already declares `.termproof/runs/latest-report.xml` under `artifacts.reports.junit`.

--- a/templates/gitlab/.gitlab-ci.yml
+++ b/templates/gitlab/.gitlab-ci.yml
@@ -1,0 +1,55 @@
+stages:
+  - test
+  - report
+
+variables:
+  TERM: xterm-256color
+  UV_CACHE_DIR: .uv-cache
+  TERMPROOF_RECIPES: .termproof/recipes
+  TERMPROOF_ARGS: --video --video-fps 60 --xml-path .termproof/runs/latest-report.xml
+
+termproof:
+  stage: test
+  image: python:3.12-slim
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends ca-certificates cargo curl ffmpeg git
+    - export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+    - if ! command -v agg >/dev/null 2>&1; then cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0; fi
+    - curl -LsSf https://astral.sh/uv/install.sh | sh
+  script:
+    - uvx --from git+https://github.com/md-mt/termproof.git termproof run "$TERMPROOF_RECIPES" --out .termproof/runs $TERMPROOF_ARGS
+  artifacts:
+    when: always
+    expire_in: 14 days
+    paths:
+      - .termproof/runs
+    reports:
+      junit: .termproof/runs/latest-report.xml
+
+termproof:mr-comment:
+  stage: report
+  image: curlimages/curl:8.10.1
+  needs:
+    - job: termproof
+      artifacts: true
+  rules:
+    - if: $CI_MERGE_REQUEST_IID
+      when: always
+    - when: never
+  script:
+    - |
+      if [ -z "$GITLAB_TOKEN" ]; then
+        echo "Set GITLAB_TOKEN with api scope to enable TermProof MR comments."
+        exit 0
+      fi
+      REPORT_PATH=.termproof/runs/latest-report.md
+      if [ ! -f "$REPORT_PATH" ]; then
+        echo "TermProof report not found at $REPORT_PATH"
+        exit 0
+      fi
+      BODY=$(printf "## TermProof CI Report\n\nPipeline: %s\n\n%s" "$CI_PIPELINE_URL" "$(cat "$REPORT_PATH")")
+      curl --fail-with-body \
+        --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        --form "body=$BODY" \
+        "$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"

--- a/tests/test_gitlab_ci_template.py
+++ b/tests/test_gitlab_ci_template.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "templates" / "gitlab" / ".gitlab-ci.yml"
+DOCS = ROOT / "docs" / "ci" / "gitlab.md"
+
+
+class GitLabCiTemplateTest(unittest.TestCase):
+    def test_template_runs_termproof_and_uploads_evidence(self) -> None:
+        text = TEMPLATE.read_text(encoding="utf-8")
+
+        self.assertIn("uvx --from git+https://github.com/md-mt/termproof.git termproof run", text)
+        self.assertIn('"$TERMPROOF_RECIPES"', text)
+        self.assertIn("--out .termproof/runs $TERMPROOF_ARGS", text)
+        self.assertIn("--xml-path .termproof/runs/latest-report.xml", text)
+        self.assertIn("cargo install --locked --git https://github.com/asciinema/agg", text)
+        self.assertIn("when: always", text)
+        self.assertIn("- .termproof/runs", text)
+
+    def test_template_can_comment_on_merge_requests(self) -> None:
+        text = TEMPLATE.read_text(encoding="utf-8")
+
+        self.assertIn("termproof:mr-comment", text)
+        self.assertIn("$CI_MERGE_REQUEST_IID", text)
+        self.assertIn("GITLAB_TOKEN", text)
+        self.assertIn("merge_requests/$CI_MERGE_REQUEST_IID/notes", text)
+        self.assertIn("latest-report.md", text)
+
+    def test_docs_link_template(self) -> None:
+        text = DOCS.read_text(encoding="utf-8")
+
+        self.assertIn("templates/gitlab/.gitlab-ci.yml", text)
+        self.assertIn("TERMPROOF_RECIPES", text)
+        self.assertIn("artifacts.reports.junit", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- add a reusable GitLab CI template that installs TermProof, records evidence, uploads artifacts, and exposes optional JUnit XML
- add an optional merge request comment job using the GitLab notes API
- document setup, variables, evidence artifacts, MR comments, and JUnit reports

## Verification
- uv run python -m unittest tests.test_gitlab_ci_template -v
- uv run python -m unittest discover -s tests
- uv build
- git diff --check

Closes #25