### PR TITLE
Add generic Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.termproof
+.venv
+dist
+plugin-template/.pkg-test
+plugin-template/dist
+**/__pycache__
+**/*.pyc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,54 @@
+name: Docker Image
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    name: Build TermProof image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Collect image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/termproof
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/termproof.Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ See [`docs/verified-badge.md`](docs/verified-badge.md) for variants (flat, plast
 - **Code of Conduct:** [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — Contributor Covenant 2.1.
 - **Pages demo:** Preview locally with `python3 -m http.server 8000 --directory site`. When Pages is enabled on this repo, the rendered site will be at https://md-mt.github.io/termproof/.
 - **Examples:** [`examples/generic`](examples/generic) — portable TUI; `examples/pi_workflow_*.recipe.json` — Pi agent showcase.
-- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md) · [`docs/ci/gitlab.md`](docs/ci/gitlab.md) · [`docs/ci/circleci.md`](docs/ci/circleci.md)
+- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md) · [`docs/ci/gitlab.md`](docs/ci/gitlab.md) · [`docs/ci/circleci.md`](docs/ci/circleci.md) · [`docs/ci/docker.md`](docs/ci/docker.md)
 
 ## Upgrading from tui-verifier
 

--- a/docker/termproof.Dockerfile
+++ b/docker/termproof.Dockerfile
@@ -1,0 +1,29 @@
+FROM rust:1.85-slim AS agg-builder
+
+ARG AGG_TAG=v1.9.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo install --locked --git https://github.com/asciinema/agg --tag "${AGG_TAG}" --root /opt/agg
+
+FROM python:3.12-slim
+
+ENV TERM=xterm-256color
+WORKDIR /workspace
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates ffmpeg git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=agg-builder /opt/agg/bin/agg /usr/local/bin/agg
+COPY . /opt/termproof
+
+RUN python -m pip install --no-cache-dir /opt/termproof \
+    && termproof --help >/dev/null \
+    && agg --version >/dev/null \
+    && ffmpeg -version >/dev/null
+
+ENTRYPOINT ["termproof"]
+CMD ["--help"]

--- a/docs/ci/docker.md
+++ b/docs/ci/docker.md
@@ -1,0 +1,50 @@
+# Docker Image
+
+TermProof ships a generic CI image from [`docker/termproof.Dockerfile`](../../docker/termproof.Dockerfile). The image includes TermProof, `agg`, and `ffmpeg`, so any CI system with Docker can run recipes and upload `.termproof/runs` as an artifact.
+
+The GitHub workflow [`.github/workflows/docker-image.yml`](../../.github/workflows/docker-image.yml) builds the image on pull requests and publishes `ghcr.io/md-mt/termproof` on `main`, release tags, and manual dispatch.
+
+## Usage
+
+Run a recipe pack from any checkout:
+
+```bash
+docker run --rm \
+  -v "$PWD:/workspace" \
+  ghcr.io/md-mt/termproof:latest \
+  run .termproof/recipes --video --video-fps 60 --out .termproof/runs
+```
+
+For local runs where evidence files should be owned by your host user:
+
+```bash
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace" \
+  ghcr.io/md-mt/termproof:latest \
+  run examples/generic --out .termproof/docker
+```
+
+## CI Pattern
+
+Most CI systems need the same three steps:
+
+```bash
+docker pull ghcr.io/md-mt/termproof:latest
+docker run --rm -v "$PWD:/workspace" ghcr.io/md-mt/termproof:latest \
+  run "$TERMPROOF_RECIPES" --out .termproof/runs $TERMPROOF_ARGS
+```
+
+Then upload `.termproof/runs` as an artifact, even when the run fails.
+
+## Image Tags
+
+The publish workflow emits:
+
+| Tag | Source |
+| --- | --- |
+| `latest` | Default branch builds. |
+| `vX.Y.Z` | Release tags. |
+| `sha-<commit>` | Every pushed commit. |
+
+The Dockerfile installs the repository checkout into the image, so release tag images contain the same code as the corresponding GitHub release.

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = ROOT / "docker" / "termproof.Dockerfile"
+WORKFLOW = ROOT / ".github" / "workflows" / "docker-image.yml"
+DOCS = ROOT / "docs" / "ci" / "docker.md"
+
+
+class DockerImageTest(unittest.TestCase):
+    def test_dockerfile_installs_termproof_and_video_tools(self) -> None:
+        text = DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertIn("FROM rust:1.85-slim AS agg-builder", text)
+        self.assertIn("cargo install --locked --git https://github.com/asciinema/agg", text)
+        self.assertIn("FROM python:3.12-slim", text)
+        self.assertIn("ffmpeg", text)
+        self.assertIn('ENTRYPOINT ["termproof"]', text)
+
+    def test_workflow_builds_and_publishes_ghcr_image(self) -> None:
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("pull_request", workflow[True])
+        self.assertIn("docker/build-push-action@v6", text)
+        self.assertIn("ghcr.io/${{ github.repository_owner }}/termproof", text)
+        self.assertIn("github.event_name != 'pull_request'", text)
+
+    def test_docs_show_docker_run_pattern(self) -> None:
+        text = DOCS.read_text(encoding="utf-8")
+
+        self.assertIn("ghcr.io/md-mt/termproof:latest", text)
+        self.assertIn("run .termproof/recipes", text)
+        self.assertIn("upload `.termproof/runs` as an artifact", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- add a first-party Dockerfile that packages TermProof with agg and ffmpeg
- add a GHCR build/publish workflow for PR validation, main, tags, and manual dispatch
- document Docker usage, CI artifact pattern, and image tags
- add structural tests for the Dockerfile, workflow, and docs

## Verification
- uv run python -m unittest tests.test_docker_image -v
- uv run python -m unittest discover -s tests
- uv build
- git diff --check

Docker daemon was unavailable locally, so the actual image build is expected to run in the added PR workflow.

Closes #27