### PR TITLE
refactor: dedupe report helpers, drop dead GlobalDefaults config

### DIFF
--- a/termproof/builtin_reporters.py
+++ b/termproof/builtin_reporters.py
@@ -7,6 +7,7 @@ from .before_after import BeforeAfterResult
 from .build_info import BuildInfo
 from .models import RunResult
 from .protocols import Reporter
+from .report_helpers import _build_info_lines, _detail, _evidence_links
 
 
 # XML 1.0 spec: allowed characters are:
@@ -208,58 +209,3 @@ class JUnitXmlReporter:
 
         xml_body = ET.tostring(testsuites, encoding="unicode")
         return f'<?xml version="1.0" encoding="UTF-8"?>\n{xml_body}\n'
-
-
-def _build_info_lines(build_info: BuildInfo) -> list[str]:
-    verified = "yes" if build_info.verify_provenance() else "no"
-    return [
-        "## Build Provenance",
-        "",
-        f"- Mode: `{build_info.mode}`",
-        f"- Command: `{_one_line(' '.join(build_info.command))}`",
-        f"- Binary: `{_one_line(str(build_info.binary_path))}`",
-        f"- Version: `{_one_line(build_info.version)}`",
-        f"- Git commit: `{_one_line(str(build_info.git_commit))}`",
-        f"- Verified: `{verified}`",
-        "",
-    ]
-
-
-def _evidence_links(result: RunResult) -> str:
-    links: list[str] = []
-    for key in (
-        "screenshot",
-        "visual_diff",
-        "visual_baseline",
-        "video",
-        "cast",
-        "screen_text",
-        "step_screenshots",
-    ):
-        value = result.artifacts.get(key)
-        if value:
-            links.append(f"[{key}]({value})")
-    return " / ".join(links) if links else "-"
-
-
-def _detail(result: RunResult) -> str:
-    status = "PASS" if result.passed else "FAIL"
-    lines = [
-        f"<details><summary>{status} {result.recipe_name} [{result.renderer}]</summary>",
-        "",
-        "### Assertions",
-        "",
-    ]
-    for assertion in result.assertions:
-        mark = "PASS" if assertion.passed else "FAIL"
-        lines.append(f"- {mark} `{assertion.name}` - {assertion.detail}")
-    lines.extend(["", "### Steps", ""])
-    for step in result.steps:
-        mark = "PASS" if step.passed else "FAIL"
-        lines.append(f"- {mark} `{step.name}` - {step.detail}")
-    lines.extend(["", "</details>"])
-    return "\n".join(lines)
-
-
-def _one_line(value: str) -> str:
-    return " / ".join(part.strip() for part in value.splitlines() if part.strip())

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -58,26 +58,10 @@ BUILTIN_DEFAULTS: dict[str, Any] = {
         "volumes": [{"host": ".", "container": "/workspace"}],
         "env": {},
     },
-    "defaults": {
-        "timeout_seconds": 30.0,
-        "cols": 100,
-        "rows": 30,
-        "video_fps": 60,
-        "out_dir": ".termproof/runs",
-    },
 }
 
 
 # -- config model -----------------------------------------------------------
-
-@dataclass(frozen=True)
-class GlobalDefaults:
-    timeout_seconds: float = 30.0
-    cols: int = 100
-    rows: int = 30
-    video_fps: int = 60
-    out_dir: str = ".termproof/runs"
-
 
 @dataclass(frozen=True)
 class DockerBackendConfig:
@@ -100,7 +84,6 @@ class VerifierConfig:
     video_backends: dict[str, str]
     session_backend: str
     docker: DockerBackendConfig
-    defaults: GlobalDefaults
 
     @classmethod
     def builtin(cls) -> "VerifierConfig":
