### PR TITLE
Add Homebrew formula

### DIFF
--- a/Formula/termproof.rb
+++ b/Formula/termproof.rb
@@ -1,0 +1,93 @@
+class Termproof < Formula
+  include Language::Python::Virtualenv
+
+  desc "Evidence-first verification for terminal and TUI applications"
+  homepage "https://github.com/md-mt/termproof"
+  url "https://github.com/md-mt/termproof/releases/download/v0.2.0/termproof-0.2.0.tar.gz"
+  sha256 "a7f5fad67e4f3af885981f0ed8ef15c8ab30b2e3e97d0f257c7ce2b4dd9092fe"
+  license "MIT"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "agg"
+  depends_on "ffmpeg"
+  depends_on "jpeg-turbo"
+  depends_on "libpng"
+  depends_on "libyaml"
+  depends_on "python@3.13"
+
+  resource "asciinema" do
+    url "https://files.pythonhosted.org/packages/f1/19/45b405438e90ad5b9618f3df62e9b3edaa2b115b530e60bd4b363465c704/asciinema-2.4.0.tar.gz"
+    sha256 "828e04c36ba622a7b8f8f912c8f0c1329538b6c7ed1c0d1b131bbbfe3a221707"
+  end
+
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz"
+    sha256 "d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"
+  end
+
+  resource "imageio-ffmpeg" do
+    url "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz"
+    sha256 "e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755"
+  end
+
+  resource "jsonschema" do
+    url "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz"
+    sha256 "0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"
+  end
+
+  resource "jsonschema-specifications" do
+    url "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz"
+    sha256 "b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"
+  end
+
+  resource "pexpect" do
+    url "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz"
+    sha256 "ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"
+  end
+
+  resource "pillow" do
+    url "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz"
+    sha256 "3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce"
+  end
+
+  resource "ptyprocess" do
+    url "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz"
+    sha256 "5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"
+  end
+
+  resource "pyte" do
+    url "https://files.pythonhosted.org/packages/ab/ab/b599762933eba04de7dc5b31ae083112a6c9a9db15b01d3109ad797559d9/pyte-0.8.2.tar.gz"
+    sha256 "5af970e843fa96a97149d64e170c984721f20e52227a2f57f0a54207f08f083f"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
+    sha256 "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+  end
+
+  resource "referencing" do
+    url "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz"
+    sha256 "44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"
+  end
+
+  resource "rpds-py" do
+    url "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz"
+    sha256 "1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4"
+  end
+
+  resource "wcwidth" do
+    url "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz"
+    sha256 "91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match "usage:", shell_output("#{bin}/termproof --help")
+    system bin/"termproof", "init", testpath/"recipes", "--name", "homebrew-smoke", "--command", "printf ready"
+    assert_path_exists testpath/"recipes/homebrew-smoke.recipe.json"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Sample artifacts are checked into `examples/artifacts/` so you can inspect witho
 Install (Python 3.11+):
 
 ```bash
+brew tap md-mt/termproof https://github.com/md-mt/termproof
+brew install termproof
+# or from GitHub with pip
 pip install git+https://github.com/md-mt/termproof.git
 # or from source
 git clone https://github.com/md-mt/termproof.git && cd termproof
@@ -193,7 +196,7 @@ See [`docs/verified-badge.md`](docs/verified-badge.md) for variants (flat, plast
 - **Pages demo:** Preview locally with `python3 -m http.server 8000 --directory site`. When Pages is enabled on this repo, the rendered site will be at https://md-mt.github.io/termproof/.
 - **Docs site:** [`docs-site`](docs-site) — VitePress documentation source and build.
 - **Examples:** [`examples/generic`](examples/generic) — portable TUI; `examples/pi_workflow_*.recipe.json` — Pi agent showcase.
-- **Docs:** [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md) · [`docs/ci/gitlab.md`](docs/ci/gitlab.md) · [`docs/ci/circleci.md`](docs/ci/circleci.md) · [`docs/ci/docker.md`](docs/ci/docker.md)
+- **Docs:** [`docs/install/homebrew.md`](docs/install/homebrew.md) · [`docs/recipe-packs.md`](docs/recipe-packs.md) · [`docs/guides/textual.md`](docs/guides/textual.md) · [`docs/guides/bubbletea.md`](docs/guides/bubbletea.md) · [`docs/guides/ratatui.md`](docs/guides/ratatui.md) · [`docs/releases.md`](docs/releases.md) · [`docs/plugins.md`](docs/plugins.md) · [`docs/verified-badge.md`](docs/verified-badge.md) · [`docs/ci/gitlab.md`](docs/ci/gitlab.md) · [`docs/ci/circleci.md`](docs/ci/circleci.md) · [`docs/ci/docker.md`](docs/ci/docker.md)
 
 ## Upgrading from tui-verifier
 

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -18,6 +18,7 @@ export default defineConfig({
         items: [
           { text: "Overview", link: "/" },
           { text: "Install and Run", link: "/getting-started" },
+          { text: "Homebrew", link: "/install/homebrew" },
           { text: "FAQ", link: "/faq" }
         ]
       },

--- a/docs-site/getting-started.md
+++ b/docs-site/getting-started.md
@@ -4,7 +4,14 @@ TermProof verifies terminal and TUI behavior by running JSON recipes against a r
 
 ## Install
 
-Until the first PyPI release is published, install from GitHub:
+On macOS, install with Homebrew:
+
+```bash
+brew tap md-mt/termproof https://github.com/md-mt/termproof
+brew install termproof
+```
+
+Or install from GitHub with pip:
 
 ```bash
 pip install git+https://github.com/md-mt/termproof.git

