### PR TITLE
refactor: expose stable public runner surface for ExecutionMode plugins

### DIFF
--- a/docs/plugin-protocols.md
+++ b/docs/plugin-protocols.md
@@ -19,6 +19,23 @@ TermProof exposes stable plugin protocols from `termproof.protocols`.
 
 `ScreenRenderer` plugins can optionally set `extension = "png"` (or another file extension) so evidence artifacts use that screenshot filename suffix.
 
+## ExecutionMode runner surface
+
+An `ExecutionMode.execute` implementation receives a `VerificationRunner` and
+should only call its stable public methods rather than any underscore-prefixed
+internals:
+
+| Method | Purpose |
+| --- | --- |
+| `run_pty(recipe, run_dir) -> tuple[list[StepResult], str, int | None, str]` | Run scripted steps interactively over a PTY session. |
+| `run_process(recipe, run_dir) -> tuple[list[StepResult], str, int | None, str]` | Run the command to completion, then replay the cast. |
+| `run_agent_driven(recipe, run_dir) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]` | Delegate execution to the configured agent runner. |
+| `evaluate_assertions(recipe, screen, raw_output, exit_code) -> list[AssertionResult]` | Evaluate a recipe's assertions against captured output. |
+
+The former private methods (`_run_pty`, `_run_process`, `_run_agent_driven`,
+`_evaluate_assertions`) remain as deprecated aliases that delegate to the public
+methods, but new execution modes should use the public surface above.
+
 ## Import policy
 
 New plugins should import protocols from `termproof.protocols`:

--- a/termproof/builtin_modes.py
+++ b/termproof/builtin_modes.py
@@ -18,8 +18,8 @@ class ScriptedPtyMode:
         recipe: Recipe,
         run_dir: Path,
     ) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]:
-        steps, raw_output, exit_code, screen = runner._run_pty(recipe, run_dir)
-        assertions = runner._evaluate_assertions(recipe, screen, raw_output, exit_code)
+        steps, raw_output, exit_code, screen = runner.run_pty(recipe, run_dir)
+        assertions = runner.evaluate_assertions(recipe, screen, raw_output, exit_code)
         return steps, assertions, raw_output, exit_code, screen
 
 
@@ -34,8 +34,8 @@ class ScriptedProcessMode:
         recipe: Recipe,
         run_dir: Path,
     ) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]:
-        steps, raw_output, exit_code, screen = runner._run_process(recipe, run_dir)
-        assertions = runner._evaluate_assertions(recipe, screen, raw_output, exit_code)
+        steps, raw_output, exit_code, screen = runner.run_process(recipe, run_dir)
+        assertions = runner.evaluate_assertions(recipe, screen, raw_output, exit_code)
         return steps, assertions, raw_output, exit_code, screen
 
 
@@ -50,4 +50,4 @@ class AgentDrivenMode:
         recipe: Recipe,
         run_dir: Path,
     ) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]:
-        return runner._run_agent_driven(recipe, run_dir)
+        return runner.run_agent_driven(recipe, run_dir)

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -224,7 +224,12 @@ class VerificationRunner:
             recipe.rows,
         ) as session:
             for index, step in enumerate(recipe.steps, start=1):
-                step_result = self._run_step(session, index, step)
+                try:
+                    step_result = self._run_step(session, index, step)
+                except Exception as exc:
+                    action_name = step["action"]
+                    name = step.get("name", f"{index}:{action_name}")
+                    step_result = StepResult(name, False, str(exc), session.screen)
                 steps.append(step_result)
                 if not step_result.passed:
                     break

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -197,7 +197,7 @@ class VerificationRunner:
         write_result_files(run_dir, result)
         return result
 