@@ -161,7 +144,6 @@ def load_config(
 # -- internal helpers --------------------------------------------------------
 
 def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
-    defaults_raw = data.get("defaults", {})
     docker_raw = data.get("docker", {})
     docker_volumes = docker_raw.get("volumes", [{"host": ".", "container": "/workspace"}])
     return VerifierConfig(
@@ -181,13 +163,6 @@ def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
                 str(key): str(value)
                 for key, value in dict(docker_raw.get("env", {})).items()
             },
-        ),
-        defaults=GlobalDefaults(
-            timeout_seconds=float(defaults_raw.get("timeout_seconds", 30.0)),
-            cols=int(defaults_raw.get("cols", 100)),
-            rows=int(defaults_raw.get("rows", 30)),
-            video_fps=int(defaults_raw.get("video_fps", 60)),
-            out_dir=str(defaults_raw.get("out_dir", ".termproof/runs")),
         ),
     )
 

--- a/termproof/report.py
+++ b/termproof/report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .before_after import BeforeAfterResult
 from .build_info import BuildInfo
 from .models import RunResult
+from .report_helpers import _build_info_lines, _detail, _evidence_links
 
 
 class ReportGenerator:
@@ -37,58 +38,3 @@ class ReportGenerator:
         for result in results:
             lines.extend(["", _detail(result).rstrip()])
         return "\n".join(lines) + "\n"
-
-
-def _build_info_lines(build_info: BuildInfo) -> list[str]:
-    verified = "yes" if build_info.verify_provenance() else "no"
-    return [
-        "## Build Provenance",
-        "",
-        f"- Mode: `{build_info.mode}`",
-        f"- Command: `{_one_line(' '.join(build_info.command))}`",
-        f"- Binary: `{_one_line(str(build_info.binary_path))}`",
-        f"- Version: `{_one_line(build_info.version)}`",
-        f"- Git commit: `{_one_line(str(build_info.git_commit))}`",
-        f"- Verified: `{verified}`",
-        "",
-    ]
-
-
-def _evidence_links(result: RunResult) -> str:
-    links: list[str] = []
-    for key in (
-        "screenshot",
-        "visual_diff",
-        "visual_baseline",
-        "video",
-        "cast",
-        "screen_text",
-        "step_screenshots",
-    ):
-        value = result.artifacts.get(key)
-        if value:
-            links.append(f"[{key}]({value})")
-    return " / ".join(links) if links else "-"
-
-
-def _detail(result: RunResult) -> str:
-    status = "PASS" if result.passed else "FAIL"
-    lines = [
-        f"<details><summary>{status} {result.recipe_name} [{result.renderer}]</summary>",
-        "",
-        "### Assertions",
-        "",
-    ]
-    for assertion in result.assertions:
-        mark = "PASS" if assertion.passed else "FAIL"
-        lines.append(f"- {mark} `{assertion.name}` - {assertion.detail}")
-    lines.extend(["", "### Steps", ""])
-    for step in result.steps:
-        mark = "PASS" if step.passed else "FAIL"
-        lines.append(f"- {mark} `{step.name}` - {step.detail}")
-    lines.extend(["", "</details>"])
-    return "\n".join(lines)
-
-
-def _one_line(value: str) -> str:
-    return " / ".join(part.strip() for part in value.splitlines() if part.strip())

--- a/termproof/report_helpers.py
+++ b/termproof/report_helpers.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from .build_info import BuildInfo
+from .models import RunResult
+
+
+def _build_info_lines(build_info: BuildInfo) -> list[str]:
+    verified = "yes" if build_info.verify_provenance() else "no"
+    return [
+        "## Build Provenance",
+        "",
+        f"- Mode: `{build_info.mode}`",
+        f"- Command: `{_one_line(' '.join(build_info.command))}`",
+        f"- Binary: `{_one_line(str(build_info.binary_path))}`",
+        f"- Version: `{_one_line(build_info.version)}`",
+        f"- Git commit: `{_one_line(str(build_info.git_commit))}`",
+        f"- Verified: `{verified}`",
+        "",
+    ]
+
+
+def _evidence_links(result: RunResult) -> str:
+    links: list[str] = []
+    for key in (
+        "screenshot",
+        "visual_diff",
+        "visual_baseline",
+        "video",
+        "cast",
+        "screen_text",
+        "step_screenshots",
+    ):
+        value = result.artifacts.get(key)
+        if value:
+            links.append(f"[{key}]({value})")
+    return " / ".join(links) if links else "-"
+
+
+def _detail(result: RunResult) -> str:
+    status = "PASS" if result.passed else "FAIL"
+    lines = [
+        f"<details><summary>{status} {result.recipe_name} [{result.renderer}]</summary>",
+        "",
+        "### Assertions",
+        "",
+    ]
+    for assertion in result.assertions:
+        mark = "PASS" if assertion.passed else "FAIL"
+        lines.append(f"- {mark} `{assertion.name}` - {assertion.detail}")
+    lines.extend(["", "### Steps", ""])
+    for step in result.steps:
+        mark = "PASS" if step.passed else "FAIL"
+        lines.append(f"- {mark} `{step.name}` - {step.detail}")
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
+
+
+def _one_line(value: str) -> str:
+    return " / ".join(part.strip() for part in value.splitlines() if part.strip())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,9 @@ class CliTest(unittest.TestCase):
                 encoding="utf-8",
             )
             config_path = root / "explicit-config.yaml"
