### PR TITLE
chore: add community-health & GitHub template files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for TermProof.
+# These owners are requested for review automatically on matching changes.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repo.
+*       @md-mt

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,10 @@
+# Funding / sponsorship configuration for GitHub's "Sponsor" button.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# No sponsorship accounts are configured yet. Uncomment and fill in a handle
+# to enable the Sponsor button.
+#
+# github: [md-mt]              # up to 4 GitHub Sponsors usernames/orgs
+# ko_fi: your-handle           # a single Ko-fi username
+# open_collective: your-handle # an Open Collective slug
+# custom: ["https://example.com/donate"]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,64 @@
+---
+name: Bug report
+about: Report a reproducible bug in TermProof
+title: "bug: <short description>"
+labels: ["bug"]
+assignees: []
+---
+
+<!--
+Before filing: please search existing issues first (open and closed).
+For security vulnerabilities, do NOT open a public issue — email md@mt.com
+instead (see SECURITY.md).
+-->
+
+## What happened
+
+A clear description of the bug: what you observed vs. what you expected.
+
+**Observed:**
+
+**Expected:**
+
+## Reproduction recipe
+
+The `*.recipe.json` (or a minimal reduction of it) that triggers the bug.
+Reproductions must be deterministic and runnable in CI.
+
+```json
+{
+  "name": "repro",
+  "command": ["..."],
+  "steps": []
+}
+```
+
+## `termproof --help` output
+
+<details>
+<summary>termproof --help</summary>
+
+```text
+$ termproof --help
+...paste output here...
+```
+
+</details>
+
+## Environment
+
+- TermProof version: <!-- e.g. 0.2.0 (run `termproof --version`) -->
+- Python version: <!-- run `python --version` -->
+- OS / architecture: <!-- e.g. macOS 14 arm64, Ubuntu 24.04 x86_64 -->
+- `ffmpeg` / `agg` available: <!-- yes/no, only relevant for --video/render -->
+
+## Additional context
+
+Logs, a `.cast` file, screenshots, or anything else that helps. Avoid
+attaching large binaries — link to a gist or trimmed artifact instead.
+
+## Area (optional)
+
+If you know which area this touches, add one of the area labels:
+`area:core`, `area:cli`, `area:ci`, `area:docs`, `area:community`,
+`area:distro`, `area:plugins`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussion
+    url: https://github.com/md-mt/termproof/discussions
+    about: Ask questions, share recipes, and propose ideas in GitHub Discussions.
+  - name: Support & getting help
+    url: https://github.com/md-mt/termproof/blob/main/SUPPORT.md
+    about: Where and how to get help with TermProof.
+  - name: Report a security vulnerability
+    url: mailto:md@mt.com
+    about: Do not open public issues for security reports — email us privately (see SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,46 @@
+---
+name: Feature request
+about: Propose an enhancement or new capability for TermProof
+title: "feat: <short description>"
+labels: ["enhancement"]
+assignees: []
+---
+
+<!--
+Before filing: please search existing issues and discussions first.
+Questions and open-ended ideas are often a better fit for Discussions —
+see SUPPORT.md.
+-->
+
+## Problem / motivation
+
+What problem are you trying to solve? What is the current behavior and why is
+it insufficient? Link any related issues.
+
+## Proposed solution
+
+Describe the feature or change you'd like. If it affects recipe semantics or
+artifact contracts, note that explicitly (these require a minor/major version
+bump per `docs/releases.md`).
+
+## Alternatives considered
+
+Other approaches you evaluated and why you didn't choose them.
+
+## Scope / contribution ladder
+
+Where does this land on the contribution ladder (see CONTRIBUTING.md)?
+
+- [ ] Recipe (an `examples/*.recipe.json`)
+- [ ] Plugin (external step / assertion / backend / reporter)
+- [ ] Core change (`termproof/` internals)
+
+## Additional context
+
+Mockups, example recipes, prior art, or anything else that clarifies the ask.
+
+## Area (optional)
+
+Add one of the area labels if you know which area this touches:
+`area:core`, `area:cli`, `area:ci`, `area:docs`, `area:community`,
+`area:distro`, `area:plugins`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+Thanks for contributing to TermProof! Please read CONTRIBUTING.md.
+All changes go through pull requests — no direct commits to `main`.
+Open as a draft early and request review when CI is green.
+-->
+
+## Summary
+
+What does this PR do and why? Keep changes small and incremental
+(~100 lines of logic, <200 with tests). Split larger work into stacked PRs.
+
+## Linked issue
+
+<!-- Use a closing keyword so the issue auto-closes on merge. -->
+
+Closes #
+
+## Test plan
+
+How did you verify this change?
+
+```bash
+uv run python -m unittest discover -s tests
+uv build
+# if you touched runner/renderer/video:
+uv run termproof run examples/generic --video --out .termproof/ci
+```
+
+- [ ] Added/updated unit tests for behavioral changes
+- [ ] Screenshots / evidence attached (if UX or output changed)
+
+## Tidy First
+
+Following Tidy First, structural moves and behavioral changes are not mixed in
+the same diff.
+
+- [ ] This PR is a **structural** change only (renames/moves/formatting), OR
+- [ ] This PR is a **behavioral** change only, OR
+- [ ] N/A (docs / chore)
+
+## Checklist
+
+- [ ] Title and commits follow Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`)
+- [ ] No comments/docstrings/type hints added to untouched code
+- [ ] Branch follows naming convention (`feat/`, `fix/`, `docs/`, `refactor/`, `chore/`)
+- [ ] No large binaries checked in (`examples/artifacts/` kept lean)
+- [ ] Backward-compatibility contract respected (legacy `tui-verifier` paths / plugin prefix — see CONTRIBUTING.md)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Python dependencies declared in the root pyproject.toml.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "area:distro"
+    commit-message:
+      prefix: "chore"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "area:ci"
+    commit-message:
+      prefix: "chore"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,8 @@ We aim to acknowledge reports within 48 hours and provide an initial assessment 
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.2.x   | :white_check_mark: |
+| 0.1.x   | :x:                |
 
 ## Disclosure
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,37 @@
+# Getting help with TermProof
+
+Thanks for using TermProof! Here's where to go depending on what you need.
+
+## Questions & ideas
+
+For usage questions, "how do I verify X?", recipe help, and open-ended
+proposals, use **[GitHub Discussions](https://github.com/md-mt/termproof/discussions)**.
+Discussions are searchable and let the whole community benefit from answers.
+
+## Bug reports & feature requests
+
+Open a **[GitHub issue](https://github.com/md-mt/termproof/issues)** using the
+appropriate template:
+
+- **Bug report** — include a reproduction recipe (JSON), `termproof --help`
+  output, your Python version, OS, and observed vs. expected behavior.
+- **Feature request** — describe the problem, proposed solution, and where it
+  lands on the contribution ladder.
+
+Please search existing issues (open and closed) before filing a new one.
+
+## Security issues
+
+**Do not** open a public issue for security vulnerabilities. Email
+**md@mt.com** instead. See [SECURITY.md](SECURITY.md) for the full policy and
+what to include.
+
+## Contributing
+
+Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution
+ladder, local setup, and the PR-only process. All participants are expected to
+follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Documentation
+
+Start with the [README](README.md) and the guides under [`docs/`](docs/).


### PR DESCRIPTION
[Assisted by CLAUDE]

Adds the community-health and GitHub template files expected of a mature OSS framework, matching the tone/structure of the existing CONTRIBUTING.md, CODE_OF_CONDUCT.md, and SECURITY.md.

## Added files
- `.github/ISSUE_TEMPLATE/bug_report.md` — encodes the CONTRIBUTING issue body (repro recipe JSON, `termproof --help`, Python version, OS, observed vs expected); labeled `bug`.
- `.github/ISSUE_TEMPLATE/feature_request.md` — problem/solution/alternatives + contribution-ladder scope; labeled `enhancement`.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; contact links to Discussions, SUPPORT.md, and the security email.
- `.github/PULL_REQUEST_TEMPLATE.md` — summary, linked issue (`Closes #`), test plan, Tidy First note, and Conventional Commit checkbox.
- `.github/CODEOWNERS` — default owner `@md-mt`.
- `SUPPORT.md` — where to get help (issues, discussions, security email).
- `.github/FUNDING.yml` — commented template (no real sponsor handle; none discoverable in repo).
- `.github/dependabot.yml` — weekly `pip` (root) and `github-actions` updates, labeled `area:distro` / `area:ci`.

## Changed
- `SECURITY.md` — supported-versions table updated to reflect 0.2.x (current version 0.2.0), 0.1.x marked unsupported.

## Validation
- `uv run python -m unittest tests.test_launch_kit` — 45 tests pass.
- All `.github/**/*.yml` files parse with PyYAML.

Closes #72