### PR TITLE
Add parallel recipe execution

### DIFF
--- a/docs/recipe-packs.md
+++ b/docs/recipe-packs.md
@@ -18,6 +18,15 @@ Run a pack with:
 termproof run .termproof/recipes --video
 ```
 
+Large packs can run independent recipes concurrently:
+
+```bash
+termproof run .termproof/recipes --parallel 4 --out .termproof/runs
+```
+
+Each recipe/renderer pair still writes its own evidence directory, and
+`latest-report.md` combines the results.
+
 Validate a pack with:
 
 ```bash

--- a/termproof/cli.py
+++ b/termproof/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import shlex
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from .agent_driven import CodexCliAgentRunner
@@ -25,6 +26,8 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--video-fps", type=int, default=60)
     run_parser.add_argument("--priority")
     run_parser.add_argument("--recipe-name", action="append", dest="recipe_names")
+    run_parser.add_argument("--parallel", type=int, default=1,
+                            help="number of recipes to run concurrently")
     run_parser.add_argument("--renderer", default="default")
     run_parser.add_argument("--operator-command")
     run_parser.add_argument("--config", type=Path, default=None,
@@ -87,6 +90,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "run":
+        if args.parallel < 1:
+            print("--parallel must be >= 1")
+            return 2
         config = _resolve_config(args)
         recipes = select_recipes(
             load_recipes(args.recipes),
@@ -97,23 +103,27 @@ def main(argv: list[str] | None = None) -> int:
         reporter_name = args.reporter
         if args.xml_path and reporter_name == "markdown":
             reporter_name = "junit_xml"
-        results = []
-        agent_runner = None
-        if args.operator_command:
-            agent_runner = CodexCliAgentRunner(command=shlex.split(args.operator_command))
-        runner = VerificationRunner(agent_runner, config=config)
-        for recipe in recipes:
-            for renderer_name, renderer_argv in selected_renderers(recipe, args.renderer):
-                results.append(
-                    runner.run(
-                        recipe,
-                        out_dir=args.out,
-                        render_video=args.video and not args.no_video,
-                        video_fps=args.video_fps,
-                        renderer=renderer_name,
-                        renderer_argv=renderer_argv,
-                        screen_renderer_name=args.screen_renderer,
-                        video_backend_name=args.video_backend,
+        run_items = [
+            (recipe, renderer_name, renderer_argv)
+            for recipe in recipes
+            for renderer_name, renderer_argv in selected_renderers(recipe, args.renderer)
+        ]
+        runner = VerificationRunner(_agent_runner(args), config=config)
+        if args.parallel == 1:
+            results = [
+                _run_item(runner, item, args)
+                for item in run_items
+            ]
+        else:
+            with ThreadPoolExecutor(max_workers=args.parallel) as executor:
+                results = list(
+                    executor.map(
+                        lambda item: _run_item(
+                            VerificationRunner(_agent_runner(args), config=config),
+                            item,
+                            args,
+                        ),
+                        run_items,
                     )
                 )
         build_info = BuildInfo.from_command(recipes[0].command.argv) if recipes else None
@@ -224,3 +234,27 @@ def _resolve_config(args: argparse.Namespace) -> VerifierConfig:
     if args.config:
         return load_config(config_path=args.config.resolve())
     return load_config()
+
+
+def _agent_runner(args: argparse.Namespace) -> CodexCliAgentRunner | None:
+    if not args.operator_command:
+        return None
+    return CodexCliAgentRunner(command=shlex.split(args.operator_command))
+
+
+def _run_item(
+    runner: VerificationRunner,
+    item: tuple,
+    args: argparse.Namespace,
+):
+    recipe, renderer_name, renderer_argv = item
+    return runner.run(
+        recipe,
+        out_dir=args.out,
+        render_video=args.video and not args.no_video,
+        video_fps=args.video_fps,
+        renderer=renderer_name,
+        renderer_argv=renderer_argv,
+        screen_renderer_name=args.screen_renderer,
+        video_backend_name=args.video_backend,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,6 +124,81 @@ class CliTest(unittest.TestCase):
             reporter_calls = runner.reporter_registry.get.call_args_list
             self.assertTrue(any("junit_xml" in str(c) for c in reporter_calls))
 
+    def test_run_parallel_runs_all_selected_recipes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            recipes = []
+            for name in ("one", "two"):
+                recipe_path = root / f"{name}.json"
+                recipe_path.write_text(
+                    f"""{{
+  "name": "{name}",
+  "command": {{"argv": ["python3", "-c", "print('ok')"], "pty": false}}
+}}
+""",
+                    encoding="utf-8",
+                )
+                recipes.append(recipe_path)
+
+            class FakeReporter:
+                def generate(self, results, build_info=None):
+                    return "report"
+
+            class FakeRegistry:
+                def get(self, name):
+                    return FakeReporter()
+
+            class FakeRunner:
+                calls: list[str] = []
+                reporter_registry = FakeRegistry()
+
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                def run(self, recipe, **kwargs):
+                    self.calls.append(recipe.name)
+                    return RunResult(
+                        recipe_name=recipe.name,
+                        passed=True,
+                        exit_code=0,
+                        duration_seconds=0.0,
+                        priority="P2",
+                        execution="scripted",
+                        renderer=kwargs["renderer"],
+                        score=1.0,
+                        steps=[],
+                        assertions=[],
+                        artifacts={},
+                    )
+
+            with patch("termproof.cli.VerificationRunner", side_effect=FakeRunner):
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    exit_code = main(
+                        [
+                            "run",
+                            str(recipes[0]),
+                            str(recipes[1]),
+                            "--out",
+                            str(root / "out"),
+                            "--parallel",
+                            "2",
+                        ]
+                    )
+
+            self.assertEqual(0, exit_code)
+            self.assertEqual(["one", "two"], sorted(FakeRunner.calls))
+            self.assertIn("2/2 passed", output.getvalue())
+
+    def test_run_rejects_invalid_parallel_count(self) -> None:
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            exit_code = main(["run", "missing.recipe.json", "--parallel", "0"])
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("--parallel must be >= 1", output.getvalue())
+
 
 class DemoCommandTest(unittest.TestCase):
     def test_demo_creates_recipe_and_passes(self):


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- add `termproof run --parallel N` for concurrent recipe/renderer execution
- keep serial behavior unchanged for the default `--parallel 1`
- preserve aggregate report generation and stable output ordering
- document parallel recipe pack usage

## Verification
- uv run python -m unittest tests.test_cli.CliTest -v
- uv run python -m unittest discover -s tests
- uv build
- git diff --check

Closes #28