### PR TITLE
Make Pages deploy opt-in

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -111,23 +111,17 @@ jobs:
           path: _site
           if-no-files-found: warn
 
-  # Deployment is guarded so private repos without Pages enabled do not fail CI.
-  # For private repos, set repository variable ENABLE_PAGES=true to enable,
-  # or rely on public visibility. The job will be skipped otherwise.
+  # Deployment is explicitly opt-in so repos without Pages enabled do not fail CI.
+  # Set repository variable ENABLE_PAGES=true and enable Pages
+  # in Settings > Pages (source: GitHub Actions) to deploy.
   deploy:
     name: Deploy to Pages
     needs: build
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main' && (
-        vars.ENABLE_PAGES == 'true' ||
-        github.event.repository.visibility == 'public'
-      )) || (
-        github.event_name == 'workflow_dispatch' && (
-          vars.ENABLE_PAGES == 'true' ||
-          github.event.repository.visibility == 'public'
-        )
-      )
+      vars.ENABLE_PAGES == 'true' &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        github.event_name == 'workflow_dispatch')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -136,20 +130,19 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
-  # Keep a separate notification that deploy was skipped for private repos — informative only.
+  # Keep a separate notification that deploy was skipped — informative only.
   deploy-skipped:
-    name: Pages deploy skipped (private repo guard)
+    name: Pages deploy skipped (ENABLE_PAGES not true)
     needs: build
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
-      !(vars.ENABLE_PAGES == 'true' ||
-        github.event.repository.visibility == 'public')
+      vars.ENABLE_PAGES != 'true'
     steps:
       - run: |
-          echo "Pages deploy skipped — repository is private and ENABLE_PAGES is not 'true'."
-          echo "To enable Pages on this private repo, set the repository variable ENABLE_PAGES=true"
+          echo "Pages deploy skipped — ENABLE_PAGES is not 'true'."
+          echo "To enable Pages deploys, set repository variable ENABLE_PAGES=true"
           echo "in Settings > Secrets and variables > Actions > Variables, and enable Pages"
           echo "in Settings > Pages (source: GitHub Actions)."
           echo "Artifact 'termproof-pages-preview' contains the site preview."

--- a/tests/test_docs_pages.py
+++ b/tests/test_docs_pages.py
@@ -180,6 +180,22 @@ class PagesWorkflowTest(unittest.TestCase):
         self.assertIn("github.event_name", deploy_section,
                       "pages.yml deploy job must check github.event_name to avoid running on PRs")
 
+    def test_deploy_requires_enable_pages_variable(self) -> None:
+        yml = _read(ROOT / ".github/workflows/pages.yml")
+        deploy_section = yml.split("name: Deploy to Pages")[1].split("environment:")[0] \
+            if "name: Deploy to Pages" in yml else ""
+
+        self.assertIn("vars.ENABLE_PAGES == 'true'", deploy_section)
+        self.assertNotIn("github.event.repository.visibility == 'public'", deploy_section)
+
+    def test_skipped_job_runs_when_enable_pages_is_not_true(self) -> None:
+        yml = _read(ROOT / ".github/workflows/pages.yml")
+        skipped_section = yml.split("name: Pages deploy skipped")[1] \
+            if "name: Pages deploy skipped" in yml else ""
+
+        self.assertIn("vars.ENABLE_PAGES != 'true'", skipped_section)
+        self.assertIn("Artifact 'termproof-pages-preview' contains the site preview.", skipped_section)
+
 
 class GenericTuiArtifactsTest(unittest.TestCase):
     """BLOCKING: examples/artifacts/generic-tui-workflow/ must contain demo evidence."""


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- require repository variable ENABLE_PAGES=true before running actions/deploy-pages
- keep the Pages build and preview artifact running by default
- add regression coverage so public repository visibility does not bypass the opt-in guard

## Context
The latest main push failed in the Pages workflow because actions/deploy-pages returned 404 when GitHub Pages was not enabled. The previous guard deployed automatically for public repos, but Pages still has to be enabled in repository settings.

## Verification
- uv run python -m unittest tests.test_docs_pages
- uv run python -m unittest discover -s tests