### PR TITLE
Add VitePress documentation site

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,0 +1,48 @@
+name: Documentation Site
+
+on:
+  pull_request:
+    paths:
+      - "docs-site/**"
+      - "docs/**"
+      - "README.md"
+      - ".github/workflows/docs-site.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs-site/**"
+      - "docs/**"
+      - "README.md"
+      - ".github/workflows/docs-site.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build VitePress docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install docs dependencies
+        run: npm install --prefix docs-site --no-package-lock
+
+      - name: Build docs site
+        run: npm run --prefix docs-site docs:build
+
+      - name: Upload docs site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: termproof-docs-site
+          path: docs-site/.vitepress/dist
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 build/
 *.egg-info/
 _site/
+node_modules/
+docs-site/.vitepress/cache/
+docs-site/.vitepress/dist/

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ See [`docs/verified-badge.md`](docs/verified-badge.md) for variants (flat, plast
 - **Contributing:** [`CONTRIBUTING.md`](CONTRIBUTING.md) — ladder, setup, PR-only process.
 - **Code of Conduct:** [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — Contributor Covenant 2.1.
 - **Pages demo:** Preview locally with `python3 -m http.server 8000 --directory site`. When Pages is enabled on this repo, the rendered site will be at https://md-mt.github.io/termproof/.
+- **Docs site:** [`docs-site`](docs-site) — VitePress documentation source and build.
 - **Examples:** [`examples/generic`](examples/generic) — portable TUI; `examples/pi_workflow_*.recipe.json` — Pi agent showcase.
 - **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md) · [`docs/ci/gitlab.md`](docs/ci/gitlab.md) · [`docs/ci/circleci.md`](docs/ci/circleci.md) · [`docs/ci/docker.md`](docs/ci/docker.md)
 

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -1,0 +1,46 @@
+import { defineConfig } from "vitepress";
+
+export default defineConfig({
+  title: "TermProof",
+  description: "Evidence-first verification for terminal and TUI applications.",
+  cleanUrls: true,
+  themeConfig: {
+    nav: [
+      { text: "Guide", link: "/getting-started" },
+      { text: "API", link: "/api/" },
+      { text: "Plugins", link: "/plugins" },
+      { text: "CI", link: "/ci/" },
+      { text: "GitHub", link: "https://github.com/md-mt/termproof" }
+    ],
+    sidebar: [
+      {
+        text: "Getting Started",
+        items: [
+          { text: "Overview", link: "/" },
+          { text: "Install and Run", link: "/getting-started" },
+          { text: "FAQ", link: "/faq" }
+        ]
+      },
+      {
+        text: "Guides",
+        items: [
+          { text: "Framework Guides", link: "/guides/" },
+          { text: "Textual", link: "/guides/textual" },
+          { text: "Bubble Tea", link: "/guides/bubbletea" },
+          { text: "Ratatui", link: "/guides/ratatui" }
+        ]
+      },
+      {
+        text: "Reference",
+        items: [
+          { text: "API Reference", link: "/api/" },
+          { text: "Plugins", link: "/plugins" },
+          { text: "CI Integration", link: "/ci/" }
+        ]
+      }
+    ],
+    socialLinks: [
+      { icon: "github", link: "https://github.com/md-mt/termproof" }
+    ]
+  }
+});

--- a/docs-site/api/index.md
+++ b/docs-site/api/index.md
@@ -1,0 +1,28 @@
+# API Reference
+
+TermProof stabilizes the recipe format and plugin protocols as public integration surfaces.
+
+## Recipe Format
+
+- `recipe_version: 1` marks the stable JSON recipe format.
+- `command.argv` launches the target process.
+- `steps` drive terminal input and waits.
+- `assertions` evaluate output, screen text, exit code, files, or JSON Schema.
+- `renderers` fan one recipe out across multiple frontend implementations.
+
+See `docs/recipe-format-v1.md` and `docs/recipe-schema-v1.json` in the repository for the complete schema and migration policy.
+
+## Plugin Protocols
+
+Stable protocols cover:
+
+- `StepAction`
+- `AssertionType`
+- `ExecutionMode`
+- `Reporter`
+- `ScreenRenderer`
+- `VideoBackend`
+- `AgentRunner`
+- `SessionBackend`
+
+See `docs/plugin-protocols.md` for signatures and compatibility policy.

--- a/docs-site/ci/index.md
+++ b/docs-site/ci/index.md
@@ -1,0 +1,24 @@
+# CI Integration
+
+TermProof CI integrations run recipes, upload `.termproof/runs`, and surface reports where reviewers already work.
+
+## GitHub Actions
+
+Use the reusable action in `action.yml` or copy the workflow pattern from `.github/workflows/ci.yml`.
+
+## GitLab CI
+
+Start from `templates/gitlab/.gitlab-ci.yml` and `docs/ci/gitlab.md`.
+
+## CircleCI
+
+Use `.circleci/orb.yml` as the orb source and `docs/ci/circleci.md` for registry usage.
+
+## Docker
+
+Use `ghcr.io/md-mt/termproof:latest` from any CI runner with Docker.
+
+```bash
+docker run --rm -v "$PWD:/workspace" ghcr.io/md-mt/termproof:latest \
+  run .termproof/recipes --out .termproof/runs
+```

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -1,0 +1,17 @@
+# FAQ
+
+## Is TermProof a browser testing tool?
+
+No. TermProof drives a real terminal session and records terminal-native evidence.
+
+## Do I need video evidence?
+
+No. Casts, final screenshots, text snapshots, JSON results, and Markdown reports are available without video. MP4 output is useful for review workflows where motion matters.
+
+## How do visual baselines work?
+
+Use `termproof run --diff` to compare final screenshots against `.termproof/baselines/<recipe>/<renderer>/final.svg` or `.png`. Use `--update-baselines` to refresh them.
+
+## How do large suites stay fast?
+
+Use `--parallel N` to run independent recipes concurrently and `--skip-unchanged` to reuse the last passing result for unchanged recipe inputs.

--- a/docs-site/getting-started.md
+++ b/docs-site/getting-started.md
@@ -1,0 +1,39 @@
+# Getting Started
+
+TermProof verifies terminal and TUI behavior by running JSON recipes against a real process and saving evidence for review.
+
+## Install
+
+Until the first PyPI release is published, install from GitHub:
+
+```bash
+pip install git+https://github.com/md-mt/termproof.git
+```
+
+From a source checkout:
+
+```bash
+git clone https://github.com/md-mt/termproof.git
+cd termproof
+uv run termproof --help
+```
+
+## Create A Recipe Pack
+
+```bash
+termproof init .termproof/recipes --name my-tui --command "my-tui"
+```
+
+## Run Verification
+
+```bash
+termproof run .termproof/recipes --video --out .termproof/runs
+```
+
+For larger suites:
+
+```bash
+termproof run .termproof/recipes --parallel 8 --skip-unchanged --out .termproof/runs
+```
+
+Upload `.termproof/runs` as a CI artifact so reviewers can inspect the cast, screenshots, text snapshots, video, JSON result, and Markdown report.

--- a/docs-site/guides/bubbletea.md
+++ b/docs-site/guides/bubbletea.md
@@ -1,0 +1,10 @@
+# Bubble Tea
+
+Bubble Tea applications work well with recipes that wait for prompt text, send key presses, and assert final screen state.
+
+```bash
+termproof init .termproof/recipes --name bubbletea-smoke --command "./my-tui"
+termproof run .termproof/recipes --video
+```
+
+See the repository guide at `docs/guides/bubbletea.md` for detailed patterns.

--- a/docs-site/guides/index.md
+++ b/docs-site/guides/index.md
@@ -1,0 +1,9 @@
+# Guides
+
+Framework-specific guides show how to choose stable waits, assertions, and CI gates for common TUI stacks.
+
+- [Textual](./textual.md)
+- [Bubble Tea](./bubbletea.md)
+- [Ratatui](./ratatui.md)
+
+For the stable recipe format, see [Recipe Format v1](../api/index.md).

--- a/docs-site/guides/ratatui.md
+++ b/docs-site/guides/ratatui.md
@@ -1,0 +1,10 @@
+# Ratatui
+
+Ratatui applications should expose deterministic startup text or test-mode fixtures so recipes can wait for stable states.
+
+```bash
+termproof init .termproof/recipes --name ratatui-smoke --command "cargo run --bin my-tui"
+termproof run .termproof/recipes --video
+```
+
+See the repository guide at `docs/guides/ratatui.md` for detailed patterns.

--- a/docs-site/guides/textual.md
+++ b/docs-site/guides/textual.md
@@ -1,0 +1,10 @@
+# Textual
+
+Use TermProof with Textual by waiting for stable screen text, command prompts, or widget labels rather than animation frames.
+
+```bash
+termproof init .termproof/recipes --name textual-smoke --command "python -m my_app"
+termproof run .termproof/recipes --video
+```
+
+See the repository guide at `docs/guides/textual.md` for detailed patterns.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -1,0 +1,23 @@
+---
+layout: home
+
+hero:
+  name: TermProof
+  text: Evidence-first verification for terminal apps
+  tagline: Drive real TUI sessions, record the proof, and ship reviewable artifacts from CI.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /getting-started
+    - theme: alt
+      text: View CI Guides
+      link: /ci/
+
+features:
+  - title: Real terminal evidence
+    details: Recipes drive PTY sessions and produce casts, screenshots, text snapshots, videos, and reports.
+  - title: CI-native outputs
+    details: GitHub Actions, GitLab CI, CircleCI, Docker, Markdown, JSON, and JUnit XML workflows are documented.
+  - title: Extensible core
+    details: Stable plugin protocols cover steps, assertions, renderers, reporters, agents, sessions, and video backends.
+---

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "docs:dev": "vitepress dev .",
+    "docs:build": "vitepress build .",
+    "docs:preview": "vitepress preview ."
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.4"
+  }
+}

