### PR TITLE
test: add unit tests for session.py exit-code logic and _load_json parser

### DIFF
--- a/tests/test_agent_driven.py
+++ b/tests/test_agent_driven.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from termproof.agent_driven import build_agent_prompt, parse_agent_output
+from termproof.agent_driven import _load_json, build_agent_prompt, parse_agent_output
 from termproof.models import CommandSpec, Recipe
 from termproof.runner import VerificationRunner
 
@@ -70,3 +70,81 @@ class AgentDrivenTest(unittest.TestCase):
             self.assertTrue(Path(result.artifacts["agent_transcript"]).exists())
             self.assertTrue(Path(result.artifacts["agent_outcome"]).exists())
             self.assertTrue(Path(result.artifacts["step_screenshots"]).exists())
+
+
+class LoadJsonTest(unittest.TestCase):
+    def test_clean_json_object(self) -> None:
+        data = _load_json('{"assertions": {"ok": true}, "transcript": "done"}')
+
+        self.assertEqual({"assertions": {"ok": True}, "transcript": "done"}, data)
+
+    def test_json_wrapped_in_prose(self) -> None:
+        output = 'Here is the result: {"assertions": {"ok": true}} thanks!'
+
+        data = _load_json(output)
+
+        self.assertEqual({"assertions": {"ok": True}}, data)
+
+    def test_json_inside_fenced_block(self) -> None:
+        output = 'Some notes\n```json\n{"assertions": {"ok": true}, "transcript": "x"}\n```\n'
+
+        data = _load_json(output)
+
+        self.assertEqual({"assertions": {"ok": True}, "transcript": "x"}, data)
+
+    def test_json_on_last_line_after_logs(self) -> None:
+        output = "\n".join(
+            [
+                "starting agent...",
+                "[info] running command",
+                "[info] finished",
+                '{"assertions": {"ok": true}, "transcript": "last"}',
+            ]
+        )
+
+        data = _load_json(output)
+
+        self.assertEqual({"assertions": {"ok": True}, "transcript": "last"}, data)
+
+    def test_object_with_assertions_wins_over_plain_object(self) -> None:
+        # Two JSON-looking fragments: only the one carrying "assertions"/"transcript"
+        # should be selected regardless of its position in the output.
+        output = "\n".join(
+            [
+                '{"unrelated": 1}',
+                '{"assertions": {"ok": true}}',
+                '{"also": 2}',
+            ]
+        )
+
+        data = _load_json(output)
+
+        self.assertEqual({"assertions": {"ok": True}}, data)
+
+    def test_trailing_text_after_object(self) -> None:
+        output = '{"assertions": {"ok": true}} trailing commentary that is not json'
+
+        data = _load_json(output)
+
+        self.assertEqual({"assertions": {"ok": True}}, data)
+
+    def test_falls_back_to_first_object_without_marker_keys(self) -> None:
+        # No fragment has "assertions"/"transcript"; the first collected dict wins.
+        output = '{"foo": 1}'
+
+        data = _load_json(output)
+
+        self.assertEqual({"foo": 1}, data)
+
+    def test_malformed_json_returns_none(self) -> None:
+        self.assertIsNone(_load_json('{"assertions": {"ok": true'))
+
+    def test_no_json_returns_none(self) -> None:
+        self.assertIsNone(_load_json("just some plain text, no json here"))
+
+    def test_empty_input_returns_none(self) -> None:
+        self.assertIsNone(_load_json(""))
+
+    def test_non_object_json_is_ignored(self) -> None:
+        # A top-level JSON array is valid JSON but not a dict, so it is skipped.
+        self.assertIsNone(_load_json("[1, 2, 3]"))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from termproof.session import (
+    KEYS,
+    TerminalSession,
+    asciinema_rec_command,
+    recorded_command,
+)
+
+
+def _make_session(tmp: str) -> TerminalSession:
+    return TerminalSession(
+        argv=["true"],
+        cast_path=Path(tmp) / "session.cast",
+        cwd=None,
+        env={},
+        cols=80,
+        rows=24,
+    )
+
+
+class RecordedCommandTest(unittest.TestCase):
+    def test_builds_status_capturing_wrapper(self) -> None:
+        exit_path = Path("/tmp/session.exitcode")
+
+        command = recorded_command(["echo", "hi"], exit_path)
+
+        quoted_exit = str(exit_path.resolve())
+        self.assertTrue(command.startswith("echo hi; "))
+        self.assertIn("__termproof_status=$?;", command)
+        self.assertIn(f"printf '%s' \"$__termproof_status\" > {quoted_exit};", command)
+        self.assertTrue(command.endswith('exit "$__termproof_status"'))
+
+    def test_shell_quotes_arguments_with_spaces_and_specials(self) -> None:
+        command = recorded_command(["ls", "-la", "my dir", "$HOME"], Path("/tmp/e.exitcode"))
+
+        # shlex.join must quote the space-containing and dollar-sign arguments so
+        # they are passed literally rather than expanded by the wrapper shell.
+        self.assertIn("ls -la 'my dir' '$HOME';", command)
+
+    def test_quotes_exit_code_path_with_spaces(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            exit_path = Path(tmp) / "a dir" / "run.exitcode"
+
+            command = recorded_command(["true"], exit_path)
+
+            self.assertIn(f"'{exit_path.resolve()}'", command)
+
+
+class AsciinemaRecCommandTest(unittest.TestCase):
+    def test_composes_full_recording_command(self) -> None:
+        cast_path = Path("/tmp/out.cast")
+        exit_path = Path("/tmp/out.exitcode")
+
+        with mock.patch(
+            "termproof.session.shutil.which", return_value="/usr/bin/asciinema"
+        ):
+            command = asciinema_rec_command(["true"], cast_path, exit_path, 100, 30)
+
+        self.assertEqual(
+            [
+                "/usr/bin/asciinema",
+                "rec",
+                "--overwrite",
+                "--stdin",
+                "--quiet",
+                "--cols",
+                "100",
+                "--rows",
+                "30",
+                "--command",
+                recorded_command(["true"], exit_path),
+                str(cast_path),
+            ],
+            command,
+        )
+
+    def test_raises_when_asciinema_missing(self) -> None:
+        with mock.patch("termproof.session.shutil.which", return_value=None):
+            with self.assertRaises(RuntimeError):
+                asciinema_rec_command(["true"], Path("/tmp/x.cast"), Path("/tmp/x.exitcode"), 80, 24)
+
+
+class ExitCodeResolutionTest(unittest.TestCase):
+    def test_sidecar_file_takes_priority_over_child_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.exit_code_path.write_text("0", encoding="utf-8")
+            session.child = mock.Mock(closed=True, exitstatus=1, signalstatus=None)
+
+            self.assertEqual(0, session._collect_exit_code())
+
+    def test_sidecar_nonzero_value_is_parsed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.exit_code_path.write_text("42\n", encoding="utf-8")
+            session.child = mock.Mock(closed=True, exitstatus=None, signalstatus=None)
+
+            self.assertEqual(42, session._collect_exit_code())
+
+    def test_falls_back_to_child_exitstatus_when_no_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock(closed=True, exitstatus=3, signalstatus=None)
+
+            self.assertEqual(3, session._collect_exit_code())
+
+    def test_falls_back_to_signal_offset_when_no_exitstatus(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock(closed=True, exitstatus=None, signalstatus=9)
+
+            self.assertEqual(137, session._collect_exit_code())
+
+    def test_returns_none_when_no_status_available(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock(closed=True, exitstatus=None, signalstatus=None)
+
+            self.assertIsNone(session._collect_exit_code())
+
+    def test_empty_sidecar_falls_back_to_child_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.exit_code_path.write_text("   ", encoding="utf-8")
+            session.child = mock.Mock(closed=True, exitstatus=5, signalstatus=None)
+
+            self.assertEqual(5, session._collect_exit_code())
+
+    def test_cached_exit_code_is_returned_without_touching_child(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.exit_code = 7
+            child = mock.Mock(closed=False, exitstatus=1, signalstatus=None)
+            session.child = child
+
+            self.assertEqual(7, session._collect_exit_code())
+            child.close.assert_not_called()
+
+
+class ReadRecordedExitCodeTest(unittest.TestCase):
+    def test_missing_file_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+
+            self.assertIsNone(session._read_recorded_exit_code())
+
+    def test_reads_and_strips_value(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.exit_code_path.write_text("  13  \n", encoding="utf-8")
+
+            self.assertEqual(13, session._read_recorded_exit_code())
+
+    def test_empty_file_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.exit_code_path.write_text("", encoding="utf-8")
+
+            self.assertIsNone(session._read_recorded_exit_code())
+
+
+class KeyPressTest(unittest.TestCase):
+    def test_named_key_sends_escape_sequence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock()
+
+            session.press("up")
+
+            session.child.send.assert_called_once_with(KEYS["up"])
+
+    def test_key_name_is_case_insensitive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock()
+
+            session.press("ENTER")
+
+            session.child.send.assert_called_once_with("\r")
+
+    def test_ctrl_prefix_uses_sendcontrol(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock()
+
+            session.press("Ctrl-C")
+
+            session.child.sendcontrol.assert_called_once_with("c")
+            session.child.send.assert_not_called()
+
+    def test_unknown_key_raises_key_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock()
+
+            with self.assertRaises(KeyError):
+                session.press("f13")
+
+
+class SendHelpersTest(unittest.TestCase):
+    def test_send_line_appends_carriage_return(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock()
+
+            session.send_line("hello")
+
+            session.child.send.assert_called_once_with("hello\r")
+
+    def test_send_text_passes_text_through(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock()
+
+            session.send_text("abc")
+
+            session.child.send.assert_called_once_with("abc")
+
+    def test_send_eof_delegates_to_child(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+            session.child = mock.Mock()
+
+            session.send_eof()
+
+            session.child.sendeof.assert_called_once_with()
+
+    def test_operations_before_start_raise_runtime_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            session = _make_session(tmp)
+
+            with self.assertRaises(RuntimeError):
+                session.send_text("x")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Assisted by CLAUDE]

Adds focused, tests-only coverage for two under-tested, robustness-critical areas. No production code changed.

## `agent_driven._load_json` (tests/test_agent_driven.py, new `LoadJsonTest`)
Covers the heuristic JSON extractor's real behavior:
- Clean JSON object
- JSON wrapped in prose
- JSON inside a fenced ```json block
- JSON on the last line after log lines
- Multiple JSON fragments: the object carrying `assertions`/`transcript` wins regardless of position
- Trailing text after the object (brace-scan `raw_decode`)
- Fallback to the first collected object when no marker keys are present
- Malformed JSON, no-JSON, and empty input all return `None` (documented sentinel behavior)
- Top-level non-object JSON (array) is ignored

## `session.TerminalSession` (tests/test_session.py, new module)
Covers the pure, tool-independent logic:
- `recorded_command`: status-capturing wrapper construction and shell-quoting of args + exit-code path
- `asciinema_rec_command`: full command composition (`shutil.which` mocked) and `RuntimeError` when asciinema is absent
- Exit-code resolution `_collect_exit_code`: `.exitcode` sidecar priority, fallback to `child.exitstatus`, then `128 + signalstatus`, `None` when nothing available, empty-sidecar fallback, and cached-value short-circuit
- `_read_recorded_exit_code`: missing file, whitespace stripping, empty file
- Key normalization / `press`: named-key escape sequences, case-insensitivity, `ctrl-` -> `sendcontrol`, unknown key raises `KeyError`
- Send helpers: `send_line` CR suffix, `send_text`, `send_eof`, and `RuntimeError` before session start

`pexpect` is isolated with `unittest.mock`, so no `asciinema`/`ffmpeg` are required. Nothing was skipped.

## Validation
`uv run python -m unittest tests.test_agent_driven tests.test_session` -> Ran 37 tests, OK (0 failures, 0 skips). 23 new session tests + 11 new `_load_json` tests + 3 pre-existing agent_driven tests.

Closes #81