### PR TITLE
List first-party plugin examples

### DIFF
--- a/docs-site/plugins.md
+++ b/docs-site/plugins.md
@@ -11,3 +11,9 @@ termproof plugins install termproof-textual --dry-run
 ```
 
 Community plugin entries live in `docs/plugins.md` until the registry needs automation.
+
+## First-Party Examples
+
+- [termproof-slack-reporter](https://github.com/md-mt/termproof-slack-reporter) posts run summaries to Slack incoming webhooks.
+- [termproof-docker-backend](https://github.com/md-mt/termproof-docker-backend) runs recipe commands inside Docker containers.
+- [termproof-png-renderer](https://github.com/md-mt/termproof-png-renderer) writes PNG screenshots for visual evidence.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -46,7 +46,9 @@ termproof run .termproof/recipes --screen-renderer png
 
 | Name | Description | Install | Author |
 | --- | --- | --- | --- |
-| _Be the first_ | Show us your step/assertion/session/reporter | `pip install <your-package>` | you |
+| [termproof-slack-reporter](https://github.com/md-mt/termproof-slack-reporter) | Reporter that posts TermProof run summaries to Slack incoming webhooks | `pip install git+https://github.com/md-mt/termproof-slack-reporter.git` | [@md-mt](https://github.com/md-mt) |
+| [termproof-docker-backend](https://github.com/md-mt/termproof-docker-backend) | Session backend that runs recipe commands inside Docker containers | `pip install git+https://github.com/md-mt/termproof-docker-backend.git` | [@md-mt](https://github.com/md-mt) |
+| [termproof-png-renderer](https://github.com/md-mt/termproof-png-renderer) | Screen renderer that writes PNG screenshots for visual evidence | `pip install git+https://github.com/md-mt/termproof-png-renderer.git` | [@md-mt](https://github.com/md-mt) |
 
 Search or install from this manual directory with:
 
@@ -74,11 +76,10 @@ To list your plugin here, open a PR editing this file with:
 From open issues:
 
 - **Framework helpers** for Textual, Bubble Tea, and Ratatui recipes — see [#24](https://github.com/md-mt/termproof/issues/24)
-- **First-party example integrations** that can graduate into separate plugin repos — see [#23](https://github.com/md-mt/termproof/issues/23)
 
 ## Publishing
 
-If you publish a first-party example as a separate repo (per [#23](https://github.com/md-mt/termproof/issues/23)), follow:
+If you publish a plugin repo, follow:
 
 1. Name: `termproof-<integration>` (e.g., `termproof-textual`, `termproof-bubbletea`).
 2. Entry points in `pyproject.toml` or documented `module:Class` references.

--- a/tests/test_plugin_directory.py
+++ b/tests/test_plugin_directory.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs" / "plugins.md"
+DOCS_SITE = ROOT / "docs-site" / "plugins.md"
+
+
+class PluginDirectoryTest(unittest.TestCase):
+    def test_first_party_plugin_repos_are_listed(self) -> None:
+        docs = DOCS.read_text(encoding="utf-8")
+        docs_site = DOCS_SITE.read_text(encoding="utf-8")
+
+        for repo in (
+            "termproof-slack-reporter",
+            "termproof-docker-backend",
+            "termproof-png-renderer",
+        ):
+            url = f"https://github.com/md-mt/{repo}"
+            self.assertIn(url, docs)
+            self.assertIn(url, docs_site)
+
+    def test_directory_uses_git_installs_until_pypi_release(self) -> None:
+        docs = DOCS.read_text(encoding="utf-8")
+
+        self.assertIn("pip install git+https://github.com/md-mt/termproof-slack-reporter.git", docs)
+        self.assertIn("pip install git+https://github.com/md-mt/termproof-docker-backend.git", docs)
+        self.assertIn("pip install git+https://github.com/md-mt/termproof-png-renderer.git", docs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- list the three first-party plugin example repos in the main plugin directory
- add the VitePress plugin page links
- add static coverage for the published repo URLs and git install commands

## Published plugin repos
- https://github.com/md-mt/termproof-slack-reporter
- https://github.com/md-mt/termproof-docker-backend
- https://github.com/md-mt/termproof-png-renderer

## Verification
- uv run python -m unittest tests.test_plugin_directory tests.test_docs_site
- uv run python -m unittest discover -s tests
- npm run --prefix docs-site docs:build

Note: npm install --prefix docs-site --no-package-lock reports 3 dependency audit findings (2 moderate, 1 high), matching the existing docs-site dependency tree.

Closes #23