### PR TITLE
Add unchanged recipe cache

### DIFF
--- a/docs/recipe-packs.md
+++ b/docs/recipe-packs.md
@@ -44,6 +44,13 @@ termproof run .termproof/recipes --update-baselines
 When a screenshot differs, TermProof adds a failing `visual_diff` assertion and
 writes `visual-diff.svg` or `visual-diff.png` beside the run artifacts.
 
+Large CI suites can skip recipe/renderer pairs whose recipe file and
+run-affecting options are unchanged from the last passing run:
+
+```bash
+termproof run .termproof/recipes --parallel 8 --skip-unchanged --cache-dir .termproof/cache
+```
+
 Validate a pack with:
 
 ```bash

--- a/termproof/cli.py
+++ b/termproof/cli.py
@@ -13,6 +13,7 @@ from .recipe_schema import has_errors, validate_recipe_file
 from .registry import find_recipe_files, load_recipes, select_recipes
 from .renderer import selected_renderers
 from .runner import VerificationRunner
+from .run_cache import load_cached_result, store_cached_result
 from .scaffold import write_recipe_pack
 from .visual_diff import apply_visual_diff
 
@@ -48,6 +49,10 @@ def main(argv: list[str] | None = None) -> int:
                             help="baseline root for --diff")
     run_parser.add_argument("--update-baselines", action="store_true",
                             help="write current final screenshots as visual baselines")
+    run_parser.add_argument("--skip-unchanged", action="store_true",
+                            help="reuse cached passing results for unchanged recipes")
+    run_parser.add_argument("--cache-dir", type=Path, default=Path(".termproof/cache"),
+                            help="cache root for --skip-unchanged")
     list_parser = subparsers.add_parser("list", help="list recipes")
     list_parser.add_argument("recipes", nargs="+", type=Path)
     list_parser.add_argument("--priority")
@@ -100,6 +105,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "run":
         if args.parallel < 1:
             print("--parallel must be >= 1")
+            return 2
+        if args.skip_unchanged and (args.diff or args.update_baselines):
+            print("--skip-unchanged cannot be combined with --diff or --update-baselines")
             return 2
         config = _resolve_config(args)
         recipes = select_recipes(
@@ -269,13 +277,42 @@ def _run_item(
     args: argparse.Namespace,
 ):
     recipe, renderer_name, renderer_argv = item
-    return runner.run(
+    render_video = args.video and not args.no_video
+    if args.skip_unchanged:
+        cached = load_cached_result(
+            args.cache_dir,
+            recipe,
+            renderer_name,
+            renderer_argv,
+            out_dir=args.out,
+            screen_renderer=args.screen_renderer,
+            video_backend=args.video_backend,
+            render_video=render_video,
+            video_fps=args.video_fps,
+        )
+        if cached is not None:
+            return cached
+    result = runner.run(
         recipe,
         out_dir=args.out,
-        render_video=args.video and not args.no_video,
+        render_video=render_video,
         video_fps=args.video_fps,
         renderer=renderer_name,
         renderer_argv=renderer_argv,
         screen_renderer_name=args.screen_renderer,
         video_backend_name=args.video_backend,
     )
+    if args.skip_unchanged:
+        store_cached_result(
+            args.cache_dir,
+            recipe,
+            renderer_name,
+            renderer_argv,
+            result,
+            out_dir=args.out,
+            screen_renderer=args.screen_renderer,
+            video_backend=args.video_backend,
+            render_video=render_video,
+            video_fps=args.video_fps,
+        )
+    return result

--- a/termproof/models.py
+++ b/termproof/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +35,7 @@ class Recipe:
     timeout_seconds: float = 30.0
     cols: int = 100
     rows: int = 30
+    source_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -122,7 +123,8 @@ def recipe_from_mapping(data: dict[str, Any]) -> Recipe:
 def load_recipe(path: Path) -> Recipe:
     import json
 
-    return recipe_from_mapping(json.loads(path.read_text(encoding="utf-8")))
+    recipe = recipe_from_mapping(json.loads(path.read_text(encoding="utf-8")))
+    return replace(recipe, source_path=str(path))
 
 
 def score_from_assertions(assertions: list[AssertionResult]) -> float:

--- a/termproof/run_cache.py
+++ b/termproof/run_cache.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from .models import AssertionResult, Recipe, RunResult, StepResult
+
+
+def load_cached_result(
+    cache_dir: Path,
+    recipe: Recipe,
+    renderer: str,
+    renderer_argv: list[str],
+    *,
+    out_dir: Path,
+    screen_renderer: str,
+    video_backend: str,
+    render_video: bool,
+    video_fps: int,
+) -> RunResult | None:
+    key = _cache_key(
+        recipe,
+        renderer,
+        renderer_argv,
+        out_dir=out_dir,
+        screen_renderer=screen_renderer,
+        video_backend=video_backend,
+        render_video=render_video,
+        video_fps=video_fps,
+    )
+    if key is None:
+        return None
+    path = _cache_path(cache_dir, recipe, renderer)
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("key") != key:
+        return None
+    result = _result_from_dict(data["result"])
+    if not result.passed or not _artifacts_exist(result):
+        return None
+    return replace(
+        result,
+        duration_seconds=0.0,
+        artifacts={**result.artifacts, "cache": str(path)},
+    )
+
+
+def store_cached_result(
+    cache_dir: Path,
+    recipe: Recipe,
+    renderer: str,
+    renderer_argv: list[str],
+    result: RunResult,
+    *,
+    out_dir: Path,
+    screen_renderer: str,
+    video_backend: str,
+    render_video: bool,
+    video_fps: int,
+) -> None:
+    if not result.passed:
+        return
+    key = _cache_key(
+        recipe,
+        renderer,
+        renderer_argv,
+        out_dir=out_dir,
+        screen_renderer=screen_renderer,
+        video_backend=video_backend,
+        render_video=render_video,
+        video_fps=video_fps,
+    )
+    if key is None:
+        return
+    path = _cache_path(cache_dir, recipe, renderer)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"key": key, "result": result.to_dict()}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _cache_key(
+    recipe: Recipe,
+    renderer: str,
+    renderer_argv: list[str],
+    *,
+    out_dir: Path,
+    screen_renderer: str,
+    video_backend: str,
+    render_video: bool,
+    video_fps: int,
+) -> str | None:
+    if not recipe.source_path:
+        return None
+    recipe_path = Path(recipe.source_path)
+    if not recipe_path.is_file():
+        return None
+    digest = hashlib.sha256()
+    _hash_path(digest, recipe_path)
+    for ci_path in sorted(recipe.ci_paths):
+        candidate = Path(ci_path)
+        path = candidate if candidate.is_absolute() else recipe_path.parent / candidate
+        _hash_path(digest, path)
+    payload = {
+        "renderer": renderer,
+        "renderer_argv": renderer_argv,
+        "out_dir": str(out_dir),
+        "screen_renderer": screen_renderer,
+        "render_video": render_video,
+        "video_backend": video_backend if render_video else "",
+        "video_fps": video_fps if render_video else 0,
+    }
+    digest.update(json.dumps(payload, sort_keys=True).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _cache_path(cache_dir: Path, recipe: Recipe, renderer: str) -> Path:
+    return cache_dir / _safe(recipe.name) / f"{_safe(renderer)}.json"
+
+
+def _safe(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in value)
+    return safe or "default"
+
+
+def _hash_path(digest: Any, path: Path) -> None:
+    digest.update(str(path).encode("utf-8"))
+    if path.is_file():
+        digest.update(path.read_bytes())
+        return
+    if path.is_dir():
+        children = sorted(child for child in path.rglob("*") if child.is_file())
+        for child in children:
+            _hash_path(digest, child)
+        return
+    digest.update(b"<missing>")
+
+
+def _result_from_dict(data: dict[str, Any]) -> RunResult:
+    return RunResult(
+        recipe_name=data["recipe_name"],
+        passed=bool(data["passed"]),
+        exit_code=data.get("exit_code"),
+        duration_seconds=float(data["duration_seconds"]),
+        priority=data["priority"],
+        execution=data["execution"],
+        renderer=data["renderer"],
+        score=float(data["score"]),
+        steps=[StepResult(**step) for step in data.get("steps", [])],
+        assertions=[
+            AssertionResult(**assertion)
+            for assertion in data.get("assertions", [])
+        ],
+        artifacts=dict(data.get("artifacts", {})),
+    )
+
+
+def _artifacts_exist(result: RunResult) -> bool:
+    for key in ("cast", "screenshot", "screen_text"):
+        value = result.artifacts.get(key)
+        if value and not Path(value).exists():
+            return False
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from termproof.cli import main
-from termproof.models import RunResult
+from termproof.models import RunResult, load_recipe
+from termproof.run_cache import store_cached_result
 
 
 class CliTest(unittest.TestCase):
@@ -253,6 +254,82 @@ class CliTest(unittest.TestCase):
             self.assertEqual(1, exit_code)
             self.assertTrue(screenshot.with_name("visual-diff.svg").is_file())
             self.assertIn("0/1 passed", output.getvalue())
+
+    def test_run_skip_unchanged_reuses_cached_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pack = root / "recipes"
+            pack.mkdir()
+            cache = root / "cache"
+            for index in range(50):
+                name = f"recipe-{index:02d}"
+                recipe_path = pack / f"{name}.recipe.json"
+                recipe_path.write_text(
+                    f"""{{
+  "name": "{name}",
+  "command": {{"argv": ["python3", "-c", "print('ok')"], "pty": false}}
+}}
+""",
+                    encoding="utf-8",
+                )
+                screenshot = root / "runs" / name / "final.svg"
+                screenshot.parent.mkdir(parents=True)
+                screenshot.write_text("<svg/>\n", encoding="utf-8")
+                store_cached_result(
+                    cache,
+                    load_recipe(recipe_path),
+                    "default",
+                    [],
+                    RunResult(
+                        recipe_name=name,
+                        passed=True,
+                        exit_code=0,
+                        duration_seconds=1.0,
+                        priority="P2",
+                        execution="scripted",
+                        renderer="default",
+                        score=1.0,
+                        steps=[],
+                        assertions=[],
+                        artifacts={"screenshot": str(screenshot)},
+                    ),
+                    out_dir=root / "runs",
+                    screen_renderer="svg",
+                    video_backend="agg_ffmpeg",
+                    render_video=False,
+                    video_fps=60,
+                )
+
+            with patch("termproof.cli.VerificationRunner") as runner_class:
+                runner = runner_class.return_value
+                runner.run.side_effect = AssertionError("runner should be skipped")
+                runner.reporter_registry.get.return_value.generate.return_value = "report"
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    exit_code = main(
+                        [
+                            "run",
+                            str(pack),
+                            "--out",
+                            str(root / "runs"),
+                            "--skip-unchanged",
+                            "--cache-dir",
+                            str(cache),
+                        ]
+                    )
+
+            self.assertEqual(0, exit_code)
+            self.assertIn("50/50 passed", output.getvalue())
+            runner.run.assert_not_called()
+
+    def test_run_rejects_skip_unchanged_with_visual_diff(self) -> None:
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            exit_code = main(["run", "missing.recipe.json", "--skip-unchanged", "--diff"])
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("cannot be combined", output.getvalue())
 
 
 class DemoCommandTest(unittest.TestCase):

--- a/tests/test_run_cache.py
+++ b/tests/test_run_cache.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from termproof.models import RunResult, load_recipe
+from termproof.run_cache import load_cached_result, store_cached_result
+
+
+class RunCacheTest(unittest.TestCase):
+    def test_load_cached_result_returns_last_passing_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            recipe_path = _write_recipe(root, "cached")
+            recipe = load_recipe(recipe_path)
+            screenshot = root / "run" / "final.svg"
+            screenshot.parent.mkdir()
+            screenshot.write_text("<svg/>\n", encoding="utf-8")
+            result = _result("cached", screenshot)
+
+            store_cached_result(
+                root / "cache",
+                recipe,
+                "default",
+                [],
+                result,
+                out_dir=root / "runs",
+                screen_renderer="svg",
+                video_backend="agg_ffmpeg",
+                render_video=False,
+                video_fps=60,
+            )
+            cached = load_cached_result(
+                root / "cache",
+                recipe,
+                "default",
+                [],
+                out_dir=root / "runs",
+                screen_renderer="svg",
+                video_backend="agg_ffmpeg",
+                render_video=False,
+                video_fps=60,
+            )
+
+            self.assertIsNotNone(cached)
+            self.assertEqual("cached", cached.recipe_name)
+            self.assertEqual(0.0, cached.duration_seconds)
+            self.assertIn("cache", cached.artifacts)
+
+    def test_recipe_file_change_invalidates_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            recipe_path = _write_recipe(root, "cached")
+            recipe = load_recipe(recipe_path)
+            screenshot = root / "run" / "final.svg"
+            screenshot.parent.mkdir()
+            screenshot.write_text("<svg/>\n", encoding="utf-8")
+            result = _result("cached", screenshot)
+
+            store_cached_result(
+                root / "cache",
+                recipe,
+                "default",
+                [],
+                result,
+                out_dir=root / "runs",
+                screen_renderer="svg",
+                video_backend="agg_ffmpeg",
+                render_video=False,
+                video_fps=60,
+            )
+            recipe_path.write_text(
+                recipe_path.read_text(encoding="utf-8") + "\n",
+                encoding="utf-8",
+            )
+
+            cached = load_cached_result(
+                root / "cache",
+                recipe,
+                "default",
+                [],
+                out_dir=root / "runs",
+                screen_renderer="svg",
+                video_backend="agg_ffmpeg",
+                render_video=False,
+                video_fps=60,
+            )
+
+            self.assertIsNone(cached)
+
+    def test_ci_path_change_invalidates_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = root / "fixture.txt"
+            fixture.write_text("before\n", encoding="utf-8")
+            recipe_path = _write_recipe(root, "cached", ci_paths=["fixture.txt"])
+            recipe = load_recipe(recipe_path)
+            screenshot = root / "run" / "final.svg"
+            screenshot.parent.mkdir()
+            screenshot.write_text("<svg/>\n", encoding="utf-8")
+            result = _result("cached", screenshot)
+
+            store_cached_result(
+                root / "cache",
+                recipe,
+                "default",
+                [],
+                result,
+                out_dir=root / "runs",
+                screen_renderer="svg",
+                video_backend="agg_ffmpeg",
+                render_video=False,
+                video_fps=60,
+            )
+            fixture.write_text("after\n", encoding="utf-8")
+
+            cached = load_cached_result(
+                root / "cache",
+                recipe,
+                "default",
+                [],
+                out_dir=root / "runs",
+                screen_renderer="svg",
+                video_backend="agg_ffmpeg",
+                render_video=False,
+                video_fps=60,
+            )
+
+            self.assertIsNone(cached)
+
+
+def _write_recipe(root: Path, name: str, ci_paths: list[str] | None = None) -> Path:
+    path = root / f"{name}.recipe.json"
+    ci_paths_json = ""
+    if ci_paths is not None:
+        quoted = ", ".join(f'"{ci_path}"' for ci_path in ci_paths)
+        ci_paths_json = f',\n  "ci_paths": [{quoted}]'
+    path.write_text(
+        f"""{{
+  "name": "{name}",
+  "command": {{"argv": ["python3", "-c", "print('ok')"], "pty": false}}{ci_paths_json}
+}}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _result(name: str, screenshot: Path) -> RunResult:
+    return RunResult(
+        recipe_name=name,
+        passed=True,
+        exit_code=0,
+        duration_seconds=1.0,
+        priority="P2",
+        execution="scripted",
+        renderer="default",
+        score=1.0,
+        steps=[],
+        assertions=[],
+        artifacts={"screenshot": str(screenshot)},
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- add `termproof run --skip-unchanged` with a cache keyed by recipe contents, declared `ci_paths`, renderer, output, screen renderer, and video options
- reuse only cached passing results whose evidence artifacts still exist
- keep `--diff`/`--update-baselines` uncached to avoid stale visual baselines
- document the `--parallel` + `--skip-unchanged` CI pattern

## Verification
- uv run python -m unittest tests.test_run_cache tests.test_cli.CliTest -v
- uv run python -m unittest discover -s tests
- uv build
- git diff --cached --check

Closes #33