### PR TITLE
docs: reconcile CHANGELOG builtin names and version drift (0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to TermProof are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] — 2026-07-29
+
+### Added
+
+#### Distribution & packaging
+- **Bundled `agg` binary.** Prebuilt `agg` wheels are shipped so video rendering works without a separate `agg` install, closing the v0.2.0 known limitation (#49).
+- **Reusable GitHub Action** (`action.yml`). Run TermProof recipes and upload reviewable evidence directly from a workflow (#49).
+- **Generic Docker image.** A ready-to-run container image for executing recipes (#59).
+- **Homebrew formula** (`Formula/termproof.rb`) for `brew install` distribution (#64).
+
+#### Core engine
+- **`json_schema` assertion.** Validate structured output against a JSON Schema (#52).
+- **PNG screen renderer** (`png`). Per-step and final screenshots rendered as PNG (#54).
+- **Docker session backend.** Execute recipes inside a Docker container (#53).
+- **Recipe v1 validation.** Recipes are validated against a versioned schema before execution (#51).
+- **Parallel recipe execution.** Run multiple recipes concurrently (#60).
+- **Visual diff mode.** Compare screenshots to detect visual regressions (#61).
+- **Unchanged recipe cache.** Skip re-running recipes whose inputs are unchanged (#62).
+
+#### CLI
+- **`termproof plugins`** command to inspect registered plugins (#55).
+
+#### CI/CD & integrations
+- **GitLab CI template** (#57), **CircleCI orb source** (#58), and **framework integration guides** (#56).
+- **Receipt-backed CI evidence reports** (#68) and **PR screenshot publishing** to an evidence branch (#70).
+- **PyPI trusted publisher setup documentation** (#66).
+
+#### Documentation
+- **VitePress documentation site** (#63).
+- **First-party plugin examples** listed in the docs (#65).
+
+### Changed
+- **Stabilized plugin protocol API** for steps, assertions, and backends (#50).
+- **Pages deploy is now opt-in** (#67).
+- **PyPI release publishing is now opt-in** via `ENABLE_PYPI` (#71).
+
+---
+
 ## [0.2.0] — 2026-07-26
 
 ### Added
@@ -14,13 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Asciinema cast recording.** Every run produces a standard `.cast` file. Replay with `asciinema play` or any asciinema-compatible tool.
 - **Evidence pipeline.** Cast → per-step screenshots (SVG, PNG) → final screenshot → text snapshot → optional 60fps MP4 video. Evidence artifacts are files, not claims.
 - **`wait_for_regex` step with group evidence.** Named capture groups in wait patterns produce structured evidence attached to the step result. No more "did the regex match?" — you see exactly what matched.
-- **JUnit XML reporter** (`builtin_reporters.junit_xml_reporter`). Native CI integration — export test results as JUnit XML for GitHub Actions, GitLab CI, Jenkins, or any JUnit-compatible dashboard.
+- **JUnit XML reporter** (`junit_xml`). Native CI integration — export test results as JUnit XML for GitHub Actions, GitLab CI, Jenkins, or any JUnit-compatible dashboard.
 - **Markdown report generation.** Every run produces a `report.md` with pass/fail summary, per-step results, and evidence links.
 
 #### Plugin system
 - **Plugin registry architecture.** Steps, assertions, reporters, session backends, execution modes, video backends, and screen renderers are all pluggable via entry points.
 - **Production-ready plugin template** (`plugin-template/`). Scaffold a new TermProof plugin with `termproof scaffold --template`. Includes working example step, assertion, reporter, config wiring, and test suite.
-- **Builtin registrations.** Steps: `spawn`, `type`, `wait_for_text`, `wait_for_regex`, `send_signal`, `sleep`, `capture_screen`. Assertions: `screen_contains`, `screen_matches`, `exit_code_equals`, `cast_duration_within`. Reporters: `markdown`, `junit_xml`.
+- **Builtin registrations.** Steps: `wait_for_text`, `wait_for_idle`, `send_text`, `send_line`, `press`, `sleep`, `wait_for_regex`. Assertions: `output_contains`, `output_not_contains`, `screen_contains`, `screen_not_contains`, `exit_code`, `file_exists`, `file_contains`. Reporters: `markdown`, `junit_xml`. Screen renderers: `svg`. Video backends: `agg_ffmpeg`. Execution modes: `scripted_pty`, `scripted_process`, `agent_driven`. Agent runners: `codex`.
 
 #### CLI
 - `termproof run <recipe>` — execute a recipe with full evidence pipeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "termproof"
-version = "0.2.0"
+version = "0.2.1"
 description = "Evidence-first verification for TUI and terminal applications"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
[Assisted by CLAUDE]

Docs/metadata-only change. No code behavior changes.

## Summary

Fixes two related documentation/metadata issues.

### (A) Correct CHANGELOG builtin names (#75)
The 0.2.0 CHANGELOG documented builtin steps/assertions that were never registered. Corrected the "Builtin registrations" line and the JUnit reporter name to match the real registrations in `termproof/config.py` (`BUILTIN_DEFAULTS`):

- Steps: `wait_for_text`, `wait_for_idle`, `send_text`, `send_line`, `press`, `sleep`, `wait_for_regex`
- Assertions: `output_contains`, `output_not_contains`, `screen_contains`, `screen_not_contains`, `exit_code`, `file_exists`, `file_contains`
- Reporters: `markdown`, `junit_xml` (was incorrectly `builtin_reporters.junit_xml_reporter`)
- Plus screen renderers (`svg`), video backends (`agg_ffmpeg`), execution modes, and agent runners

Removed phantom names that do not exist in the code: `spawn`, `type`, `send_signal`, `capture_screen`, `screen_matches`, `exit_code_equals`, `cast_duration_within`.

### (B) Reconcile version drift (#76)
`pyproject.toml` still said `0.2.0` while `main` carries 0.2.1-era features and `action.yml`/Homebrew reference v0.2.1.

- Bumped `version` to `0.2.1` in `pyproject.toml`
- Added a Keep-a-Changelog `## [0.2.1] — 2026-07-29` section summarizing the post-0.2.0 additions (bundled agg wheels, reusable GitHub Action, Docker image/session backend, Homebrew formula, `json_schema` assertion, PNG renderer, recipe v1 validation, parallel execution, visual diff, recipe cache, `plugins` CLI, CI templates/orb, VitePress docs, opt-in Pages/PyPI). Entries are derived from `git log v0.2.0..HEAD` (#49–#71).

## Validation
- `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` parses; version reads `0.2.1`
- `uv run python -m unittest tests.test_release_docs tests.test_termproof_rename` — 5 tests, OK

Closes #75
Closes #76