### PR TITLE
Add CircleCI orb source

### DIFF
--- a/.circleci/orb.yml
+++ b/.circleci/orb.yml
@@ -1,0 +1,108 @@
+version: 2.1
+
+description: Run TermProof recipes and upload reviewable TUI evidence.
+
+executors:
+  python:
+    docker:
+      - image: cimg/python:3.12
+
+commands:
+  verify:
+    description: Install TermProof, run recipes, and store evidence artifacts.
+    parameters:
+      recipe-path:
+        type: string
+        description: Recipe file or recipe pack directory to execute.
+      output-dir:
+        type: string
+        default: .termproof/runs
+        description: Directory where TermProof writes evidence.
+      termproof-source:
+        type: string
+        default: git+https://github.com/md-mt/termproof.git
+        description: Package source passed to uvx --from.
+      video:
+        type: boolean
+        default: true
+        description: Render MP4 evidence.
+      fps:
+        type: integer
+        default: 60
+        description: Video frames per second.
+      extra-args:
+        type: string
+        default: ""
+        description: Extra arguments appended to termproof run.
+    steps:
+      - run:
+          name: Install TermProof dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends cargo curl ffmpeg git
+            echo 'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            if ! command -v agg >/dev/null 2>&1; then
+              cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0
+            fi
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run:
+          name: Run TermProof
+          command: |
+            source "$BASH_ENV"
+            mkdir -p "<< parameters.output-dir >>"
+            args=(
+              termproof run "<< parameters.recipe-path >>"
+              --out "<< parameters.output-dir >>"
+              --xml-path "<< parameters.output-dir >>/latest-report.xml"
+            )
+            if [ "<< parameters.video >>" = "true" ]; then
+              args+=(--video --video-fps "<< parameters.fps >>")
+            fi
+            set +e
+            uvx --from "<< parameters.termproof-source >>" "${args[@]}" << parameters.extra-args >>
+            status=$?
+            printf "%s\n" "$status" > "<< parameters.output-dir >>/.termproof-exit-code"
+            exit 0
+      - store_artifacts:
+          path: << parameters.output-dir >>
+          destination: termproof-evidence
+      - store_test_results:
+          path: << parameters.output-dir >>
+      - run:
+          name: Fail on TermProof result
+          command: |
+            status=$(cat "<< parameters.output-dir >>/.termproof-exit-code")
+            exit "$status"
+
+jobs:
+  verify:
+    description: Check out a project and run TermProof recipes.
+    executor: python
+    parameters:
+      recipe-path:
+        type: string
+      output-dir:
+        type: string
+        default: .termproof/runs
+      termproof-source:
+        type: string
+        default: git+https://github.com/md-mt/termproof.git
+      video:
+        type: boolean
+        default: true
+      fps:
+        type: integer
+        default: 60
+      extra-args:
+        type: string
+        default: ""
+    steps:
+      - checkout
+      - verify:
+          recipe-path: << parameters.recipe-path >>
+          output-dir: << parameters.output-dir >>
+          termproof-source: << parameters.termproof-source >>
+          video: << parameters.video >>
+          fps: << parameters.fps >>
+          extra-args: << parameters.extra-args >>

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ See [`docs/verified-badge.md`](docs/verified-badge.md) for variants (flat, plast
 - **Code of Conduct:** [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — Contributor Covenant 2.1.
 - **Pages demo:** Preview locally with `python3 -m http.server 8000 --directory site`. When Pages is enabled on this repo, the rendered site will be at https://md-mt.github.io/termproof/.
 - **Examples:** [`examples/generic`](examples/generic) — portable TUI; `examples/pi_workflow_*.recipe.json` — Pi agent showcase.
-- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md) · [`docs/ci/gitlab.md`](docs/ci/gitlab.md)
+- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md) · [`docs/ci/gitlab.md`](docs/ci/gitlab.md) · [`docs/ci/circleci.md`](docs/ci/circleci.md)
 
 ## Upgrading from tui-verifier
 

