### PR TITLE
fix: convert PTY-mode step exceptions to failed StepResult

### DIFF
--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -224,7 +224,12 @@ class VerificationRunner:
             recipe.rows,
         ) as session:
             for index, step in enumerate(recipe.steps, start=1):
-                step_result = self._run_step(session, index, step)
+                try:
+                    step_result = self._run_step(session, index, step)
+                except Exception as exc:
+                    action_name = step["action"]
+                    name = step.get("name", f"{index}:{action_name}")
+                    step_result = StepResult(name, False, str(exc), session.screen)
                 steps.append(step_result)
                 if not step_result.passed:
                     break

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -106,6 +106,58 @@ class RunnerTest(unittest.TestCase):
         backend = runner.video_backend_registry.get("agg_ffmpeg")
         self.assertIsNotNone(backend)
 
+    def test_run_pty_converts_step_exception_to_failed_result(self) -> None:
+        """A PTY step that raises yields a failed StepResult, not an abort.
+
+        Mirrors the process-mode behavior. Uses a fake session backend so the
+        test does not need asciinema/ffmpeg to exercise the error-wrapping path.
+        """
+
+        class _FakeSession:
+            screen = "screen-snapshot"
+            raw_output = "raw"
+            exit_code = 0
+
+            def __enter__(self) -> "_FakeSession":
+                return self
+
+            def __exit__(self, *exc: object) -> bool:
+                return False
+
+            def press(self, key: str) -> None:
+                # Mirror the real session: unknown key raises KeyError.
+                raise KeyError(key.lower())
+
+            def wait_for_exit(self, timeout_seconds: float) -> None:
+                return None
+
+            def wait_for_idle(self, stable: float, timeout: float) -> bool:
+                return True
+
+        class _FakeBackend:
+            def create_session(self, *args: object, **kwargs: object) -> "_FakeSession":
+                return _FakeSession()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = VerificationRunner()
+            runner.session_backend = _FakeBackend()
+            recipe = Recipe(
+                name="pty-error",
+                command=CommandSpec(
+                    argv=[sys.executable, "-c", "pass"],
+                    pty=True,
+                ),
+                steps=[{"action": "press", "key": "not-a-real-key"}],
+                expect_exit_code=None,
+            )
+            steps, raw_output, exit_code, screen = runner._run_pty(
+                recipe, Path(tmp)
+            )
+            self.assertEqual(len(steps), 1)
+            self.assertFalse(steps[0].passed)
+            self.assertIn("not-a-real-key", steps[0].detail)
+            self.assertEqual(steps[0].screen, "screen-snapshot")
+
     def test_runner_run_uses_video_backend(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             recipe = Recipe(


### PR DESCRIPTION
[Assisted by CLAUDE]

## Bug
In `termproof/runner.py`, `_run_process` wraps each step execution in try/except and converts any raised exception into a failed `StepResult`. `_run_pty` did NOT do this, so an exception raised inside a PTY-mode step (e.g. a `press` step with an unknown key hitting `KEYS[normalized]` -> `KeyError`) propagated uncaught and aborted the entire run instead of producing a clean failed `StepResult`.

## Fix
Made PTY-mode step error handling symmetric with process mode: each PTY step is now wrapped so an exception becomes a failed `StepResult`, mirroring the existing process-mode pattern exactly (same `StepResult(name, False, str(exc), session.screen)` shape, capturing the exception message). The happy path is unchanged.

## Test
Added `test_run_pty_converts_step_exception_to_failed_result` in `tests/test_runner.py`. It injects a fake session backend whose `press` raises `KeyError` (mirroring the real session's behavior for an unknown key) and calls `_run_pty` directly, asserting the run completes with a single failed `StepResult` (with the exception message and screen snapshot captured) rather than raising.

Because the local env lacks `asciinema`/`ffmpeg`, the test exercises the error-wrapping logic directly via a fake session backend so it is fully runnable without external tools.

Result: `uv run python -m unittest tests.test_runner` -> 10 tests pass, 0 skips.

Closes #74