-    def _run_agent_driven(
+    def run_agent_driven(
         self,
         recipe: Recipe,
         run_dir: Path,
@@ -208,7 +208,7 @@ class VerificationRunner:
             agent_runner = CodexCliAgentRunner.from_recipe(recipe)
         return AgentDrivenRunner(agent_runner).run(recipe, run_dir)
 
-    def _run_pty(
+    def run_pty(
         self,
         recipe: Recipe,
         run_dir: Path,
@@ -239,7 +239,7 @@ class VerificationRunner:
                 session.wait_for_idle(0.5, min(3, recipe.timeout_seconds))
             return steps, session.raw_output, session.exit_code, session.screen
 
-    def _run_process(
+    def run_process(
         self,
         recipe: Recipe,
         run_dir: Path,
@@ -286,7 +286,7 @@ class VerificationRunner:
             raise ValueError(f"unknown step action: {action_name}")
         return action.execute(session, step, index)
 
-    def _evaluate_assertions(
+    def evaluate_assertions(
         self,
         recipe: Recipe,
         screen: str,
@@ -300,6 +300,41 @@ class VerificationRunner:
             self._evaluate_assertion(recipe, assertion, screen, raw_output, exit_code)
             for assertion in assertions
         ]
+
+    # -- deprecated private aliases (retained for backward compatibility) -----
+    # The public ``run_*`` / ``evaluate_assertions`` methods above are the
+    # stable surface for ExecutionMode plugins. These underscore-prefixed
+    # aliases delegate to them so existing callers keep working.
+
+    def _run_agent_driven(
+        self,
+        recipe: Recipe,
+        run_dir: Path,
+    ) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]:
+        return self.run_agent_driven(recipe, run_dir)
+
+    def _run_pty(
+        self,
+        recipe: Recipe,
+        run_dir: Path,
+    ) -> tuple[list[StepResult], str, int | None, str]:
+        return self.run_pty(recipe, run_dir)
+
+    def _run_process(
+        self,
+        recipe: Recipe,
+        run_dir: Path,
+    ) -> tuple[list[StepResult], str, int | None, str]:
+        return self.run_process(recipe, run_dir)
+
+    def _evaluate_assertions(
+        self,
+        recipe: Recipe,
+        screen: str,
+        raw_output: str,
+        exit_code: int | None,
+    ) -> list[AssertionResult]:
+        return self.evaluate_assertions(recipe, screen, raw_output, exit_code)
 
     def _evaluate_assertion(
         self,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -106,6 +106,58 @@ class RunnerTest(unittest.TestCase):
         backend = runner.video_backend_registry.get("agg_ffmpeg")
         self.assertIsNotNone(backend)
 
+    def test_run_pty_converts_step_exception_to_failed_result(self) -> None:
+        """A PTY step that raises yields a failed StepResult, not an abort.
+
+        Mirrors the process-mode behavior. Uses a fake session backend so the
+        test does not need asciinema/ffmpeg to exercise the error-wrapping path.
+        """
+
+        class _FakeSession:
+            screen = "screen-snapshot"
+            raw_output = "raw"
+            exit_code = 0
+
+            def __enter__(self) -> "_FakeSession":
+                return self
+
+            def __exit__(self, *exc: object) -> bool:
+                return False
+
+            def press(self, key: str) -> None:
+                # Mirror the real session: unknown key raises KeyError.
+                raise KeyError(key.lower())
+
+            def wait_for_exit(self, timeout_seconds: float) -> None:
+                return None
+
+            def wait_for_idle(self, stable: float, timeout: float) -> bool:
+                return True
+
+        class _FakeBackend:
+            def create_session(self, *args: object, **kwargs: object) -> "_FakeSession":
+                return _FakeSession()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = VerificationRunner()
+            runner.session_backend = _FakeBackend()
+            recipe = Recipe(
+                name="pty-error",
+                command=CommandSpec(
+                    argv=[sys.executable, "-c", "pass"],
+                    pty=True,
+                ),
+                steps=[{"action": "press", "key": "not-a-real-key"}],
+                expect_exit_code=None,
+            )
+            steps, raw_output, exit_code, screen = runner._run_pty(
+                recipe, Path(tmp)
+            )
+            self.assertEqual(len(steps), 1)
+            self.assertFalse(steps[0].passed)
+            self.assertIn("not-a-real-key", steps[0].detail)
+            self.assertEqual(steps[0].screen, "screen-snapshot")
+
     def test_runner_run_uses_video_backend(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             recipe = Recipe(


### PR DESCRIPTION
[Assisted by CLAUDE]

Behavior-preserving structural change (Tidy First). **Stacked on #85** — base branch is `fix/pty-step-error-symmetry`, not `main`, because #85 already modified `_run_pty` in `termproof/runner.py`. Review/merge #85 first.

## Problem (Closes #78)
`ExecutionMode` plugins in `termproof/builtin_modes.py` reached into private runner internals (`runner._run_pty`, `runner._run_process`, `runner._run_agent_driven`, `runner._evaluate_assertions`), coupling any third-party execution mode to underscore-prefixed private methods.

## Change
- Promoted the operations execution modes legitimately need into a stable public surface on `VerificationRunner`: `run_pty`, `run_process`, `run_agent_driven`, `evaluate_assertions`.
- The original private methods now remain as thin deprecated aliases that delegate to the public ones, so nothing else breaks (e.g. `tests/test_runner.py` still calls `runner._run_pty`).
- Updated `builtin_modes.py` to call ONLY the public surface.
- Documented the public ExecutionMode runner surface in `docs/plugin-protocols.md`.

No protocol signature changes. Behavior is identical.

## Validation
- `uv sync` + `uv run python -c "import termproof"` — ok
- `uv run python -m unittest tests.test_runner tests.test_protocols tests.test_cli` — 30 passed
- Full suite `uv run python -m unittest discover -s tests` — 222 passed, 0 failures