--- a/docs-site/plugins.md
+++ b/docs-site/plugins.md
@@ -1,0 +1,13 @@
+# Plugins
+
+TermProof plugins extend recipe steps, assertions, execution modes, reporters, renderers, video backends, agent runners, and session backends.
+
+Use the plugin CLI to inspect configured plugins:
+
+```bash
+termproof plugins list
+termproof plugins search textual
+termproof plugins install termproof-textual --dry-run
+```
+
+Community plugin entries live in `docs/plugins.md` until the registry needs automation.

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_SITE = ROOT / "docs-site"
+CONFIG = DOCS_SITE / ".vitepress" / "config.mts"
+WORKFLOW = ROOT / ".github" / "workflows" / "docs-site.yml"
+
+
+class DocsSiteTest(unittest.TestCase):
+    def test_vitepress_package_and_sections_exist(self) -> None:
+        package = json.loads((DOCS_SITE / "package.json").read_text(encoding="utf-8"))
+
+        self.assertEqual("vitepress build .", package["scripts"]["docs:build"])
+        for path in (
+            "getting-started.md",
+            "guides/index.md",
+            "api/index.md",
+            "plugins.md",
+            "ci/index.md",
+            "faq.md",
+        ):
+            self.assertTrue((DOCS_SITE / path).is_file(), path)
+
+    def test_vitepress_nav_has_expected_structure(self) -> None:
+        text = CONFIG.read_text(encoding="utf-8")
+
+        self.assertIn("Getting Started", text)
+        self.assertIn("Guides", text)
+        self.assertIn("API Reference", text)
+        self.assertIn("Plugins", text)
+        self.assertIn("CI Integration", text)
+        self.assertIn("FAQ", text)
+
+    def test_docs_site_workflow_builds_artifact(self) -> None:
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("pull_request", workflow[True])
+        self.assertIn("npm run --prefix docs-site docs:build", text)
+        self.assertIn("docs-site/.vitepress/dist", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- add a VitePress documentation site with Getting Started, Guides, API Reference, Plugins, CI Integration, and FAQ sections
- add a dedicated docs-site build workflow that uploads the generated site artifact
- document the docs-site source from the README
- add tests for the docs site structure and workflow

## Verification
- uv run python -m unittest tests.test_docs_site -v
- npm install --prefix docs-site --no-package-lock
- npm run --prefix docs-site docs:build
- uv run python -m unittest discover -s tests
- uv build
- git diff --check

Note: npm reported transient dependency audit findings during install; no runtime dependency is added to the Python package.

Closes #34