### PR TITLE
ci: deploy VitePress docs to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -20,6 +20,13 @@ on:
 permissions:
   contents: read
 
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do not cancel in-progress runs so a deploy
+# finishes cleanly.
+concurrency:
+  group: "docs-site-pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build VitePress docs
@@ -34,6 +41,10 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Configure Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+
       - name: Install docs dependencies
         run: npm install --prefix docs-site --no-package-lock
 
@@ -46,3 +57,27 @@ jobs:
           name: termproof-docs-site
           path: docs-site/.vitepress/dist
           if-no-files-found: error
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-site/.vitepress/dist
+
+  # Deploy only on push to main (or manual dispatch); pull requests build only.
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   title: "TermProof",
   description: "Evidence-first verification for terminal and TUI applications.",
+  base: "/termproof/",
   cleanUrls: true,
   themeConfig: {
     nav: [


### PR DESCRIPTION
[Assisted by CLAUDE]

## What & why

The `Documentation Site` workflow (`.github/workflows/docs-site.yml`) previously built the VitePress site and uploaded a plain build artifact, but it never deployed anywhere, so `md-mt.github.io/termproof/` had nothing published. This wires up the official GitHub Pages deploy actions so the VitePress site actually ships on every push to `main`. We are standardizing on VitePress as the docs site.

## Changes

1. **Deploy VitePress to GitHub Pages** (`docs-site.yml`):
   - Added `actions/configure-pages@v5` (build job) and `actions/upload-pages-artifact@v3` pointing at the VitePress output `docs-site/.vitepress/dist`.
   - Added a separate `deploy` job using `actions/deploy-pages@v4` with the `github-pages` environment and `permissions: pages: write, id-token: write`.
   - Deploy runs **only** on push to `main` (and `workflow_dispatch`); on `pull_request` the workflow **builds only** (the Pages steps and deploy job are gated with `if: github.event_name != 'pull_request'`).
   - Kept the existing Node 22 build and the pre-existing `termproof-docs-site` artifact upload intact.
   - Added a `concurrency` group (`docs-site-pages`, `cancel-in-progress: false`) — deliberately a **distinct** name from `pages.yml`'s `pages` group so the two workflows do not serialize/cancel each other.

2. **VitePress `base` path** (`docs-site/.vitepress/config.mts`):
   - Set `base: "/termproof/"`. A project Pages site is served under `/termproof/`, so without this all assets 404. Verified the built `index.html` now references `/termproof/assets/...`.

## No deploy conflict with pages.yml

`.github/workflows/pages.yml` deploys a *different* hand-written static site and its `deploy` job is gated behind `vars.ENABLE_PAGES == 'true'`. That gate is left **unchanged / off**, so pages.yml will not deploy to Pages and there is no conflict — only `docs-site.yml` publishes to Pages. (No changes were made to `pages.yml`.)

## Manual steps required at merge time

These are intentionally **not** done in this PR:
- **Enable Pages**: Settings -> Pages -> Source: **GitHub Actions**.
- **Set the repo homepage URL** to `https://md-mt.github.io/termproof/` (`homepageUrl` is currently empty).

## Validation

- YAML parses (`yaml.safe_load` on `docs-site.yml` — OK).
- Built locally with Node 24 / npm 11: `npm install --prefix docs-site --no-package-lock` then `npm run --prefix docs-site docs:build` — build completed successfully and output assets are prefixed with `/termproof/`.
- No deploy was run.

Closes #83