-            config_path.write_text("defaults:\n  rows: 77\n", encoding="utf-8")
+            config_path.write_text(
+                "docker:\n  image: explicit-image\n", encoding="utf-8"
+            )
             result = RunResult(
                 recipe_name="configured-run",
                 passed=True,
@@ -75,7 +77,8 @@ class CliTest(unittest.TestCase):
 
             self.assertEqual(0, exit_code)
             self.assertEqual(
-                77, runner_class.call_args.kwargs["config"].defaults.rows
+                "explicit-image",
+                runner_class.call_args.kwargs["config"].docker.image,
             )
 
     def test_xml_path_writes_junit_xml_to_explicit_path(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from termproof.config import (
     BUILTIN_DEFAULTS,
     DockerBackendConfig,
-    GlobalDefaults,
     VerifierConfig,
     load_config,
 )
@@ -21,10 +20,9 @@ class ConfigTest(unittest.TestCase):
         self.assertIn("send_text", config.steps)
         self.assertIn("output_contains", config.assertions)
         self.assertIn("exit_code", config.assertions)
-        self.assertIsInstance(config.defaults, GlobalDefaults)
         self.assertIsInstance(config.docker, DockerBackendConfig)
-        self.assertEqual(config.defaults.timeout_seconds, 30.0)
-        self.assertEqual(config.defaults.cols, 100)
+        self.assertEqual(config.docker.image, "")
+        self.assertEqual(config.docker.workdir, "/workspace")
 
     def test_load_config_returns_builtin_when_no_files_exist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -39,16 +37,16 @@ class ConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             user_yaml = tmp + "/user.yaml"
             Path(user_yaml).write_text(
-                "defaults:\n  timeout_seconds: 60\n",
+                "docker:\n  image: user-image\n",
                 encoding="utf-8",
             )
             config = load_config(
                 project_path=Path(tmp),
                 user_path=Path(user_yaml),
             )
-            self.assertEqual(config.defaults.timeout_seconds, 60.0)
-            # other defaults unchanged
-            self.assertEqual(config.defaults.cols, 100)
+            self.assertEqual(config.docker.image, "user-image")
+            # other docker settings unchanged
+            self.assertEqual(config.docker.workdir, "/workspace")
 
     def test_load_config_cascades_project_over_user_and_builtin(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -57,21 +55,23 @@ class ConfigTest(unittest.TestCase):
             config_dir = project_dir / ".termproof"
             config_dir.mkdir()
             (config_dir / "config.yaml").write_text(
-                "defaults:\n  timeout_seconds: 90\n  cols: 120\n",
+                "docker:\n  image: project-image\n  workdir: /project\n",
                 encoding="utf-8",
             )
             user_yaml = tmp + "/user.yaml"
             Path(user_yaml).write_text(
-                "defaults:\n  timeout_seconds: 60\n  rows: 40\n",
+                "docker:\n  image: user-image\n  env:\n    FROM_USER: \"1\"\n",
                 encoding="utf-8",
             )
             config = load_config(
                 project_path=project_dir,
                 user_path=Path(user_yaml),
             )
-            self.assertEqual(config.defaults.timeout_seconds, 90.0)  # project wins
-            self.assertEqual(config.defaults.cols, 120)  # project wins
-            self.assertEqual(config.defaults.rows, 40)  # user supplies, project doesn't
+            self.assertEqual(config.docker.image, "project-image")  # project wins
+            self.assertEqual(config.docker.workdir, "/project")  # project wins
+            self.assertEqual(
+                config.docker.env, {"FROM_USER": "1"}
+            )  # user supplies, project doesn't
 
     def test_custom_step_registration_in_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_termproof_rename.py
+++ b/tests/test_termproof_rename.py
@@ -32,28 +32,33 @@ class TermProofRenameTest(unittest.TestCase):
                 directory.mkdir(parents=True)
 
             (legacy_user / "config.yaml").write_text(
-                "defaults:\n  timeout_seconds: 10\n  rows: 40\n",
+                "docker:\n  workdir: /legacy-user\n  image: persist-image\n",
                 encoding="utf-8",
             )
             (current_user / "config.yaml").write_text(
-                "defaults:\n  timeout_seconds: 20\n",
+                "docker:\n  workdir: /current-user\n",
                 encoding="utf-8",
             )
             (legacy_project / "config.yaml").write_text(
-                "defaults:\n  cols: 110\n",
+                "docker:\n  volumes:\n    - host: legacy\n      container: /x\n",
                 encoding="utf-8",
             )
             (current_project / "config.yaml").write_text(
-                "defaults:\n  cols: 120\n",
+                "docker:\n  volumes:\n    - host: current\n      container: /x\n",
                 encoding="utf-8",
             )
 
             with patch("termproof.config.Path.home", return_value=home):
                 config = load_config(project_path=project)
 
-            self.assertEqual(20.0, config.defaults.timeout_seconds)
-            self.assertEqual(40, config.defaults.rows)
-            self.assertEqual(120, config.defaults.cols)
+            # current user config wins over legacy user config
+            self.assertEqual("/current-user", config.docker.workdir)
+            # legacy user supplies a value neither newer file overrides
+            self.assertEqual("persist-image", config.docker.image)
+            # current project config wins over legacy project config
+            self.assertEqual(
+                [{"host": "current", "container": "/x"}], config.docker.volumes
+            )
 
     def test_legacy_plugin_references_resolve_through_compatibility_alias(self) -> None:
         from termproof.config import VerifierConfig


### PR DESCRIPTION
[Assisted by CLAUDE]

This is a **behavior-preserving structural change** (Tidy First — no behavior changes). It covers the safe subset of the design-consolidation work in #79 and #80.

## What changed

### (B) Deduplicate report helpers (#80, partial)
`termproof/report.py` and `termproof/builtin_reporters.py` contained four **byte-identical** private helpers: `_build_info_lines`, `_evidence_links`, `_detail`, and `_one_line`. All four were verified identical and extracted verbatim into a new small module `termproof/report_helpers.py`; both files now import them. Rendered Markdown output is unchanged (covered by existing tests, e.g. `tests/test_stack_design.py`).

### (A) Remove dead `GlobalDefaults` config (#79)
Verified that `config.defaults` (a `GlobalDefaults` with `timeout_seconds`/`cols`/`rows`/`video_fps`/`out_dir`) is **never read by production code** — `runner.py` and `cli.py` use their own hardcoded defaults; the only references were in tests. Removed:
- the `GlobalDefaults` dataclass
- the `defaults` field on `VerifierConfig`
- its population in `_from_mapping`
- the `"defaults": {...}` block in `BUILTIN_DEFAULTS`

Tests that referenced `config.defaults` used it only as a proxy for the loader's cascade / deep-merge behavior. They were rewritten to exercise that same behavior via the live `docker` config field (`test_config.py`, `test_cli.py`, `test_termproof_rename.py`).

## Validation
- `uv run python -m unittest discover -s tests` — all 221 tests pass.
- `uv run python -c "import termproof"` — OK.

## Deliberately deferred (need separate review)
- Result (de)serialization consolidation across `run_cache` / `ci_evidence` / `models`.
- Recipe-validation triple source of truth.
- The `ExecutionMode` private-internal refactor (#78).

Closes #79
Closes #80
