### PR TITLE
Add receipt-backed CI evidence reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,24 +98,43 @@ jobs:
             "$GITHUB_WORKSPACE/.pkg-test/bin/python" -c "import termproof; from pathlib import Path; assert 'site-packages' in str(Path(termproof.__file__))"
           )
 
+      - name: Run base TUI verification for PR comparison
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git worktree add ../termproof-base "$BASE_SHA"
+          uv run python -m termproof.ci_evidence run ci \
+            --repo ../termproof-base \
+            --out "$GITHUB_WORKSPACE/.termproof/pr-base" \
+            --continue-on-fail
+
       - name: Run generic and Pi agent UI verification
         run: |
-          uv run termproof run \
-            examples/generic \
-            examples/multi_turn_conversation.recipe.json \
-            examples/pi_workflow_readonly_review.recipe.json \
-            examples/pi_workflow_guarded_edit.recipe.json \
-            examples/pi_workflow_session_resume_export.recipe.json \
-            examples/pi_workflow_model_context.recipe.json \
-            --video --video-fps 60 --out .termproof/ci
+          uv run python -m termproof.ci_evidence run ci --out .termproof/ci
 
-      - name: Publish TUI verification summary
+      - name: Compose TUI verification report
         if: always()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BASE_LABEL: ${{ github.event.pull_request.base.sha }}
+          HEAD_LABEL: ${{ github.sha }}
         run: |
