### PR TITLE
Document PyPI trusted publisher setup

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -34,6 +34,20 @@ uv run termproof run examples/generic examples/multi_turn_conversation.recipe.js
    and release body, uploads evidence, and creates a GitHub release.
 4. PyPI publishing uses GitHub trusted publishing from the release workflow.
 
+## PyPI Trusted Publishing
+
+Before pushing the first release tag, create or claim the `termproof` project on
+PyPI and add this trusted publisher:
+
+- Owner: `md-mt`
+- Repository: `termproof`
+- Workflow: `release.yml`
+- Environment: `pypi`
+
+The release job must keep `permissions.id-token: write` and `environment: pypi`.
+If PyPI reports `invalid-publisher`, the GitHub release can still be created but
+the package upload will fail until the PyPI project has the publisher above.
+
 The GitHub Release includes `termproof-release-evidence.tgz`. That archive
 contains `.termproof/release/latest-report.md`, per-recipe `report.md`,
 `result.json`, `session.cast`, `final.svg`, `final.txt`, step screenshots, and

--- a/tests/test_release_docs.py
+++ b/tests/test_release_docs.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs" / "releases.md"
+
+
+class ReleaseDocsTest(unittest.TestCase):
+    def test_pypi_trusted_publisher_values_are_documented(self) -> None:
+        text = DOCS.read_text(encoding="utf-8")
+
+        self.assertIn("Owner: `md-mt`", text)
+        self.assertIn("Repository: `termproof`", text)
+        self.assertIn("Workflow: `release.yml`", text)
+        self.assertIn("Environment: `pypi`", text)
+        self.assertIn("invalid-publisher", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- document the exact PyPI trusted publisher values required by the release workflow
- add a regression test so the release docs keep the owner/repo/workflow/environment values visible

## Context
The v0.2.0 release workflow built artifacts and created the GitHub release, but PyPI upload failed with invalid-publisher because PyPI has no matching trusted publisher for repo md-mt/termproof, workflow release.yml, environment pypi.

## Verification
- uv run python -m unittest tests.test_release_docs
- uv run python -m unittest discover -s tests

Refs #7