--- a/docs-site/install/homebrew.md
+++ b/docs-site/install/homebrew.md
@@ -1,0 +1,18 @@
+# Homebrew
+
+Install TermProof from the repository tap:
+
+```bash
+brew tap md-mt/termproof https://github.com/md-mt/termproof
+brew install termproof
+termproof --help
+```
+
+If Homebrew asks for tap trust:
+
+```bash
+brew trust --formula md-mt/termproof/termproof
+brew install termproof
+```
+
+The formula installs `agg`, `ffmpeg`, and `python@3.13`, so video evidence works without a separate Rust toolchain.

--- a/docs/install/homebrew.md
+++ b/docs/install/homebrew.md
@@ -1,0 +1,34 @@
+# Homebrew
+
+TermProof ships a tap-compatible Homebrew formula at `Formula/termproof.rb`.
+
+## Install
+
+```bash
+brew tap md-mt/termproof https://github.com/md-mt/termproof
+brew install termproof
+termproof --help
+```
+
+If Homebrew asks you to trust the tap before installing, trust only this formula:
+
+```bash
+brew trust --formula md-mt/termproof/termproof
+brew install termproof
+```
+
+The formula installs Homebrew `agg`, `ffmpeg`, and `python@3.13`, so `termproof run --video` works without a separate Rust toolchain.
+
+## Upgrade
+
+```bash
+brew update
+brew upgrade termproof
+```
+
+## Smoke Test
+
+```bash
+termproof init .termproof/recipes --name homebrew-smoke --command "printf ready"
+termproof run .termproof/recipes --out .termproof/runs
+```

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -20,6 +20,7 @@ class DocsSiteTest(unittest.TestCase):
         self.assertEqual("vitepress build .", package["scripts"]["docs:build"])
         for path in (
             "getting-started.md",
+            "install/homebrew.md",
             "guides/index.md",
             "api/index.md",
             "plugins.md",
@@ -32,6 +33,7 @@ class DocsSiteTest(unittest.TestCase):
         text = CONFIG.read_text(encoding="utf-8")
 
         self.assertIn("Getting Started", text)
+        self.assertIn("Homebrew", text)
         self.assertIn("Guides", text)
         self.assertIn("API Reference", text)
         self.assertIn("Plugins", text)

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FORMULA = ROOT / "Formula" / "termproof.rb"
+DOCS = ROOT / "docs" / "install" / "homebrew.md"
+README = ROOT / "README.md"
+
+
+class HomebrewFormulaTest(unittest.TestCase):
+    def test_formula_installs_termproof_release(self) -> None:
+        text = FORMULA.read_text(encoding="utf-8")
+
+        self.assertIn("class Termproof < Formula", text)
+        self.assertIn("url \"https://github.com/md-mt/termproof/releases/download/v0.2.0/termproof-0.2.0.tar.gz\"", text)
+        self.assertIn("sha256 \"a7f5fad67e4f3af885981f0ed8ef15c8ab30b2e3e97d0f257c7ce2b4dd9092fe\"", text)
+        self.assertIn("depends_on \"agg\"", text)
+        self.assertIn("depends_on \"ffmpeg\"", text)
+        self.assertIn("depends_on \"python@3.13\"", text)
+        self.assertIn("virtualenv_install_with_resources", text)
+        self.assertEqual(13, text.count("resource \""))
+
+    def test_formula_smoke_test_exercises_cli(self) -> None:
+        text = FORMULA.read_text(encoding="utf-8")
+
+        self.assertIn("shell_output(\"#{bin}/termproof --help\")", text)
+        self.assertIn("\"init\", testpath/\"recipes\"", text)
+        self.assertIn("homebrew-smoke.recipe.json", text)
+
+    def test_docs_show_tap_install_path(self) -> None:
+        docs = DOCS.read_text(encoding="utf-8")
+        readme = README.read_text(encoding="utf-8")
+
+        for text in (docs, readme):
+            self.assertIn("brew tap md-mt/termproof https://github.com/md-mt/termproof", text)
+            self.assertIn("brew install termproof", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- add a tap-compatible Homebrew formula for the v0.2.0 release with pinned Python resources
- document the Homebrew install path in README, markdown docs, and the VitePress site
- add focused tests for the formula and docs wiring

## Verification
- uv run python -m unittest discover -s tests
- npm run --prefix docs-site docs:build
- brew style Formula/termproof.rb
- HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew audit md-mt/termproof/termproof --strict --online
- HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew install --dry-run md-mt/termproof/termproof
- ruby -c Formula/termproof.rb

Note: npm install --prefix docs-site --no-package-lock reports 3 dependency audit findings (2 moderate, 1 high), matching the docs-site dependency tree rather than this formula change.

Closes #17