--- a/docs/ci/circleci.md
+++ b/docs/ci/circleci.md
@@ -1,0 +1,68 @@
+# CircleCI Orb
+
+TermProof provides a CircleCI orb source at [`.circleci/orb.yml`](../../.circleci/orb.yml). The orb installs TermProof, runs a recipe pack, stores `.termproof/runs` as build artifacts, and publishes JUnit XML through CircleCI test results.
+
+After the orb is published to the CircleCI registry, projects can use:
+
+```yaml
+version: 2.1
+
+orbs:
+  termproof: md-mt/termproof@1.0.0
+
+workflows:
+  verify:
+    jobs:
+      - termproof/verify:
+          recipe-path: .termproof/recipes
+```
+
+The reusable command can also run inside an existing job:
+
+```yaml
+version: 2.1
+
+orbs:
+  termproof: md-mt/termproof@1.0.0
+
+jobs:
+  test:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - termproof/verify:
+          recipe-path: examples/generic
+          output-dir: .termproof/circleci
+```
+
+## Parameters
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `recipe-path` | required | Recipe file or recipe pack directory to run. |
+| `output-dir` | `.termproof/runs` | Evidence output directory. |
+| `termproof-source` | `git+https://github.com/md-mt/termproof.git` | Package source passed to `uvx --from`. Use `termproof` after PyPI publishing. |
+| `video` | `true` | Render MP4 evidence. |
+| `fps` | `60` | Video frames per second. |
+| `extra-args` | empty | Extra arguments appended to `termproof run`. |
+
+## Evidence
+
+The orb stores the output directory as `termproof-evidence`. TermProof verification failures still upload evidence before the job exits non-zero; use workflow reruns or SSH debugging to inspect partial output when dependency installation fails before TermProof starts.
+
+The orb also writes JUnit XML at `latest-report.xml` and publishes it with `store_test_results`, so failures appear in CircleCI's Tests tab.
+
+## Publishing
+
+Validate the orb source before publishing:
+
+```bash
+circleci orb validate .circleci/orb.yml
+```
+
+Publish from a CI context that has a CircleCI token and access to the `md-mt` namespace:
+
+```bash
+circleci orb publish .circleci/orb.yml md-mt/termproof@1.0.0
+```

--- a/tests/test_circleci_orb.py
+++ b/tests/test_circleci_orb.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ORB = ROOT / ".circleci" / "orb.yml"
+DOCS = ROOT / "docs" / "ci" / "circleci.md"
+
+
+class CircleCiOrbTest(unittest.TestCase):
+    def test_orb_defines_verify_job_and_command(self) -> None:
+        orb = yaml.safe_load(ORB.read_text(encoding="utf-8"))
+
+        self.assertEqual(2.1, orb["version"])
+        self.assertIn("verify", orb["commands"])
+        self.assertIn("verify", orb["jobs"])
+        self.assertEqual("cimg/python:3.12", orb["executors"]["python"]["docker"][0]["image"])
+
+    def test_orb_runs_termproof_and_stores_evidence(self) -> None:
+        text = ORB.read_text(encoding="utf-8")
+
+        self.assertIn('uvx --from "<< parameters.termproof-source >>"', text)
+        self.assertIn('termproof run "<< parameters.recipe-path >>"', text)
+        self.assertIn("--xml-path", text)
+        self.assertIn(".termproof-exit-code", text)
+        self.assertIn("store_artifacts", text)
+        self.assertIn("store_test_results", text)
+
+    def test_docs_show_registry_usage(self) -> None:
+        text = DOCS.read_text(encoding="utf-8")
+
+        self.assertIn("md-mt/termproof@1.0.0", text)
+        self.assertIn("circleci orb validate .circleci/orb.yml", text)
+        self.assertIn("termproof-source", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- add CircleCI orb source with a reusable `verify` job and command
- install TermProof dependencies, run recipes, upload evidence artifacts, and publish JUnit XML test results
- preserve evidence on TermProof verification failures before exiting with the run status
- document registry usage, parameters, local validation, and publishing commands

## Verification
- uv run python -m unittest tests.test_circleci_orb -v
- uv run python -m unittest discover -s tests
- uv build
- git diff --check

Closes #26