+          uv run python -m termproof.ci_evidence comment \
+            --base-dir .termproof/pr-base \
+            --head-dir .termproof/ci \
+            --out .termproof/ci-pr-comment.md \
+            --run-url "$RUN_URL" \
+            --base-label "$BASE_LABEL" \
+            --head-label "$HEAD_LABEL"
           {
             echo "## TermProof CI Report"
             echo
             echo "Evidence artifact: \`termproof-ci-evidence\`"
+            echo "Includes: \`.termproof/ci\`, \`.termproof/pr-base\`, and the PR comment body."
+            echo "PR comment: before/after report in \`.termproof/ci-pr-comment.md\`"
             echo
             if [ -f .termproof/ci/latest-report.md ]; then
               cat .termproof/ci/latest-report.md
@@ -129,7 +148,10 @@ jobs:
         if: always()
         with:
           name: termproof-ci-evidence
-          path: .termproof/ci
+          path: |
+            .termproof/ci
+            .termproof/pr-base
+            .termproof/ci-pr-comment.md
           if-no-files-found: ignore
 
       - name: Comment TUI verification report on PR
@@ -140,31 +162,7 @@ jobs:
           script: |
             const fs = require('fs');
             const marker = '<!-- termproof-ci-report -->';
-            const reportPath = '.termproof/ci/latest-report.md';
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            let report = fs.existsSync(reportPath)
-              ? fs.readFileSync(reportPath, 'utf8')
-              : 'No TermProof report was generated.';
-            const maxReportChars = 55000;
-            if (report.length > maxReportChars) {
-              report = `${report.slice(0, maxReportChars)}\n\n_Report truncated. Download the ` +
-                '`termproof-ci-evidence` artifact from the run for the full report._';
-            }
-            const body = [
-              marker,
-              '## TermProof CI Report',
-              '',
-              `Run: [${context.workflow} #${context.runNumber}](${runUrl})`,
-              '',
-              'Evidence artifact: `termproof-ci-evidence` in the workflow run artifacts.',
-              'Report links point to files inside that artifact.',
-              '',
-              '<details open><summary>latest-report.md</summary>',
-              '',
-              report,
-              '',
-              '</details>',
-            ].join('\n');
+            const body = fs.readFileSync('.termproof/ci-pr-comment.md', 'utf8');
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,14 +67,7 @@ jobs:
 
       - name: Run release generic and Pi agent UI verification
         run: |
-          uv run termproof run \
-            examples/generic \
-            examples/multi_turn_conversation.recipe.json \
-            examples/pi_workflow_readonly_review.recipe.json \
-            examples/pi_workflow_guarded_edit.recipe.json \
-            examples/pi_workflow_session_resume_export.recipe.json \
-            examples/pi_workflow_model_context.recipe.json \
-            --video --video-fps 60 --out .termproof/release
+          uv run python -m termproof.ci_evidence run release --out .termproof/release
           tar -czf termproof-release-evidence.tgz -C .termproof release
 
       - name: Write release verification notes

--- a/README.md
+++ b/README.md
@@ -164,7 +164,11 @@ Copy-paste for GitHub Actions. Identical to what this repository uses:
   run: cat .termproof/ci/latest-report.md >> "$GITHUB_STEP_SUMMARY"
 ```
 
-This repo also posts a sticky **TermProof CI Report** comment on every PR with the run link and embedded report. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for the full implementation.
+This repo also posts a sticky **TermProof CI Report** comment on every PR with
+the run link, base-commit report, head report, and behavioral delta. Release
+tags package the same receipt-backed report as `termproof-release-evidence.tgz`.
+See [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for the full
+implementation.
 
 Reuse as a GitLab template or CircleCI orb by porting the same three steps — no Docker image required (see [#27](https://github.com/md-mt/termproof/issues/27) for generic image).
 

--- a/docs/ci/evidence-receipt.json
+++ b/docs/ci/evidence-receipt.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "targets": {
+    "ci": {
+      "artifact_name": "termproof-ci-evidence",
+      "out": ".termproof/ci",
+      "recipes": [
+        "examples/generic",
+        "examples/multi_turn_conversation.recipe.json",
+        "examples/pi_workflow_readonly_review.recipe.json",
+        "examples/pi_workflow_guarded_edit.recipe.json",
+        "examples/pi_workflow_session_resume_export.recipe.json",
+        "examples/pi_workflow_model_context.recipe.json"
+      ],
+      "video": true,
+      "video_fps": 60
+    },
+    "release": {
+      "artifact_name": "termproof-release-evidence",
+      "archive_name": "termproof-release-evidence.tgz",
+      "out": ".termproof/release",
+      "recipes": [
+        "examples/generic",
+        "examples/multi_turn_conversation.recipe.json",
+        "examples/pi_workflow_readonly_review.recipe.json",
+        "examples/pi_workflow_guarded_edit.recipe.json",
+        "examples/pi_workflow_session_resume_export.recipe.json",
+        "examples/pi_workflow_model_context.recipe.json"
+      ],
+      "video": true,
+      "video_fps": 60
+    }
+  },
+  "pr_comment": {
+    "marker": "<!-- termproof-ci-report -->",
+    "max_chars": 55000
+  }
+}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,9 +30,15 @@ uv run termproof run examples/generic examples/multi_turn_conversation.recipe.js
 1. Update `pyproject.toml`.
 2. Push a tag such as `v0.1.1`.
 3. GitHub Actions runs unit tests, builds the wheel and sdist, executes the
-   portable TUI end-to-end suite, writes the verifier report to the run summary
-   and release body, uploads evidence, and creates a GitHub release.
+   receipt-backed portable TUI end-to-end suite, writes the verifier report to
+   the run summary and release body, uploads evidence, and creates a GitHub
+   release.
 4. PyPI publishing uses GitHub trusted publishing from the release workflow.
+
+The release evidence receipt lives at
+[`docs/ci/evidence-receipt.json`](ci/evidence-receipt.json). Update that receipt
+whenever the release or PR evidence suite changes; CI tests fail if the
+workflows stop using the receipt-backed runner.
 
 ## PyPI Trusted Publishing
 
@@ -51,7 +57,13 @@ the package upload will fail until the PyPI project has the publisher above.
 The GitHub Release includes `termproof-release-evidence.tgz`. That archive
 contains `.termproof/release/latest-report.md`, per-recipe `report.md`,
 `result.json`, `session.cast`, `final.svg`, `final.txt`, step screenshots, and
-`session.mp4` videos.
+`session.mp4` videos. It also contains `evidence-receipt.json`, so each release
+records which recipes and render settings produced the report.
+
+Pull requests publish the same suite as the `termproof-ci-evidence` workflow
+artifact and as a sticky PR comment. The comment includes a base-commit report,
+a head-commit report, and a behavioral delta generated from each run's
+`result.json` files.
 
 The release workflow intentionally uses portable recipes for public CI. The Pi
 coding-agent recipes remain the showcase and can be run in environments where

--- a/termproof/ci_evidence.py
+++ b/termproof/ci_evidence.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .before_after import build_before_after
+from .models import AssertionResult, RunResult, StepResult
+
+DEFAULT_RECEIPT = Path("docs/ci/evidence-receipt.json")
+
+
+def load_receipt(path: Path = DEFAULT_RECEIPT) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_target(target_name: str, repo: Path, out: Path | None = None,
+               receipt_path: Path = DEFAULT_RECEIPT) -> int:
+    receipt = load_receipt(receipt_path)
+    target = receipt["targets"][target_name]
+    out_dir = out or Path(target["out"])
+    receipt_out = out_dir if out_dir.is_absolute() else repo / out_dir
+    cmd = ["uv", "run", "termproof", "run", *target["recipes"]]
+    if target.get("video"):
+        cmd.append("--video")
+    if "video_fps" in target:
+        cmd.extend(["--video-fps", str(target["video_fps"])])
+    cmd.extend(["--out", str(out_dir)])
+    completed = subprocess.run(cmd, cwd=repo)
+    _normalize_artifact_paths(receipt_out)
+    _copy_receipt(receipt_path, receipt_out)
+    return completed.returncode
+
+
+def compose_pr_comment(base_dir: Path, head_dir: Path, run_url: str,
+                       base_label: str = "base", head_label: str = "head",
+                       receipt_path: Path = DEFAULT_RECEIPT) -> str:
+    receipt = load_receipt(receipt_path)
+    ci_target = receipt["targets"]["ci"]
+    release_target = receipt["targets"]["release"]
+    marker = receipt["pr_comment"]["marker"]
+    before_after = build_before_after(
+        load_results(base_dir),
+        load_results(head_dir),
+    )
+    base_report = _truncate(_read_report(base_dir), 18000)
+    head_report = _truncate(_read_report(head_dir), 26000)
+    return "\n".join(
+        [
+            marker,
+            "## TermProof CI Report",
+            "",
+            f"Run: [{run_url}]({run_url})",
+            "",
+            f"PR evidence artifact: `{ci_target['artifact_name']}` in this workflow run.",
+            f"Release destination: GitHub Release asset `{release_target['archive_name']}`.",
+            "Download the artifact/archive to inspect linked evidence files.",
+            "",
+            "<details open><summary>Behavioral delta</summary>",
+            "",
+            before_after.to_markdown().rstrip(),
+            "",
+            "</details>",
+            "",
+            f"<details><summary>Before: base commit {base_label}</summary>",
+            "",
+            base_report,
+            "",
+            "</details>",
+            "",
+            f"<details open><summary>After: head commit {head_label}</summary>",
+            "",
+            head_report,
+            "",
+            "</details>",
+            "",
+        ]
+    )
+
+
+def load_results(root: Path) -> list[RunResult]:
+    if not root.exists():
+        return []
+    return [
+        _result_from_mapping(json.loads(path.read_text(encoding="utf-8")))
+        for path in sorted(root.rglob("result.json"))
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m termproof.ci_evidence")
+    parser.add_argument("--receipt", type=Path, default=DEFAULT_RECEIPT)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("target", choices=("ci", "release"))
+    run_parser.add_argument("--repo", type=Path, default=Path("."))
+    run_parser.add_argument("--out", type=Path)
+    run_parser.add_argument("--continue-on-fail", action="store_true")
+
+    comment_parser = subparsers.add_parser("comment")
+    comment_parser.add_argument("--base-dir", type=Path, required=True)
+    comment_parser.add_argument("--head-dir", type=Path, required=True)
+    comment_parser.add_argument("--out", type=Path, required=True)
+    comment_parser.add_argument("--run-url", required=True)
+    comment_parser.add_argument("--base-label", default="base")
+    comment_parser.add_argument("--head-label", default="head")
+
+    args = parser.parse_args(argv)
+    if args.command == "run":
+        code = run_target(args.target, args.repo, out=args.out, receipt_path=args.receipt)
+        return 0 if args.continue_on_fail else code
+    if args.command == "comment":
+        body = compose_pr_comment(
+            args.base_dir,
+            args.head_dir,
+            args.run_url,
+            base_label=args.base_label or "base",
+            head_label=args.head_label or "head",
+            receipt_path=args.receipt,
+        )
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(body, encoding="utf-8")
+        return 0
+    raise AssertionError(args.command)
+
+
+def _copy_receipt(receipt_path: Path, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(receipt_path, out_dir / "evidence-receipt.json")
+
+
+def _normalize_artifact_paths(out_dir: Path) -> None:
+    if not out_dir.is_absolute() or not out_dir.exists():
+        return
+    try:
+        display_dir = out_dir.relative_to(Path.cwd())
+    except ValueError:
+        return
+    old = str(out_dir)
+    new = str(display_dir)
+    for path in [out_dir / "latest-report.md", *out_dir.rglob("report.md")]:
+        if path.is_file():
+            text = path.read_text(encoding="utf-8")
+            path.write_text(text.replace(old, new), encoding="utf-8")
+    for path in out_dir.rglob("result.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["artifacts"] = {
+            key: str(value).replace(old, new) for key, value in data.get("artifacts", {}).items()
+        }
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_report(root: Path) -> str:
+    path = root / "latest-report.md"
+    if path.is_file():
+        return path.read_text(encoding="utf-8")
+    return "No TermProof report was generated."
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return (
+        f"{text[:limit]}\n\n_Report truncated. Download the "
+        "`termproof-ci-evidence` artifact from the run for the full report._"
+    )
+
+
+def _result_from_mapping(data: dict[str, Any]) -> RunResult:
+    return RunResult(
+        recipe_name=data["recipe_name"],
+        passed=bool(data["passed"]),
+        exit_code=data["exit_code"],
+        duration_seconds=float(data["duration_seconds"]),
+        priority=data["priority"],
+        execution=data["execution"],
+        renderer=data["renderer"],
+        score=float(data["score"]),
+        steps=[
+            StepResult(step["name"], bool(step["passed"]), step["detail"], step["screen"])
+            for step in data.get("steps", [])
+        ],
+        assertions=[
+            AssertionResult(assertion["name"], bool(assertion["passed"]), assertion["detail"])
+            for assertion in data.get("assertions", [])
+        ],
+        artifacts=dict(data.get("artifacts", {})),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_evidence.py
+++ b/tests/test_ci_evidence.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from termproof import ci_evidence
+from termproof.ci_evidence import compose_pr_comment, load_receipt, run_target
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = ROOT / "docs" / "ci" / "evidence-receipt.json"
+
+
+class CiEvidenceReceiptTest(unittest.TestCase):
+    def test_receipt_targets_existing_recipes(self) -> None:
+        receipt = load_receipt(RECEIPT)
+        for target in receipt["targets"].values():
+            for recipe in target["recipes"]:
+                self.assertTrue((ROOT / recipe).exists(), recipe)
+
+    def test_ci_and_release_share_evidence_suite(self) -> None:
+        receipt = load_receipt(RECEIPT)
+        self.assertEqual(
+            receipt["targets"]["ci"]["recipes"],
+            receipt["targets"]["release"]["recipes"],
+        )
+        self.assertEqual(True, receipt["targets"]["release"]["video"])
+        self.assertEqual(60, receipt["targets"]["release"]["video_fps"])
+
+    def test_workflows_are_receipt_backed(self) -> None:
+        ci_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        release_text = (ROOT / ".github" / "workflows" / "release.yml").read_text(
+            encoding="utf-8"
+        )
+        receipt = load_receipt(RECEIPT)
+
+        self.assertIn("python -m termproof.ci_evidence run ci", ci_text)
+        self.assertIn("python -m termproof.ci_evidence run release", release_text)
+        self.assertIn(receipt["targets"]["ci"]["artifact_name"], ci_text)
+        self.assertIn(".termproof/pr-base", ci_text)
+        self.assertIn(".termproof/ci-pr-comment.md", ci_text)
+        self.assertIn(receipt["targets"]["release"]["artifact_name"], release_text)
+        self.assertIn(receipt["targets"]["release"]["archive_name"], release_text)
+
+    def test_pr_comment_step_posts_composed_report(self) -> None:
+        workflow = yaml.safe_load(
+            (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        )
+        steps = workflow["jobs"]["verify"]["steps"]
+        names = [step["name"] for step in steps]
+
+        self.assertIn("Run base TUI verification for PR comparison", names)
+        self.assertIn("Compose TUI verification report", names)
+        comment_step = next(
+            step for step in steps if step["name"] == "Comment TUI verification report on PR"
+        )
+        self.assertIn(".termproof/ci-pr-comment.md", comment_step["with"]["script"])
+
+    def test_run_target_uses_receipt_command_and_copies_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            receipt_path = root / "receipt.json"
+            receipt_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "targets": {
+                            "ci": {
+                                "artifact_name": "artifact",
+                                "out": "out",
+                                "recipes": ["recipe.json"],
+                                "video": True,
+                                "video_fps": 24,
+                            }
+                        },
+                        "pr_comment": {"marker": "<!-- marker -->", "max_chars": 55000},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch("termproof.ci_evidence.subprocess.run") as run:
+                run.return_value.returncode = 0
+                code = run_target("ci", root, receipt_path=receipt_path)
+
+            self.assertEqual(0, code)
+            self.assertEqual(
+                [
+                    "uv",
+                    "run",
+                    "termproof",
+                    "run",
+                    "recipe.json",
+                    "--video",
+                    "--video-fps",
+                    "24",
+                    "--out",
+                    "out",
+                ],
+                run.call_args.args[0],
+            )
+            self.assertTrue((root / "out" / "evidence-receipt.json").is_file())
+
+    def test_pr_comment_includes_before_after_reports_and_delta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            receipt_path = root / "receipt.json"
+            receipt_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "targets": {
+                            "ci": {
+                                "artifact_name": "termproof-ci-evidence",
+                                "archive_name": "",
+                                "out": ".termproof/ci",
+                                "recipes": [],
+                                "video": True,
+                                "video_fps": 60,
+                            },
+                            "release": {
+                                "artifact_name": "termproof-release-evidence",
+                                "archive_name": "termproof-release-evidence.tgz",
+                                "out": ".termproof/release",
+                                "recipes": [],
+                                "video": True,
+                                "video_fps": 60,
+                            },
+                        },
+                        "pr_comment": {
+                            "marker": "<!-- termproof-ci-report -->",
+                            "max_chars": 55000,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            base = root / "base"
+            head = root / "head"
+            _write_result(base, True)
+            _write_result(head, False)
+            (base / "latest-report.md").write_text("# before\n", encoding="utf-8")
+            (head / "latest-report.md").write_text("# after\n", encoding="utf-8")
+
+            body = compose_pr_comment(
+                base,
+                head,
+                "https://example.test/run",
+                base_label="abc123",
+                head_label="def456",
+                receipt_path=receipt_path,
+            )
+
+        self.assertIn("<!-- termproof-ci-report -->", body)
+        self.assertIn("PASS -> FAIL", body)
+        self.assertIn("Before: base commit abc123", body)
+        self.assertIn("# before", body)
+        self.assertIn("After: head commit def456", body)
+        self.assertIn("# after", body)
+        self.assertIn("termproof-release-evidence.tgz", body)
+
+    def test_absolute_artifact_paths_are_normalized_to_artifact_relative(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out = root / ".termproof" / "pr-base"
+            run_dir = out / "demo"
+            run_dir.mkdir(parents=True)
+            absolute_svg = run_dir / "final.svg"
+            (out / "latest-report.md").write_text(
+                f"[screenshot]({absolute_svg})\n",
+                encoding="utf-8",
+            )
+            (run_dir / "report.md").write_text(
+                f"- screenshot: `{absolute_svg}`\n",
+                encoding="utf-8",
+            )
+            (run_dir / "result.json").write_text(
+                json.dumps({"artifacts": {"screenshot": str(absolute_svg)}}),
+                encoding="utf-8",
+            )
+
+            with patch("termproof.ci_evidence.Path.cwd", return_value=root):
+                ci_evidence._normalize_artifact_paths(out)
+
+            self.assertIn(
+                "(.termproof/pr-base/demo/final.svg)",
+                (out / "latest-report.md").read_text(encoding="utf-8"),
+            )
+            data = json.loads((run_dir / "result.json").read_text(encoding="utf-8"))
+            self.assertEqual(
+                ".termproof/pr-base/demo/final.svg",
+                data["artifacts"]["screenshot"],
+            )
+
+
+def _write_result(root: Path, passed: bool) -> None:
+    run_dir = root / "demo"
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "recipe_name": "demo",
+                "passed": passed,
+                "exit_code": 0 if passed else 1,
+                "duration_seconds": 1.0,
+                "priority": "P0",
+                "execution": "scripted",
+                "renderer": "default",
+                "score": 1.0 if passed else 0.0,
+                "steps": [],
+                "assertions": [],
+                "artifacts": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- Add a receipt file for the CI/release TermProof evidence suite and a reusable helper for receipt-backed runs.
- Run the PR base commit evidence suite, compose a before/after sticky PR report, and upload base/head evidence in the same artifact.
- Route the release evidence run through the same receipt and document the release archive destination.

## Validation
- uv run python -m unittest tests.test_ci_evidence tests.test_docs_pages tests.test_release_docs
- uv run python -m unittest discover -s tests