### PR TITLE
Publish PR screenshot evidence to raw GitHub links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 
@@ -115,25 +115,85 @@ jobs:
         run: |
           uv run python -m termproof.ci_evidence run ci --out .termproof/ci
 
+      - name: Prepare screenshot evidence branch payload
+        if: always() && github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          uv run python -m termproof.evidence_publish screenshots \
+            --base-dir .termproof/pr-base \
+            --head-dir .termproof/ci \
+            --out .termproof/evidence-branch \
+            --pr-number "$PR_NUMBER" \
+            --run-id "$RUN_ID"
+
+      - name: Publish screenshot evidence branch
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          EVIDENCE_BRANCH: termproof-evidence
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [ ! -d .termproof/evidence-branch/pr ]; then
+            echo "No screenshot evidence to publish."
+            exit 0
+          fi
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          tmp="$(mktemp -d)"
+          git -C "$tmp" init
+          git -C "$tmp" remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git -C "$tmp" fetch --depth=1 origin "$EVIDENCE_BRANCH"; then
+            git -C "$tmp" checkout "$EVIDENCE_BRANCH"
+          else
+            git -C "$tmp" checkout --orphan "$EVIDENCE_BRANCH"
+            git -C "$tmp" rm -rf . || true
+          fi
+          mkdir -p "$tmp/pr"
+          cp -R .termproof/evidence-branch/pr/. "$tmp/pr/"
+          git -C "$tmp" add pr
+          if git -C "$tmp" diff --cached --quiet; then
+            echo "No screenshot evidence changes."
+            exit 0
+          fi
+          git -C "$tmp" commit -m "Add TermProof screenshots for PR ${PR_NUMBER} run ${RUN_ID}"
+          git -C "$tmp" push origin "HEAD:${EVIDENCE_BRANCH}"
+
       - name: Compose TUI verification report
         if: always()
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BASE_LABEL: ${{ github.event.pull_request.base.sha }}
           HEAD_LABEL: ${{ github.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          screenshot_args=()
+          if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ] && [ -n "$PR_NUMBER" ]; then
+            screenshot_args=(
+              --screenshot-base-url
+              "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/termproof-evidence/pr/${PR_NUMBER}/${GITHUB_RUN_ID}"
+            )
+          fi
           uv run python -m termproof.ci_evidence comment \
             --base-dir .termproof/pr-base \
             --head-dir .termproof/ci \
             --out .termproof/ci-pr-comment.md \
             --run-url "$RUN_URL" \
             --base-label "$BASE_LABEL" \
-            --head-label "$HEAD_LABEL"
+            --head-label "$HEAD_LABEL" \
+            "${screenshot_args[@]}"
           {
             echo "## TermProof CI Report"
             echo
             echo "Evidence artifact: \`termproof-ci-evidence\`"
             echo "Includes: \`.termproof/ci\`, \`.termproof/pr-base\`, and the PR comment body."
+            echo "Screenshot previews: \`termproof-evidence\` branch for same-repo PRs."
             echo "PR comment: before/after report in \`.termproof/ci-pr-comment.md\`"
             echo
             if [ -f .termproof/ci/latest-report.md ]; then

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Copy-paste for GitHub Actions. Identical to what this repository uses:
 This repo also posts a sticky **TermProof CI Report** comment on every PR with
 the run link, base-commit report, head report, and behavioral delta. Release
 tags package the same receipt-backed report as `termproof-release-evidence.tgz`.
+For same-repository PRs, screenshot links are copied to the `termproof-evidence`
+branch and rewritten to raw GitHub URLs so they are directly viewable from the
+comment. Videos remain in the workflow artifact until hosted video evidence is
+implemented in [#69](https://github.com/md-mt/termproof/issues/69).
 See [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for the full
 implementation.
 

--- a/docs/ci/evidence-receipt.json
+++ b/docs/ci/evidence-receipt.json
@@ -31,6 +31,17 @@
       "video_fps": 60
     }
   },
+  "screenshots": {
+    "branch": "termproof-evidence",
+    "image_extensions": [
+      ".gif",
+      ".jpeg",
+      ".jpg",
+      ".png",
+      ".svg"
+    ],
+    "video_issue": "https://github.com/md-mt/termproof/issues/69"
+  },
   "pr_comment": {
     "marker": "<!-- termproof-ci-report -->",
     "max_chars": 55000

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -63,7 +63,10 @@ records which recipes and render settings produced the report.
 Pull requests publish the same suite as the `termproof-ci-evidence` workflow
 artifact and as a sticky PR comment. The comment includes a base-commit report,
 a head-commit report, and a behavioral delta generated from each run's
-`result.json` files.
+`result.json` files. Same-repository PRs also copy screenshot files to the
+`termproof-evidence` branch and rewrite screenshot links to raw GitHub URLs.
+Videos remain in the workflow artifact; hosted video evidence is tracked in
+[#69](https://github.com/md-mt/termproof/issues/69).
 
 The release workflow intentionally uses portable recipes for public CI. The Pi
 coding-agent recipes remain the showcase and can be run in environments where

--- a/termproof/ci_evidence.py
+++ b/termproof/ci_evidence.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .before_after import build_before_after
+from .evidence_publish import rewrite_screenshot_links
 from .models import AssertionResult, RunResult, StepResult
 
 DEFAULT_RECEIPT = Path("docs/ci/evidence-receipt.json")
@@ -37,17 +38,20 @@ def run_target(target_name: str, repo: Path, out: Path | None = None,
 
 def compose_pr_comment(base_dir: Path, head_dir: Path, run_url: str,
                        base_label: str = "base", head_label: str = "head",
+                       screenshot_base_url: str = "",
                        receipt_path: Path = DEFAULT_RECEIPT) -> str:
     receipt = load_receipt(receipt_path)
     ci_target = receipt["targets"]["ci"]
     release_target = receipt["targets"]["release"]
     marker = receipt["pr_comment"]["marker"]
-    before_after = build_before_after(
-        load_results(base_dir),
-        load_results(head_dir),
-    )
-    base_report = _truncate(_read_report(base_dir), 18000)
-    head_report = _truncate(_read_report(head_dir), 26000)
+    before_after = build_before_after(load_results(base_dir), load_results(head_dir))
+    base_report = _read_report(base_dir)
+    head_report = _read_report(head_dir)
+    if screenshot_base_url:
+        base_report = rewrite_screenshot_links(base_report, base_dir, f"{screenshot_base_url.rstrip('/')}/base")
+        head_report = rewrite_screenshot_links(head_report, head_dir, f"{screenshot_base_url.rstrip('/')}/head")
+    base_report = _truncate(base_report, 18000)
+    head_report = _truncate(head_report, 26000)
     return "\n".join(
         [
             marker,
@@ -58,6 +62,8 @@ def compose_pr_comment(base_dir: Path, head_dir: Path, run_url: str,
             f"PR evidence artifact: `{ci_target['artifact_name']}` in this workflow run.",
             f"Release destination: GitHub Release asset `{release_target['archive_name']}`.",
             "Download the artifact/archive to inspect linked evidence files.",
+            "Screenshots are linked through raw GitHub URLs when available.",
+            f"Hosted video links are tracked separately in {receipt['screenshots']['video_issue']}.",
             "",
             "<details open><summary>Behavioral delta</summary>",
             "",
@@ -102,12 +108,12 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--continue-on-fail", action="store_true")
 
     comment_parser = subparsers.add_parser("comment")
-    comment_parser.add_argument("--base-dir", type=Path, required=True)
-    comment_parser.add_argument("--head-dir", type=Path, required=True)
-    comment_parser.add_argument("--out", type=Path, required=True)
+    for name in ("base-dir", "head-dir", "out"):
+        comment_parser.add_argument(f"--{name}", type=Path, required=True)
     comment_parser.add_argument("--run-url", required=True)
     comment_parser.add_argument("--base-label", default="base")
     comment_parser.add_argument("--head-label", default="head")
+    comment_parser.add_argument("--screenshot-base-url", default="")
 
     args = parser.parse_args(argv)
     if args.command == "run":
@@ -120,6 +126,7 @@ def main(argv: list[str] | None = None) -> int:
             args.run_url,
             base_label=args.base_label or "base",
             head_label=args.head_label or "head",
+            screenshot_base_url=args.screenshot_base_url,
             receipt_path=args.receipt,
         )
         args.out.parent.mkdir(parents=True, exist_ok=True)
@@ -180,14 +187,8 @@ def _result_from_mapping(data: dict[str, Any]) -> RunResult:
         execution=data["execution"],
         renderer=data["renderer"],
         score=float(data["score"]),
-        steps=[
-            StepResult(step["name"], bool(step["passed"]), step["detail"], step["screen"])
-            for step in data.get("steps", [])
-        ],
-        assertions=[
-            AssertionResult(assertion["name"], bool(assertion["passed"]), assertion["detail"])
-            for assertion in data.get("assertions", [])
-        ],
+        steps=[StepResult(**step) for step in data.get("steps", [])],
+        assertions=[AssertionResult(**assertion) for assertion in data.get("assertions", [])],
         artifacts=dict(data.get("artifacts", {})),
     )
 

--- a/termproof/evidence_publish.py
+++ b/termproof/evidence_publish.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from urllib.parse import quote
+
+IMAGE_SUFFIXES = {".gif", ".jpeg", ".jpg", ".png", ".svg"}
+
+
+def prepare_screenshot_evidence(
+    base_dir: Path,
+    head_dir: Path,
+    out_dir: Path,
+    pr_number: str,
+    run_id: str,
+) -> list[dict[str, str]]:
+    root = out_dir / "pr" / pr_number / run_id
+    manifest = [
+        *_copy_images(base_dir, root / "base", "base"),
+        *_copy_images(head_dir, root / "head", "head"),
+    ]
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "screenshot-manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def rewrite_screenshot_links(text: str, root: Path, url_prefix: str) -> str:
+    if not url_prefix or not root.exists():
+        return text
+    prefix = url_prefix.rstrip("/")
+    for image in _image_files(root):
+        rel = image.relative_to(root).as_posix()
+        url = f"{prefix}/{quote(rel, safe='/._-~')}"
+        for value in {str(image), image.as_posix()}:
+            text = text.replace(value, url)
+    return text
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m termproof.evidence_publish")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    screenshots = subparsers.add_parser("screenshots")
+    screenshots.add_argument("--base-dir", type=Path, required=True)
+    screenshots.add_argument("--head-dir", type=Path, required=True)
+    screenshots.add_argument("--out", type=Path, required=True)
+    screenshots.add_argument("--pr-number", required=True)
+    screenshots.add_argument("--run-id", required=True)
+
+    args = parser.parse_args(argv)
+    if args.command == "screenshots":
+        manifest = prepare_screenshot_evidence(
+            args.base_dir,
+            args.head_dir,
+            args.out,
+            args.pr_number,
+            args.run_id,
+        )
+        print(f"{len(manifest)} screenshots prepared")
+        return 0
+    raise AssertionError(args.command)
+
+
+def _copy_images(source: Path, target: Path, scope: str) -> list[dict[str, str]]:
+    if not source.exists():
+        return []
+    entries: list[dict[str, str]] = []
+    for image in _image_files(source):
+        rel = image.relative_to(source)
+        dest = target / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(image, dest)
+        entries.append({"scope": scope, "source": image.as_posix(), "path": rel.as_posix()})
+    return entries
+
+
+def _image_files(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_evidence.py
+++ b/tests/test_ci_evidence.py
@@ -10,6 +10,7 @@ import yaml
 
 from termproof import ci_evidence
 from termproof.ci_evidence import compose_pr_comment, load_receipt, run_target
+from termproof.evidence_publish import prepare_screenshot_evidence, rewrite_screenshot_links
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -31,6 +32,9 @@ class CiEvidenceReceiptTest(unittest.TestCase):
         )
         self.assertEqual(True, receipt["targets"]["release"]["video"])
         self.assertEqual(60, receipt["targets"]["release"]["video_fps"])
+        self.assertEqual("termproof-evidence", receipt["screenshots"]["branch"])
+        self.assertIn(".svg", receipt["screenshots"]["image_extensions"])
+        self.assertIn("/issues/69", receipt["screenshots"]["video_issue"])
 
     def test_workflows_are_receipt_backed(self) -> None:
         ci_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
@@ -54,12 +58,18 @@ class CiEvidenceReceiptTest(unittest.TestCase):
         steps = workflow["jobs"]["verify"]["steps"]
         names = [step["name"] for step in steps]
 
+        self.assertEqual("write", workflow["permissions"]["contents"])
         self.assertIn("Run base TUI verification for PR comparison", names)
+        self.assertIn("Prepare screenshot evidence branch payload", names)
+        self.assertIn("Publish screenshot evidence branch", names)
         self.assertIn("Compose TUI verification report", names)
         comment_step = next(
             step for step in steps if step["name"] == "Comment TUI verification report on PR"
         )
         self.assertIn(".termproof/ci-pr-comment.md", comment_step["with"]["script"])
+        compose_step = next(step for step in steps if step["name"] == "Compose TUI verification report")
+        self.assertIn("--screenshot-base-url", compose_step["run"])
+        self.assertIn("raw.githubusercontent.com", compose_step["run"])
 
     def test_run_target_uses_receipt_command_and_copies_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -132,6 +142,11 @@ class CiEvidenceReceiptTest(unittest.TestCase):
                                 "video_fps": 60,
                             },
                         },
+                        "screenshots": {
+                            "branch": "termproof-evidence",
+                            "image_extensions": [".svg"],
+                            "video_issue": "https://github.com/md-mt/termproof/issues/69",
+                        },
                         "pr_comment": {
                             "marker": "<!-- termproof-ci-report -->",
                             "max_chars": 55000,
@@ -144,8 +159,18 @@ class CiEvidenceReceiptTest(unittest.TestCase):
             head = root / "head"
             _write_result(base, True)
             _write_result(head, False)
-            (base / "latest-report.md").write_text("# before\n", encoding="utf-8")
-            (head / "latest-report.md").write_text("# after\n", encoding="utf-8")
+            base_svg = base / "demo" / "final.svg"
+            head_svg = head / "demo" / "final.svg"
+            base_svg.write_text("<svg />\n", encoding="utf-8")
+            head_svg.write_text("<svg />\n", encoding="utf-8")
+            (base / "latest-report.md").write_text(
+                f"# before\n[screenshot]({base_svg}) / [video](base/demo/session.mp4)\n",
+                encoding="utf-8",
+            )
+            (head / "latest-report.md").write_text(
+                f"# after\n[screenshot]({head_svg}) / [video](head/demo/session.mp4)\n",
+                encoding="utf-8",
+            )
 
             body = compose_pr_comment(
                 base,
@@ -153,6 +178,7 @@ class CiEvidenceReceiptTest(unittest.TestCase):
                 "https://example.test/run",
                 base_label="abc123",
                 head_label="def456",
+                screenshot_base_url="https://raw.example/pr/1/2",
                 receipt_path=receipt_path,
             )
 
@@ -163,6 +189,10 @@ class CiEvidenceReceiptTest(unittest.TestCase):
         self.assertIn("After: head commit def456", body)
         self.assertIn("# after", body)
         self.assertIn("termproof-release-evidence.tgz", body)
+        self.assertIn("https://raw.example/pr/1/2/base/demo/final.svg", body)
+        self.assertIn("https://raw.example/pr/1/2/head/demo/final.svg", body)
+        self.assertIn("base/demo/session.mp4", body)
+        self.assertIn("issues/69", body)
 
     def test_absolute_artifact_paths_are_normalized_to_artifact_relative(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -196,6 +226,43 @@ class CiEvidenceReceiptTest(unittest.TestCase):
                 ".termproof/pr-base/demo/final.svg",
                 data["artifacts"]["screenshot"],
             )
+
+    def test_prepare_screenshot_evidence_copies_images_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / "base"
+            head = root / "head"
+            (base / "run" / "steps").mkdir(parents=True)
+            (head / "run").mkdir(parents=True)
+            (base / "run" / "final.svg").write_text("<svg />\n", encoding="utf-8")
+            (base / "run" / "steps" / "01.svg").write_text("<svg />\n", encoding="utf-8")
+            (base / "run" / "session.mp4").write_text("video\n", encoding="utf-8")
+            (head / "run" / "final.png").write_text("png\n", encoding="utf-8")
+
+            manifest = prepare_screenshot_evidence(base, head, root / "publish", "68", "123")
+
+            published = root / "publish" / "pr" / "68" / "123"
+            self.assertTrue((published / "base" / "run" / "final.svg").is_file())
+            self.assertTrue((published / "base" / "run" / "steps" / "01.svg").is_file())
+            self.assertTrue((published / "head" / "run" / "final.png").is_file())
+            self.assertFalse((published / "base" / "run" / "session.mp4").exists())
+            self.assertEqual(3, len(manifest))
+
+    def test_rewrite_screenshot_links_leaves_video_links_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            evidence = root / "evidence"
+            (evidence / "run").mkdir(parents=True)
+            (evidence / "run" / "final.svg").write_text("<svg />\n", encoding="utf-8")
+            report = "[screenshot]({}) / [video]({})".format(
+                (evidence / "run" / "final.svg").as_posix(),
+                (evidence / "run" / "session.mp4").as_posix(),
+            )
+
+            rewritten = rewrite_screenshot_links(report, evidence, "https://raw.example/head")
+
+            self.assertIn("https://raw.example/head/run/final.svg", rewritten)
+            self.assertIn((evidence / "run" / "session.mp4").as_posix(), rewritten)
 
 
 def _write_result(root: Path, passed: bool) -> None:


### PR DESCRIPTION
[Assisted by Codex]

## Summary
- Copy PR base/head screenshot files to a dedicated `termproof-evidence` branch for same-repository PRs.
- Rewrite screenshot links in the sticky TermProof PR report to raw GitHub URLs while leaving videos in the workflow artifact.
- Document screenshot hosting and track hosted video evidence in #69.

## Validation
- uv run python -m unittest tests.test_ci_evidence tests.test_docs_pages tests.test_release_docs tests.test_docs_site
- uv run python -m unittest discover -s tests