### PR TITLE
fix: warn when requested video cannot be produced (missing agg/ffmpeg)

### DIFF
--- a/termproof/evidence.py
+++ b/termproof/evidence.py
@@ -62,15 +62,41 @@ def render_artifacts(
         path = run_dir / name
         if path.exists():
             artifacts[name.removesuffix(".md").removesuffix(".json")] = str(path)
-    agg_path = resolve_agg()
-    if render_video and agg_path:
-        mp4_path = run_dir / "session.mp4"
-        if video_backend is not None:
-            video_backend.render(cast_path, mp4_path, video_fps)
+    if render_video:
+        missing = _missing_video_tools()
+        if missing:
+            warnings.warn(
+                "video evidence was requested (--video) but "
+                f"{' and '.join(missing)} could not be resolved; skipping video. "
+                "Install the missing tool(s) or use a platform wheel that bundles agg.",
+                stacklevel=2,
+            )
         else:
-            render_mp4(cast_path, mp4_path, video_fps)
-        artifacts["video"] = str(mp4_path)
+            mp4_path = run_dir / "session.mp4"
+            if video_backend is not None:
+                video_backend.render(cast_path, mp4_path, video_fps)
+            else:
+                render_mp4(cast_path, mp4_path, video_fps)
+            artifacts["video"] = str(mp4_path)
     return artifacts
+
+
+def _missing_video_tools() -> list[str]:
+    """Return the names of video tools that cannot be resolved on this system."""
+    missing = []
+    if not resolve_agg():
+        missing.append("agg")
+    if _resolve_ffmpeg() is None:
+        missing.append("ffmpeg")
+    return missing
+
+
+def _resolve_ffmpeg() -> str | None:
+    """Resolve ffmpeg without raising, returning None when it is unavailable."""
+    try:
+        return find_ffmpeg()
+    except Exception:
+        return None
 
 
 def _render_step_screens(

--- a/tests/test_bundled_video.py
+++ b/tests/test_bundled_video.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -21,23 +22,60 @@ class RenderMp4Tests(unittest.TestCase):
 
 
 class ResolveAggFallbackTests(unittest.TestCase):
+    @staticmethod
+    def _write_cast(run_dir: Path) -> None:
+        run_dir.mkdir()
+        # Create a minimal cast file so replay_cast doesn't crash.
+        (run_dir / "session.cast").write_text(
+            '{"version":2,"width":100,"height":30}\n'
+            '[0.1,"o","hello\\n"]\n',
+            encoding="utf-8",
+        )
+
     @patch("termproof.evidence.resolve_agg", return_value=None)
-    def test_render_artifacts_skips_video_when_no_agg(self, resolve_agg) -> None:
-        """Video rendering should be silently skipped when no agg is available."""
+    def test_render_artifacts_omits_video_when_no_agg(self, resolve_agg) -> None:
+        """Video must be omitted gracefully when no agg is available."""
         from termproof.evidence import render_artifacts
         import tempfile
 
         with tempfile.TemporaryDirectory() as tmp:
             run_dir = Path(tmp) / "run"
-            run_dir.mkdir()
-            # Create a minimal cast file so replay_cast doesn't crash
-            cast_path = run_dir / "session.cast"
-            cast_path.write_text(
-                '{"version":2,"width":100,"height":30}\n'
-                '[0.1,"o","hello\\n"]\n',
-                encoding="utf-8",
-            )
-            artifacts = render_artifacts(run_dir, render_video=True, video_fps=60)
+            self._write_cast(run_dir)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                artifacts = render_artifacts(run_dir, render_video=True, video_fps=60)
+            self.assertNotIn("video", artifacts)
+
+    @patch("termproof.evidence.resolve_agg", return_value=None)
+    def test_render_artifacts_warns_when_video_requested_without_tools(self, resolve_agg) -> None:
+        """An explicit --video request must not be silently dropped."""
+        from termproof.evidence import render_artifacts
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            self._write_cast(run_dir)
+            with self.assertWarns(UserWarning) as caught:
+                artifacts = render_artifacts(run_dir, render_video=True, video_fps=60)
+
+        message = str(caught.warning)
+        self.assertIn("agg", message)
+        self.assertIn("--video", message)
+        self.assertIn("skipping video", message)
+        self.assertNotIn("video", artifacts)
+
+    @patch("termproof.evidence.resolve_agg", return_value=None)
+    def test_render_artifacts_no_warning_when_video_not_requested(self, resolve_agg) -> None:
+        """No warning should be emitted when video was not requested."""
+        from termproof.evidence import render_artifacts
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            self._write_cast(run_dir)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                artifacts = render_artifacts(run_dir, render_video=False, video_fps=60)
             self.assertNotIn("video", artifacts)
 
 


### PR DESCRIPTION
[Assisted by CLAUDE]

## Problem
Closes #77

When a user requests video evidence (`--video`) but the required tools (`agg`/`ffmpeg`) cannot be resolved, `termproof/evidence.py` (`render_artifacts`) silently omitted the video. The run still PASSed and the only signal was `video: -` in the CLI output. An evidence tool must not silently drop requested evidence.

## Fix
In `render_artifacts`, when video is explicitly requested but the required tool(s) cannot be resolved, emit a clear `warnings.warn(...)` that names the missing tool(s) and states that video was skipped. The `warnings` module was already imported in `evidence.py` (previously unused), so this matches the module's intended mechanism.

- Added `_missing_video_tools()` which checks `resolve_agg()` and a new non-raising `_resolve_ffmpeg()` helper, returning the names of unresolved tools.
- Behavior is unchanged when `--video` is not requested (no warning, no video). Video is still omitted gracefully rather than hard-failing — a loud, visible warning is the goal.

## Test
`tests/test_bundled_video.py`:
- New: asserts a `UserWarning` is emitted (naming `agg`, mentioning `--video` and "skipping video") when agg resolution is mocked to `None` while video is requested, and that the artifact set omits `video`.
- New: asserts no warning is emitted when video is not requested.
- Updated the pre-existing test (previously documenting "silently skipped") to reflect the new graceful-omit-with-warning behavior.

Tests mock the agg-path resolver rather than depending on real tools (`agg` is present locally but `ffmpeg`/`asciinema` are not).

Result: `uv run python -m unittest tests.test_bundled_video` — 4 tests OK. Related modules (`test_runner`, `test_cli`, `test_demo`) also pass.

## Follow-up (not in this PR)
The idle-wait hard-cap of 3s in `runner.py:234` (`wait_for_idle(0.5, min(3, recipe.timeout_seconds))`) is an undocumented magic number. Left as a follow-up to keep this PR focused and avoid mixing a structural rename into a behavioral fix (Tidy First).
