### PR TITLE
Make PyPI release publish opt-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,5 +111,15 @@ jobs:
             termproof-release-evidence.tgz
 
       - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && vars.ENABLE_PYPI == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Note skipped PyPI publish
+        if: startsWith(github.ref, 'refs/tags/v') && vars.ENABLE_PYPI != 'true'
+        run: |
+          {
+            echo "## PyPI Publish"
+            echo
+            echo "Skipped because repository variable \`ENABLE_PYPI\` is not \`true\`."
+            echo "Configure PyPI trusted publishing, then set \`ENABLE_PYPI=true\` for future release tags."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -33,7 +33,8 @@ uv run termproof run examples/generic examples/multi_turn_conversation.recipe.js
    receipt-backed portable TUI end-to-end suite, writes the verifier report to
    the run summary and release body, uploads evidence, and creates a GitHub
    release.
-4. PyPI publishing uses GitHub trusted publishing from the release workflow.
+4. PyPI publishing uses GitHub trusted publishing from the release workflow
+   when the repository variable `ENABLE_PYPI` is set to `true`.
 
 The release evidence receipt lives at
 [`docs/ci/evidence-receipt.json`](ci/evidence-receipt.json). Update that receipt
@@ -51,8 +52,12 @@ PyPI and add this trusted publisher:
 - Environment: `pypi`
 
 The release job must keep `permissions.id-token: write` and `environment: pypi`.
-If PyPI reports `invalid-publisher`, the GitHub release can still be created but
-the package upload will fail until the PyPI project has the publisher above.
+Keep the repository variable `ENABLE_PYPI` unset or set to any value other than
+`true` until the PyPI project has the publisher above. The workflow will still
+create the GitHub release and attach evidence, but it will skip PyPI upload.
+After trusted publishing is configured, set `ENABLE_PYPI=true` before pushing
+the next release tag. If PyPI reports `invalid-publisher`, unset `ENABLE_PYPI`
+again until the publisher claims match the configuration above.
 
 The GitHub Release includes `termproof-release-evidence.tgz`. That archive
 contains `.termproof/release/latest-report.md`, per-recipe `report.md`,

--- a/tests/test_release_docs.py
+++ b/tests/test_release_docs.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs" / "releases.md"
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 
 
 class ReleaseDocsTest(unittest.TestCase):
@@ -16,7 +19,26 @@ class ReleaseDocsTest(unittest.TestCase):
         self.assertIn("Repository: `termproof`", text)
         self.assertIn("Workflow: `release.yml`", text)
         self.assertIn("Environment: `pypi`", text)
+        self.assertIn("ENABLE_PYPI", text)
         self.assertIn("invalid-publisher", text)
+
+    def test_pypi_publish_is_opt_in(self) -> None:
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["release"]["steps"]
+
+        publish_step = next(step for step in steps if step["name"] == "Publish to PyPI")
+        self.assertEqual(
+            "startsWith(github.ref, 'refs/tags/v') && vars.ENABLE_PYPI == 'true'",
+            publish_step["if"],
+        )
+        self.assertEqual("pypa/gh-action-pypi-publish@release/v1", publish_step["uses"])
+
+        skip_step = next(step for step in steps if step["name"] == "Note skipped PyPI publish")
+        self.assertEqual(
+            "startsWith(github.ref, 'refs/tags/v') && vars.ENABLE_PYPI != 'true'",
+            skip_step["if"],
+        )
+        self.assertIn("ENABLE_PYPI", skip_step["run"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[Assisted by Codex]\n\n## Summary\n- Gate PyPI publishing on the repository variable ENABLE_PYPI=true so release tags still build, verify, attach evidence, and create GitHub releases before PyPI trusted publishing is configured.\n- Add a release summary note when PyPI publish is intentionally skipped.\n- Document the opt-in release flow and add a regression test for the workflow condition.\n\n## Validation\n- uv run python -m unittest tests.test_release_docs tests.test_ci_evidence\n- uv run python -m unittest discover -s tests\n\n## Failure Confirmed\nThe failed v0.2.0 release created the GitHub release and evidence archive, then failed at pypa/gh-action-pypi-publish with invalid-publisher because PyPI trusted publishing is not configured yet.