### PR TITLE
Add visual diff mode

### DIFF
--- a/docs/recipe-packs.md
+++ b/docs/recipe-packs.md
@@ -27,6 +27,23 @@ termproof run .termproof/recipes --parallel 4 --out .termproof/runs
 Each recipe/renderer pair still writes its own evidence directory, and
 `latest-report.md` combines the results.
 
+Compare final screenshots against checked-in baselines with:
+
+```bash
+termproof run .termproof/recipes --diff --baseline-dir .termproof/baselines
+```
+
+Baselines live at `.termproof/baselines/<recipe>/<renderer>/final.svg` or
+`.termproof/baselines/<recipe>/<renderer>/final.png`. To create or refresh
+baselines from the current run:
+
+```bash
+termproof run .termproof/recipes --update-baselines
+```
+
+When a screenshot differs, TermProof adds a failing `visual_diff` assertion and
+writes `visual-diff.svg` or `visual-diff.png` beside the run artifacts.
+
 Validate a pack with:
 
 ```bash

--- a/termproof/builtin_reporters.py
+++ b/termproof/builtin_reporters.py
@@ -227,7 +227,15 @@ def _build_info_lines(build_info: BuildInfo) -> list[str]:
 
 def _evidence_links(result: RunResult) -> str:
     links: list[str] = []
-    for key in ("screenshot", "video", "cast", "screen_text", "step_screenshots"):
+    for key in (
+        "screenshot",
+        "visual_diff",
+        "visual_baseline",
+        "video",
+        "cast",
+        "screen_text",
+        "step_screenshots",
+    ):
         value = result.artifacts.get(key)
         if value:
             links.append(f"[{key}]({value})")

--- a/termproof/cli.py
+++ b/termproof/cli.py
@@ -8,11 +8,13 @@ from pathlib import Path
 from .agent_driven import CodexCliAgentRunner
 from .build_info import BuildInfo
 from .config import VerifierConfig, load_config
+from .evidence import write_result_files
 from .recipe_schema import has_errors, validate_recipe_file
 from .registry import find_recipe_files, load_recipes, select_recipes
 from .renderer import selected_renderers
 from .runner import VerificationRunner
 from .scaffold import write_recipe_pack
+from .visual_diff import apply_visual_diff
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -40,6 +42,12 @@ def main(argv: list[str] | None = None) -> int:
                             help="screen renderer to use (default: svg)")
     run_parser.add_argument("--video-backend", default="agg_ffmpeg",
                             help="video backend to use (default: agg_ffmpeg)")
+    run_parser.add_argument("--diff", action="store_true",
+                            help="compare final screenshots against baselines")
+    run_parser.add_argument("--baseline-dir", type=Path, default=Path(".termproof/baselines"),
+                            help="baseline root for --diff")
+    run_parser.add_argument("--update-baselines", action="store_true",
+                            help="write current final screenshots as visual baselines")
     list_parser = subparsers.add_parser("list", help="list recipes")
     list_parser.add_argument("recipes", nargs="+", type=Path)
     list_parser.add_argument("--priority")
@@ -126,6 +134,19 @@ def main(argv: list[str] | None = None) -> int:
                         run_items,
                     )
                 )
+        if args.diff or args.update_baselines:
+            results = [
+                apply_visual_diff(
+                    result,
+                    args.baseline_dir,
+                    update=args.update_baselines,
+                )
+                for result in results
+            ]
+            for result in results:
+                screenshot = result.artifacts.get("screenshot")
+                if screenshot:
+                    write_result_files(Path(screenshot).parent, result)
         build_info = BuildInfo.from_command(recipes[0].command.argv) if recipes else None
         reporter = runner.reporter_registry.get(reporter_name)
         report = reporter.generate(results, build_info=build_info)

--- a/termproof/report.py
+++ b/termproof/report.py
@@ -56,7 +56,15 @@ def _build_info_lines(build_info: BuildInfo) -> list[str]:
 
 def _evidence_links(result: RunResult) -> str:
     links: list[str] = []
-    for key in ("screenshot", "video", "cast", "screen_text", "step_screenshots"):
+    for key in (
+        "screenshot",
+        "visual_diff",
+        "visual_baseline",
+        "video",
+        "cast",
+        "screen_text",
+        "step_screenshots",
+    ):
         value = result.artifacts.get(key)
         if value:
             links.append(f"[{key}]({value})")

--- a/termproof/visual_diff.py
+++ b/termproof/visual_diff.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import base64
+import html
+import shutil
+from dataclasses import replace
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageDraw, ImageFont
+
+from .models import AssertionResult, RunResult, score_from_assertions
+
+
+def apply_visual_diff(
+    result: RunResult,
+    baseline_root: Path,
+    *,
+    update: bool = False,
+) -> RunResult:
+    screenshot_value = result.artifacts.get("screenshot")
+    artifacts = dict(result.artifacts)
+    assertions = list(result.assertions)
+    if not screenshot_value:
+        assertions.append(
+            AssertionResult("visual_diff", False, "no screenshot artifact to compare")
+        )
+        return _replace_result(result, assertions, artifacts)
+
+    screenshot = Path(screenshot_value)
+    baseline = _baseline_path(baseline_root, result, screenshot.suffix)
+    artifacts["visual_baseline"] = str(baseline)
+
+    if update:
+        baseline.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(screenshot, baseline)
+        assertions.append(
+            AssertionResult("visual_diff", True, f"updated baseline: {baseline}")
+        )
+        return _replace_result(result, assertions, artifacts)
+
+    if not baseline.exists():
+        assertions.append(
+            AssertionResult(
+                "visual_diff",
+                False,
+                f"missing baseline: {baseline}; run with --update-baselines to create it",
+            )
+        )
+        return _replace_result(result, assertions, artifacts)
+
+    if _screenshots_match(baseline, screenshot):
+        assertions.append(
+            AssertionResult("visual_diff", True, f"matches baseline: {baseline}")
+        )
+        return _replace_result(result, assertions, artifacts)
+
+    diff_path = screenshot.with_name(f"visual-diff{screenshot.suffix}")
+    _write_diff_image(baseline, screenshot, diff_path)
+    artifacts["visual_diff"] = str(diff_path)
+    assertions.append(
+        AssertionResult(
+            "visual_diff",
+            False,
+            f"visual regression: baseline={baseline} actual={screenshot} diff={diff_path}",
+        )
+    )
+    return _replace_result(result, assertions, artifacts)
+
+
+def _replace_result(
+    result: RunResult,
+    assertions: list[AssertionResult],
+    artifacts: dict[str, str],
+) -> RunResult:
+    return replace(
+        result,
+        passed=result.passed and all(assertion.passed for assertion in assertions),
+        score=score_from_assertions(assertions),
+        assertions=assertions,
+        artifacts=artifacts,
+    )
+
+
+def _baseline_path(baseline_root: Path, result: RunResult, suffix: str) -> Path:
+    return (
+        baseline_root
+        / _safe_path_part(result.recipe_name)
+        / _safe_path_part(result.renderer)
+        / f"final{suffix}"
+    )
+
+
+def _safe_path_part(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in value)
+    return safe or "default"
+
+
+def _write_diff_image(baseline: Path, screenshot: Path, diff_path: Path) -> None:
+    diff_path.parent.mkdir(parents=True, exist_ok=True)
+    if screenshot.suffix.lower() == ".png" and baseline.suffix.lower() == ".png":
+        _write_png_diff(baseline, screenshot, diff_path)
+        return
+    _write_svg_side_by_side(baseline, screenshot, diff_path.with_suffix(".svg"))
+
+
+def _screenshots_match(baseline: Path, screenshot: Path) -> bool:
+    if screenshot.suffix.lower() == ".png" and baseline.suffix.lower() == ".png":
+        with Image.open(baseline) as baseline_image, Image.open(screenshot) as actual_image:
+            baseline_rgb = baseline_image.convert("RGB")
+            actual_rgb = actual_image.convert("RGB")
+            if baseline_rgb.size != actual_rgb.size:
+                return False
+            return ImageChops.difference(baseline_rgb, actual_rgb).getbbox() is None
+    return baseline.read_bytes() == screenshot.read_bytes()
+
+
+def _write_png_diff(baseline: Path, screenshot: Path, diff_path: Path) -> None:
+    with Image.open(baseline) as baseline_image, Image.open(screenshot) as actual_image:
+        baseline_rgb = baseline_image.convert("RGB")
+        actual_rgb = actual_image.convert("RGB")
+        width = max(baseline_rgb.width, actual_rgb.width)
+        height = max(baseline_rgb.height, actual_rgb.height)
+        baseline_panel = _padded_image(baseline_rgb, width, height)
+        actual_panel = _padded_image(actual_rgb, width, height)
+        diff_panel = ImageChops.difference(baseline_panel, actual_panel)
+        label_height = 28
+        combined = Image.new("RGB", (width * 3, height + label_height), "white")
+        combined.paste(baseline_panel, (0, label_height))
+        combined.paste(actual_panel, (width, label_height))
+        combined.paste(diff_panel, (width * 2, label_height))
+        draw = ImageDraw.Draw(combined)
+        font = ImageFont.load_default()
+        for index, label in enumerate(("baseline", "actual", "diff")):
+            draw.text((width * index + 8, 8), label, fill="black", font=font)
+        combined.save(diff_path, format="PNG")
+
+
+def _padded_image(image: Image.Image, width: int, height: int) -> Image.Image:
+    padded = Image.new("RGB", (width, height), "white")
+    padded.paste(image, (0, 0))
+    return padded
+
+
+def _write_svg_side_by_side(baseline: Path, screenshot: Path, diff_path: Path) -> None:
+    baseline_uri = _data_uri(baseline)
+    actual_uri = _data_uri(screenshot)
+    width = 1200
+    height = 620
+    panel_width = 560
+    panel_height = 520
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="#f6f8fa"/>',
+        '<style>text{font:16px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;fill:#24292f}</style>',
+        '<text x="24" y="32">baseline</text>',
+        '<text x="616" y="32">actual</text>',
+        f'<image href="{html.escape(baseline_uri)}" x="24" y="56" width="{panel_width}" height="{panel_height}" preserveAspectRatio="xMinYMin meet"/>',
+        f'<image href="{html.escape(actual_uri)}" x="616" y="56" width="{panel_width}" height="{panel_height}" preserveAspectRatio="xMinYMin meet"/>',
+        "</svg>",
+    ]
+    diff_path.write_text("\n".join(parts) + "\n", encoding="utf-8")
+
+
+def _data_uri(path: Path) -> str:
+    media_type = "image/png" if path.suffix.lower() == ".png" else "image/svg+xml"
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{media_type};base64,{encoded}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,6 +199,61 @@ class CliTest(unittest.TestCase):
         self.assertEqual(2, exit_code)
         self.assertIn("--parallel must be >= 1", output.getvalue())
 
+    def test_run_diff_marks_visual_regression(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            recipe_path = root / "recipe.json"
+            recipe_path.write_text(
+                """{
+  "name": "diff-test",
+  "command": {"argv": ["python3", "-c", "print('ok')"], "pty": false}
+}
+""",
+                encoding="utf-8",
+            )
+            screenshot = root / "run" / "final.svg"
+            baseline = root / "baselines" / "diff-test" / "default" / "final.svg"
+            screenshot.parent.mkdir()
+            baseline.parent.mkdir(parents=True)
+            screenshot.write_text("<svg>actual</svg>\n", encoding="utf-8")
+            baseline.write_text("<svg>baseline</svg>\n", encoding="utf-8")
+
+            result = RunResult(
+                recipe_name="diff-test",
+                passed=True,
+                exit_code=0,
+                duration_seconds=0.0,
+                priority="P2",
+                execution="scripted",
+                renderer="default",
+                score=1.0,
+                steps=[],
+                assertions=[],
+                artifacts={"screenshot": str(screenshot)},
+            )
+
+            with patch("termproof.cli.VerificationRunner") as runner_class:
+                runner = runner_class.return_value
+                runner.run.return_value = result
+                runner.reporter_registry.get.return_value.generate.return_value = "report"
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    exit_code = main(
+                        [
+                            "run",
+                            str(recipe_path),
+                            "--out",
+                            str(root / "out"),
+                            "--diff",
+                            "--baseline-dir",
+                            str(root / "baselines"),
+                        ]
+                    )
+
+            self.assertEqual(1, exit_code)
+            self.assertTrue(screenshot.with_name("visual-diff.svg").is_file())
+            self.assertIn("0/1 passed", output.getvalue())
+
 
 class DemoCommandTest(unittest.TestCase):
     def test_demo_creates_recipe_and_passes(self):

--- a/tests/test_visual_diff.py
+++ b/tests/test_visual_diff.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from termproof.models import RunResult
+from termproof.visual_diff import apply_visual_diff
+
+
+class VisualDiffTest(unittest.TestCase):
+    def test_update_baselines_writes_current_screenshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            screenshot = root / "run" / "final.svg"
+            screenshot.parent.mkdir()
+            screenshot.write_text("<svg>current</svg>\n", encoding="utf-8")
+
+            result = apply_visual_diff(_result(screenshot), root / "baselines", update=True)
+
+            baseline = root / "baselines" / "recipe" / "default" / "final.svg"
+            self.assertTrue(result.passed)
+            self.assertEqual(screenshot.read_text(encoding="utf-8"), baseline.read_text(encoding="utf-8"))
+            self.assertEqual(str(baseline), result.artifacts["visual_baseline"])
+
+    def test_missing_baseline_fails_with_actionable_message(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            screenshot = root / "run" / "final.svg"
+            screenshot.parent.mkdir()
+            screenshot.write_text("<svg>current</svg>\n", encoding="utf-8")
+
+            result = apply_visual_diff(_result(screenshot), root / "baselines")
+
+            self.assertFalse(result.passed)
+            self.assertIn("missing baseline", result.assertions[-1].detail)
+            self.assertIn("--update-baselines", result.assertions[-1].detail)
+
+    def test_matching_baseline_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            screenshot = root / "run" / "final.svg"
+            baseline = root / "baselines" / "recipe" / "default" / "final.svg"
+            screenshot.parent.mkdir()
+            baseline.parent.mkdir(parents=True)
+            screenshot.write_text("<svg>same</svg>\n", encoding="utf-8")
+            baseline.write_text("<svg>same</svg>\n", encoding="utf-8")
+
+            result = apply_visual_diff(_result(screenshot), root / "baselines")
+
+            self.assertTrue(result.passed)
+            self.assertIn("matches baseline", result.assertions[-1].detail)
+
+    def test_svg_difference_writes_side_by_side_diff(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            screenshot = root / "run" / "final.svg"
+            baseline = root / "baselines" / "recipe" / "default" / "final.svg"
+            screenshot.parent.mkdir()
+            baseline.parent.mkdir(parents=True)
+            screenshot.write_text("<svg>actual</svg>\n", encoding="utf-8")
+            baseline.write_text("<svg>baseline</svg>\n", encoding="utf-8")
+
+            result = apply_visual_diff(_result(screenshot), root / "baselines")
+
+            diff_path = screenshot.with_name("visual-diff.svg")
+            self.assertFalse(result.passed)
+            self.assertTrue(diff_path.is_file())
+            self.assertEqual(str(diff_path), result.artifacts["visual_diff"])
+
+    def test_png_difference_writes_pixel_diff(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            screenshot = root / "run" / "final.png"
+            baseline = root / "baselines" / "recipe" / "default" / "final.png"
+            screenshot.parent.mkdir()
+            baseline.parent.mkdir(parents=True)
+            Image.new("RGB", (20, 20), "red").save(screenshot)
+            Image.new("RGB", (20, 20), "blue").save(baseline)
+
+            result = apply_visual_diff(_result(screenshot), root / "baselines")
+
+            diff_path = screenshot.with_name("visual-diff.png")
+            self.assertFalse(result.passed)
+            self.assertTrue(diff_path.is_file())
+            with Image.open(diff_path) as image:
+                self.assertEqual("PNG", image.format)
+
+
+def _result(screenshot: Path) -> RunResult:
+    return RunResult(
+        recipe_name="recipe",
+        passed=True,
+        exit_code=0,
+        duration_seconds=0.0,
+        priority="P2",
+        execution="scripted",
+        renderer="default",
+        score=1.0,
+        steps=[],
+        assertions=[],
+        artifacts={"screenshot": str(screenshot)},
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- add `termproof run --diff` and `--update-baselines` for final screenshot baselines
- compare SVG/PNG screenshots under `.termproof/baselines/<recipe>/<renderer>/final.<ext>`
- generate `visual-diff.svg` or `visual-diff.png` artifacts and attach a `visual_diff` assertion to reports
- document baseline layout and refresh flow

## Verification
- uv run python -m unittest tests.test_visual_diff tests.test_cli.CliTest tests.test_stack_design -v
- uv run python -m unittest discover -s tests
- uv build
- git diff --cached --check

Closes #30