### PR TITLE
refactor: unify RunResult (de)serialization and validate recipes against canonical JSON schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ termproof = "termproof.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["termproof"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"docs/recipe-schema-v1.json" = "termproof/_resources/recipe-schema-v1.json"
+
 [tool.hatch.build.hooks.custom]
 path = "hatch_build.py"
 

--- a/termproof/builtin_reporters.py
+++ b/termproof/builtin_reporters.py
@@ -7,6 +7,7 @@ from .before_after import BeforeAfterResult
 from .build_info import BuildInfo
 from .models import RunResult
 from .protocols import Reporter
+from .report_helpers import _build_info_lines, _detail, _evidence_links
 
 
 # XML 1.0 spec: allowed characters are:
@@ -208,58 +209,3 @@ class JUnitXmlReporter:
 
         xml_body = ET.tostring(testsuites, encoding="unicode")
         return f'<?xml version="1.0" encoding="UTF-8"?>\n{xml_body}\n'
-
-
-def _build_info_lines(build_info: BuildInfo) -> list[str]:
-    verified = "yes" if build_info.verify_provenance() else "no"
-    return [
-        "## Build Provenance",
-        "",
-        f"- Mode: `{build_info.mode}`",
-        f"- Command: `{_one_line(' '.join(build_info.command))}`",
-        f"- Binary: `{_one_line(str(build_info.binary_path))}`",
-        f"- Version: `{_one_line(build_info.version)}`",
-        f"- Git commit: `{_one_line(str(build_info.git_commit))}`",
-        f"- Verified: `{verified}`",
-        "",
-    ]
-
-
-def _evidence_links(result: RunResult) -> str:
-    links: list[str] = []
-    for key in (
-        "screenshot",
-        "visual_diff",
-        "visual_baseline",
-        "video",
-        "cast",
-        "screen_text",
-        "step_screenshots",
-    ):
-        value = result.artifacts.get(key)
-        if value:
-            links.append(f"[{key}]({value})")
-    return " / ".join(links) if links else "-"
-
-
-def _detail(result: RunResult) -> str:
-    status = "PASS" if result.passed else "FAIL"
-    lines = [
-        f"<details><summary>{status} {result.recipe_name} [{result.renderer}]</summary>",
-        "",
-        "### Assertions",
-        "",
-    ]
-    for assertion in result.assertions:
-        mark = "PASS" if assertion.passed else "FAIL"
-        lines.append(f"- {mark} `{assertion.name}` - {assertion.detail}")
-    lines.extend(["", "### Steps", ""])
-    for step in result.steps:
-        mark = "PASS" if step.passed else "FAIL"
-        lines.append(f"- {mark} `{step.name}` - {step.detail}")
-    lines.extend(["", "</details>"])
-    return "\n".join(lines)
-
-
-def _one_line(value: str) -> str:
-    return " / ".join(part.strip() for part in value.splitlines() if part.strip())

--- a/termproof/ci_evidence.py
+++ b/termproof/ci_evidence.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from .before_after import build_before_after
 from .evidence_publish import rewrite_screenshot_links
-from .models import AssertionResult, RunResult, StepResult
+from .models import RunResult
 
 DEFAULT_RECEIPT = Path("docs/ci/evidence-receipt.json")
 
@@ -91,7 +91,7 @@ def load_results(root: Path) -> list[RunResult]:
     if not root.exists():
         return []
     return [
-        _result_from_mapping(json.loads(path.read_text(encoding="utf-8")))
+        RunResult.from_dict(json.loads(path.read_text(encoding="utf-8")))
         for path in sorted(root.rglob("result.json"))
     ]
 
@@ -174,22 +174,6 @@ def _truncate(text: str, limit: int) -> str:
     return (
         f"{text[:limit]}\n\n_Report truncated. Download the "
         "`termproof-ci-evidence` artifact from the run for the full report._"
-    )
-
-
-def _result_from_mapping(data: dict[str, Any]) -> RunResult:
-    return RunResult(
-        recipe_name=data["recipe_name"],
-        passed=bool(data["passed"]),
-        exit_code=data["exit_code"],
-        duration_seconds=float(data["duration_seconds"]),
-        priority=data["priority"],
-        execution=data["execution"],
-        renderer=data["renderer"],
-        score=float(data["score"]),
-        steps=[StepResult(**step) for step in data.get("steps", [])],
-        assertions=[AssertionResult(**assertion) for assertion in data.get("assertions", [])],
-        artifacts=dict(data.get("artifacts", {})),
     )
 
 

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -58,26 +58,10 @@ BUILTIN_DEFAULTS: dict[str, Any] = {
         "volumes": [{"host": ".", "container": "/workspace"}],
         "env": {},
     },
-    "defaults": {
-        "timeout_seconds": 30.0,
-        "cols": 100,
-        "rows": 30,
-        "video_fps": 60,
-        "out_dir": ".termproof/runs",
-    },
 }
 
 
 # -- config model -----------------------------------------------------------
-
-@dataclass(frozen=True)
-class GlobalDefaults:
-    timeout_seconds: float = 30.0
-    cols: int = 100
-    rows: int = 30
-    video_fps: int = 60
-    out_dir: str = ".termproof/runs"
-
 
 @dataclass(frozen=True)
 class DockerBackendConfig:
@@ -100,7 +84,6 @@ class VerifierConfig:
     video_backends: dict[str, str]
     session_backend: str
     docker: DockerBackendConfig
-    defaults: GlobalDefaults
 
     @classmethod
     def builtin(cls) -> "VerifierConfig":
@@ -161,7 +144,6 @@ def load_config(
 # -- internal helpers --------------------------------------------------------
 
 def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
-    defaults_raw = data.get("defaults", {})
     docker_raw = data.get("docker", {})
     docker_volumes = docker_raw.get("volumes", [{"host": ".", "container": "/workspace"}])
     return VerifierConfig(
@@ -181,13 +163,6 @@ def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
                 str(key): str(value)
                 for key, value in dict(docker_raw.get("env", {})).items()
             },
-        ),
-        defaults=GlobalDefaults(
-            timeout_seconds=float(defaults_raw.get("timeout_seconds", 30.0)),
-            cols=int(defaults_raw.get("cols", 100)),
-            rows=int(defaults_raw.get("rows", 30)),
-            video_fps=int(defaults_raw.get("video_fps", 60)),
-            out_dir=str(defaults_raw.get("out_dir", ".termproof/runs")),
         ),
     )
 

--- a/termproof/models.py
+++ b/termproof/models.py
@@ -45,12 +45,35 @@ class StepResult:
     detail: str
     screen: str
 
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "passed": self.passed,
+            "detail": self.detail,
+            "screen": self.screen,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StepResult:
+        return cls(**data)
+
 
 @dataclass(frozen=True)
 class AssertionResult:
     name: str
     passed: bool
     detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "passed": self.passed,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AssertionResult:
+        return cls(**data)
 
 
 @dataclass(frozen=True)
@@ -77,10 +100,29 @@ class RunResult:
             "execution": self.execution,
             "renderer": self.renderer,
             "score": self.score,
-            "steps": [step.__dict__ for step in self.steps],
-            "assertions": [assertion.__dict__ for assertion in self.assertions],
+            "steps": [step.to_dict() for step in self.steps],
+            "assertions": [assertion.to_dict() for assertion in self.assertions],
             "artifacts": self.artifacts,
         }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunResult:
+        return cls(
+            recipe_name=data["recipe_name"],
+            passed=bool(data["passed"]),
+            exit_code=data.get("exit_code"),
+            duration_seconds=float(data["duration_seconds"]),
+            priority=data["priority"],
+            execution=data["execution"],
+            renderer=data["renderer"],
+            score=float(data["score"]),
+            steps=[StepResult.from_dict(step) for step in data.get("steps", [])],
+            assertions=[
+                AssertionResult.from_dict(assertion)
+                for assertion in data.get("assertions", [])
+            ],
+            artifacts=dict(data.get("artifacts", {})),
+        )
 
 
 def recipe_from_mapping(data: dict[str, Any]) -> Recipe:

--- a/termproof/recipe_schema.py
+++ b/termproof/recipe_schema.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
+import jsonschema
+
 from .config import VerifierConfig
 from .models import RECIPE_VERSION
+
+_SCHEMA_RESOURCE = "recipe-schema-v1.json"
 
 
 @dataclass(frozen=True)
@@ -18,6 +24,38 @@ class ValidationIssue:
 
 def has_errors(issues: list[ValidationIssue]) -> bool:
     return any(issue.severity == "error" for issue in issues)
+
+
+@lru_cache(maxsize=1)
+def load_recipe_schema() -> dict[str, Any]:
+    """Load the canonical recipe JSON schema shipped as a package resource."""
+    resource = resources.files("termproof").joinpath("_resources", _SCHEMA_RESOURCE)
+    if resource.is_file():
+        return json.loads(resource.read_text(encoding="utf-8"))
+    # Source-tree fallback: the canonical schema lives under docs/ and is only
+    # force-included into the built wheel under termproof/_resources/.
+    docs_schema = Path(__file__).resolve().parent.parent / "docs" / _SCHEMA_RESOURCE
+    return json.loads(docs_schema.read_text(encoding="utf-8"))
+
+
+@lru_cache(maxsize=1)
+def _schema_validator() -> jsonschema.protocols.Validator:
+    schema = load_recipe_schema()
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    return validator_cls(schema)
+
+
+def _issue_path(error: jsonschema.ValidationError) -> str:
+    parts: list[str] = []
+    for part in error.absolute_path:
+        if isinstance(part, int):
+            parts.append(f"[{part}]")
+        elif parts:
+            parts.append(f".{part}")
+        else:
+            parts.append(str(part))
+    return "".join(parts) or "$"
 
 
 def validate_recipe_file(path: Path, config: VerifierConfig) -> list[ValidationIssue]:
@@ -35,6 +73,18 @@ def validate_recipe_mapping(
     config: VerifierConfig,
 ) -> list[ValidationIssue]:
     issues: list[ValidationIssue] = []
+    _validate_recipe_version(data, issues)
+    for error in _schema_validator().iter_errors(data):
+        # recipe_version carries a legacy-warning nuance that JSON Schema cannot
+        # express, so it is handled entirely by _validate_recipe_version above.
+        if list(error.absolute_path) == ["recipe_version"]:
+            continue
+        issues.append(ValidationIssue(_issue_path(error), error.message))
+    _validate_plugin_names(data, config, issues)
+    return issues
+
+
+def _validate_recipe_version(data: dict[str, Any], issues: list[ValidationIssue]) -> None:
     version = data.get("recipe_version")
     if version is None:
         issues.append(
@@ -47,164 +97,35 @@ def validate_recipe_mapping(
     elif not isinstance(version, int) or isinstance(version, bool) or version != RECIPE_VERSION:
         issues.append(ValidationIssue("recipe_version", "must be 1"))
 
-    _require_str(data, "name", issues)
-    _validate_command(data.get("command"), issues)
-    _validate_positive_number(data, "timeout_seconds", issues)
-    _validate_positive_int(data, "cols", issues)
-    _validate_positive_int(data, "rows", issues)
-    _validate_expect_exit_code(data.get("expect_exit_code"), issues)
-    _validate_optional_string(data, "priority", issues)
-    _validate_optional_string(data, "execution", issues)
-    _validate_optional_string(data, "determinism", issues)
-    _validate_string_list(data, "checks", issues)
-    _validate_string_list(data, "ci_paths", issues)
-    _validate_object(data, "operator", issues)
-    _validate_renderers(data.get("renderers"), issues)
-    _validate_steps(data.get("steps", []), config, issues)
-    _validate_assertions(data.get("assertions", []), config, issues)
-    return issues
 
-
-def _require_str(data: dict[str, Any], key: str, issues: list[ValidationIssue]) -> None:
-    value = data.get(key)
-    if not isinstance(value, str) or not value:
-        issues.append(ValidationIssue(key, "must be a non-empty string"))
-
-
-def _validate_optional_string(
+def _validate_plugin_names(
     data: dict[str, Any],
-    key: str,
-    issues: list[ValidationIssue],
-) -> None:
-    value = data.get(key)
-    if value is not None and not isinstance(value, str):
-        issues.append(ValidationIssue(key, "must be a string"))
-
-
-def _validate_command(value: Any, issues: list[ValidationIssue]) -> None:
-    if not isinstance(value, dict):
-        issues.append(ValidationIssue("command", "must be an object"))
-        return
-    argv = value.get("argv")
-    if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
-        issues.append(ValidationIssue("command.argv", "must be a non-empty list of strings"))
-    if value.get("cwd") is not None and not isinstance(value.get("cwd"), str):
-        issues.append(ValidationIssue("command.cwd", "must be a string"))
-    env = value.get("env", {})
-    if not isinstance(env, dict) or not all(
-        isinstance(key, str) and isinstance(item, str) for key, item in env.items()
-    ):
-        issues.append(ValidationIssue("command.env", "must be an object of string values"))
-    if value.get("pty") is not None and not isinstance(value.get("pty"), bool):
-        issues.append(ValidationIssue("command.pty", "must be true or false"))
-
-
-def _validate_positive_number(
-    data: dict[str, Any],
-    key: str,
-    issues: list[ValidationIssue],
-) -> None:
-    value = data.get(key)
-    if value is not None and (
-        not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0
-    ):
-        issues.append(ValidationIssue(key, "must be a positive number"))
-
-
-def _validate_positive_int(
-    data: dict[str, Any],
-    key: str,
-    issues: list[ValidationIssue],
-) -> None:
-    value = data.get(key)
-    if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
-        issues.append(ValidationIssue(key, "must be a positive integer"))
-
-
-def _validate_expect_exit_code(value: Any, issues: list[ValidationIssue]) -> None:
-    if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
-        issues.append(ValidationIssue("expect_exit_code", "must be an integer or null"))
-
-
-def _validate_string_list(
-    data: dict[str, Any],
-    key: str,
-    issues: list[ValidationIssue],
-) -> None:
-    value = data.get(key)
-    if value is not None and (
-        not isinstance(value, list) or not all(isinstance(item, str) for item in value)
-    ):
-        issues.append(ValidationIssue(key, "must be a list of strings"))
-
-
-def _validate_object(data: dict[str, Any], key: str, issues: list[ValidationIssue]) -> None:
-    value = data.get(key)
-    if value is not None and not isinstance(value, dict):
-        issues.append(ValidationIssue(key, "must be an object"))
-
-
-def _validate_renderers(value: Any, issues: list[ValidationIssue]) -> None:
-    if value is None:
-        return
-    if not isinstance(value, dict):
-        issues.append(ValidationIssue("renderers", "must be an object"))
-        return
-    for name, argv in value.items():
-        if not isinstance(name, str) or not isinstance(argv, list) or not all(
-            isinstance(item, str) for item in argv
-        ):
-            issues.append(ValidationIssue(f"renderers.{name}", "must be a list of strings"))
-
-
-def _validate_steps(
-    value: Any,
     config: VerifierConfig,
     issues: list[ValidationIssue],
 ) -> None:
-    if not isinstance(value, list):
-        issues.append(ValidationIssue("steps", "must be a list"))
-        return
-    for index, step in enumerate(value):
-        path = f"steps[{index}]"
-        if not isinstance(step, dict):
-            issues.append(ValidationIssue(path, "must be an object"))
-            continue
-        action = step.get("action")
-        if not isinstance(action, str):
-            issues.append(ValidationIssue(f"{path}.action", "must be a string"))
-        elif action not in config.steps:
-            issues.append(ValidationIssue(f"{path}.action", f"unknown step action {action!r}"))
-        _validate_step_timeout(step, path, issues)
-
-
-def _validate_step_timeout(
-    step: dict[str, Any],
-    path: str,
-    issues: list[ValidationIssue],
-) -> None:
-    value = step.get("timeout_seconds")
-    if value is not None and (
-        not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0
-    ):
-        issues.append(ValidationIssue(f"{path}.timeout_seconds", "must be a positive number"))
-
-
-def _validate_assertions(
-    value: Any,
-    config: VerifierConfig,
-    issues: list[ValidationIssue],
-) -> None:
-    if not isinstance(value, list):
-        issues.append(ValidationIssue("assertions", "must be a list"))
-        return
-    for index, assertion in enumerate(value):
-        path = f"assertions[{index}]"
-        if not isinstance(assertion, dict):
-            issues.append(ValidationIssue(path, "must be an object"))
-            continue
-        kind = assertion.get("type")
-        if not isinstance(kind, str):
-            issues.append(ValidationIssue(f"{path}.type", "must be a string"))
-        elif kind not in config.assertions:
-            issues.append(ValidationIssue(f"{path}.type", f"unknown assertion type {kind!r}"))
+    # Plugin-registry membership depends on runtime config and cannot be encoded
+    # in the static JSON Schema, so these checks stay in Python.
+    steps = data.get("steps")
+    if isinstance(steps, list):
+        for index, step in enumerate(steps):
+            if isinstance(step, dict):
+                action = step.get("action")
+                if isinstance(action, str) and action not in config.steps:
+                    issues.append(
+                        ValidationIssue(
+                            f"steps[{index}].action",
+                            f"unknown step action {action!r}",
+                        )
+                    )
+    assertions = data.get("assertions")
+    if isinstance(assertions, list):
+        for index, assertion in enumerate(assertions):
+            if isinstance(assertion, dict):
+                kind = assertion.get("type")
+                if isinstance(kind, str) and kind not in config.assertions:
+                    issues.append(
+                        ValidationIssue(
+                            f"assertions[{index}].type",
+                            f"unknown assertion type {kind!r}",
+                        )
+                    )

--- a/termproof/report.py
+++ b/termproof/report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .before_after import BeforeAfterResult
 from .build_info import BuildInfo
 from .models import RunResult
+from .report_helpers import _build_info_lines, _detail, _evidence_links
 
 
 class ReportGenerator:
@@ -37,58 +38,3 @@ class ReportGenerator:
         for result in results:
             lines.extend(["", _detail(result).rstrip()])
         return "\n".join(lines) + "\n"
-
-
-def _build_info_lines(build_info: BuildInfo) -> list[str]:
-    verified = "yes" if build_info.verify_provenance() else "no"
-    return [
-        "## Build Provenance",
-        "",
-        f"- Mode: `{build_info.mode}`",
-        f"- Command: `{_one_line(' '.join(build_info.command))}`",
-        f"- Binary: `{_one_line(str(build_info.binary_path))}`",
-        f"- Version: `{_one_line(build_info.version)}`",
-        f"- Git commit: `{_one_line(str(build_info.git_commit))}`",
-        f"- Verified: `{verified}`",
-        "",
-    ]
-
-
-def _evidence_links(result: RunResult) -> str:
-    links: list[str] = []
-    for key in (
-        "screenshot",
-        "visual_diff",
-        "visual_baseline",
-        "video",
-        "cast",
-        "screen_text",
-        "step_screenshots",
-    ):
-        value = result.artifacts.get(key)
-        if value:
-            links.append(f"[{key}]({value})")
-    return " / ".join(links) if links else "-"
-
-
-def _detail(result: RunResult) -> str:
-    status = "PASS" if result.passed else "FAIL"
-    lines = [
-        f"<details><summary>{status} {result.recipe_name} [{result.renderer}]</summary>",
-        "",
-        "### Assertions",
-        "",
-    ]
-    for assertion in result.assertions:
-        mark = "PASS" if assertion.passed else "FAIL"
-        lines.append(f"- {mark} `{assertion.name}` - {assertion.detail}")
-    lines.extend(["", "### Steps", ""])
-    for step in result.steps:
-        mark = "PASS" if step.passed else "FAIL"
-        lines.append(f"- {mark} `{step.name}` - {step.detail}")
-    lines.extend(["", "</details>"])
-    return "\n".join(lines)
-
-
-def _one_line(value: str) -> str:
-    return " / ".join(part.strip() for part in value.splitlines() if part.strip())

--- a/termproof/report_helpers.py
+++ b/termproof/report_helpers.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from .build_info import BuildInfo
+from .models import RunResult
+
+
+def _build_info_lines(build_info: BuildInfo) -> list[str]:
+    verified = "yes" if build_info.verify_provenance() else "no"
+    return [
+        "## Build Provenance",
+        "",
+        f"- Mode: `{build_info.mode}`",
+        f"- Command: `{_one_line(' '.join(build_info.command))}`",
+        f"- Binary: `{_one_line(str(build_info.binary_path))}`",
+        f"- Version: `{_one_line(build_info.version)}`",
+        f"- Git commit: `{_one_line(str(build_info.git_commit))}`",
+        f"- Verified: `{verified}`",
+        "",
+    ]
+
+
+def _evidence_links(result: RunResult) -> str:
+    links: list[str] = []
+    for key in (
+        "screenshot",
+        "visual_diff",
+        "visual_baseline",
+        "video",
+        "cast",
+        "screen_text",
+        "step_screenshots",
+    ):
+        value = result.artifacts.get(key)
+        if value:
+            links.append(f"[{key}]({value})")
+    return " / ".join(links) if links else "-"
+
+
+def _detail(result: RunResult) -> str:
+    status = "PASS" if result.passed else "FAIL"
+    lines = [
+        f"<details><summary>{status} {result.recipe_name} [{result.renderer}]</summary>",
+        "",
+        "### Assertions",
+        "",
+    ]
+    for assertion in result.assertions:
+        mark = "PASS" if assertion.passed else "FAIL"
+        lines.append(f"- {mark} `{assertion.name}` - {assertion.detail}")
+    lines.extend(["", "### Steps", ""])
+    for step in result.steps:
+        mark = "PASS" if step.passed else "FAIL"
+        lines.append(f"- {mark} `{step.name}` - {step.detail}")
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
+
+
+def _one_line(value: str) -> str:
+    return " / ".join(part.strip() for part in value.splitlines() if part.strip())

--- a/termproof/run_cache.py
+++ b/termproof/run_cache.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from .models import AssertionResult, Recipe, RunResult, StepResult
+from .models import Recipe, RunResult
 
 
 def load_cached_result(
@@ -39,7 +39,7 @@ def load_cached_result(
     data = json.loads(path.read_text(encoding="utf-8"))
     if data.get("key") != key:
         return None
-    result = _result_from_dict(data["result"])
+    result = RunResult.from_dict(data["result"])
     if not result.passed or not _artifacts_exist(result):
         return None
     return replace(
@@ -139,25 +139,6 @@ def _hash_path(digest: Any, path: Path) -> None:
             _hash_path(digest, child)
         return
     digest.update(b"<missing>")
-
-
-def _result_from_dict(data: dict[str, Any]) -> RunResult:
-    return RunResult(
-        recipe_name=data["recipe_name"],
-        passed=bool(data["passed"]),
-        exit_code=data.get("exit_code"),
-        duration_seconds=float(data["duration_seconds"]),
-        priority=data["priority"],
-        execution=data["execution"],
-        renderer=data["renderer"],
-        score=float(data["score"]),
-        steps=[StepResult(**step) for step in data.get("steps", [])],
-        assertions=[
-            AssertionResult(**assertion)
-            for assertion in data.get("assertions", [])
-        ],
-        artifacts=dict(data.get("artifacts", {})),
-    )
 
 
 def _artifacts_exist(result: RunResult) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,9 @@ class CliTest(unittest.TestCase):
                 encoding="utf-8",
             )
             config_path = root / "explicit-config.yaml"
-            config_path.write_text("defaults:\n  rows: 77\n", encoding="utf-8")
+            config_path.write_text(
+                "docker:\n  image: explicit-image\n", encoding="utf-8"
+            )
             result = RunResult(
                 recipe_name="configured-run",
                 passed=True,
@@ -75,7 +77,8 @@ class CliTest(unittest.TestCase):
 
             self.assertEqual(0, exit_code)
             self.assertEqual(
-                77, runner_class.call_args.kwargs["config"].defaults.rows
+                "explicit-image",
+                runner_class.call_args.kwargs["config"].docker.image,
             )
 
     def test_xml_path_writes_junit_xml_to_explicit_path(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from termproof.config import (
     BUILTIN_DEFAULTS,
     DockerBackendConfig,
-    GlobalDefaults,
     VerifierConfig,
     load_config,
 )
@@ -21,10 +20,9 @@ class ConfigTest(unittest.TestCase):
         self.assertIn("send_text", config.steps)
         self.assertIn("output_contains", config.assertions)
         self.assertIn("exit_code", config.assertions)
-        self.assertIsInstance(config.defaults, GlobalDefaults)
         self.assertIsInstance(config.docker, DockerBackendConfig)
-        self.assertEqual(config.defaults.timeout_seconds, 30.0)
-        self.assertEqual(config.defaults.cols, 100)
+        self.assertEqual(config.docker.image, "")
+        self.assertEqual(config.docker.workdir, "/workspace")
 
     def test_load_config_returns_builtin_when_no_files_exist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -39,16 +37,16 @@ class ConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             user_yaml = tmp + "/user.yaml"
             Path(user_yaml).write_text(
-                "defaults:\n  timeout_seconds: 60\n",
+                "docker:\n  image: user-image\n",
                 encoding="utf-8",
             )
             config = load_config(
                 project_path=Path(tmp),
                 user_path=Path(user_yaml),
             )
-            self.assertEqual(config.defaults.timeout_seconds, 60.0)
-            # other defaults unchanged
-            self.assertEqual(config.defaults.cols, 100)
+            self.assertEqual(config.docker.image, "user-image")
+            # other docker settings unchanged
+            self.assertEqual(config.docker.workdir, "/workspace")
 
     def test_load_config_cascades_project_over_user_and_builtin(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -57,21 +55,23 @@ class ConfigTest(unittest.TestCase):
             config_dir = project_dir / ".termproof"
             config_dir.mkdir()
             (config_dir / "config.yaml").write_text(
-                "defaults:\n  timeout_seconds: 90\n  cols: 120\n",
+                "docker:\n  image: project-image\n  workdir: /project\n",
                 encoding="utf-8",
             )
             user_yaml = tmp + "/user.yaml"
             Path(user_yaml).write_text(
-                "defaults:\n  timeout_seconds: 60\n  rows: 40\n",
+                "docker:\n  image: user-image\n  env:\n    FROM_USER: \"1\"\n",
                 encoding="utf-8",
             )
             config = load_config(
                 project_path=project_dir,
                 user_path=Path(user_yaml),
             )
-            self.assertEqual(config.defaults.timeout_seconds, 90.0)  # project wins
-            self.assertEqual(config.defaults.cols, 120)  # project wins
-            self.assertEqual(config.defaults.rows, 40)  # user supplies, project doesn't
+            self.assertEqual(config.docker.image, "project-image")  # project wins
+            self.assertEqual(config.docker.workdir, "/project")  # project wins
+            self.assertEqual(
+                config.docker.env, {"FROM_USER": "1"}
+            )  # user supplies, project doesn't
 
     def test_custom_step_registration_in_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import unittest
+
+from termproof.models import AssertionResult, RunResult, StepResult
+
+
+def _result() -> RunResult:
+    return RunResult(
+        recipe_name="demo",
+        passed=True,
+        exit_code=0,
+        duration_seconds=1.25,
+        priority="P1",
+        execution="scripted",
+        renderer="default",
+        score=1.0,
+        steps=[StepResult("step", True, "detail", "screen")],
+        assertions=[AssertionResult("assert", True, "detail")],
+        artifacts={"screenshot": "final.svg"},
+    )
+
+
+class RunResultSerializationTest(unittest.TestCase):
+    def test_to_dict_matches_expected_shape(self) -> None:
+        self.assertEqual(
+            {
+                "recipe_name": "demo",
+                "passed": True,
+                "exit_code": 0,
+                "duration_seconds": 1.25,
+                "priority": "P1",
+                "execution": "scripted",
+                "renderer": "default",
+                "score": 1.0,
+                "steps": [
+                    {"name": "step", "passed": True, "detail": "detail", "screen": "screen"}
+                ],
+                "assertions": [{"name": "assert", "passed": True, "detail": "detail"}],
+                "artifacts": {"screenshot": "final.svg"},
+            },
+            _result().to_dict(),
+        )
+
+    def test_round_trip_is_lossless(self) -> None:
+        result = _result()
+        self.assertEqual(result, RunResult.from_dict(result.to_dict()))
+
+    def test_from_dict_defaults_missing_exit_code_to_none(self) -> None:
+        data = _result().to_dict()
+        data.pop("exit_code")
+        self.assertIsNone(RunResult.from_dict(data).exit_code)
+
+    def test_from_dict_defaults_missing_collections(self) -> None:
+        data = _result().to_dict()
+        del data["steps"]
+        del data["assertions"]
+        del data["artifacts"]
+        restored = RunResult.from_dict(data)
+        self.assertEqual([], restored.steps)
+        self.assertEqual([], restored.assertions)
+        self.assertEqual({}, restored.artifacts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recipe_validation.py
+++ b/tests/test_recipe_validation.py
@@ -9,7 +9,11 @@ from pathlib import Path
 from termproof.cli import main
 from termproof.config import VerifierConfig
 from termproof.models import recipe_from_mapping
-from termproof.recipe_schema import has_errors, validate_recipe_mapping
+from termproof.recipe_schema import (
+    has_errors,
+    load_recipe_schema,
+    validate_recipe_mapping,
+)
 
 
 def _recipe(**overrides):
@@ -105,6 +109,91 @@ class RecipeValidationTest(unittest.TestCase):
                 code = main(["validate", tmp])
         self.assertEqual(0, code)
         self.assertIn("PASS", output.getvalue())
+
+
+class RecipeSchemaStructuralTest(unittest.TestCase):
+    """Lock in the structural verdicts now delegated to the canonical JSON schema."""
+
+    def _errors(self, **overrides) -> list[str]:
+        issues = validate_recipe_mapping(_recipe(**overrides), VerifierConfig.builtin())
+        return [issue.path for issue in issues if issue.severity == "error"]
+
+    def test_canonical_schema_loads_as_resource(self) -> None:
+        schema = load_recipe_schema()
+        self.assertEqual(1, schema["properties"]["recipe_version"]["const"])
+        self.assertEqual(["name", "command"], schema["required"])
+
+    def test_structurally_valid_recipe_passes(self) -> None:
+        self.assertEqual([], self._errors())
+
+    def test_recipe_version_two_is_error(self) -> None:
+        self.assertTrue(has_errors(validate_recipe_mapping(_recipe(recipe_version=2), VerifierConfig.builtin())))
+
+    def test_empty_name_is_error(self) -> None:
+        self.assertTrue(self._errors(name=""))
+
+    def test_missing_command_is_error(self) -> None:
+        data = _recipe()
+        data.pop("command")
+        self.assertTrue(has_errors(validate_recipe_mapping(data, VerifierConfig.builtin())))
+
+    def test_command_not_object_is_error(self) -> None:
+        self.assertTrue(self._errors(command="echo"))
+
+    def test_empty_argv_is_error(self) -> None:
+        self.assertTrue(self._errors(command={"argv": []}))
+
+    def test_non_string_argv_is_error(self) -> None:
+        self.assertTrue(self._errors(command={"argv": [1, 2]}))
+
+    def test_non_string_env_value_is_error(self) -> None:
+        self.assertTrue(self._errors(command={"argv": ["a"], "env": {"K": 1}}))
+
+    def test_non_bool_pty_is_error(self) -> None:
+        self.assertTrue(self._errors(command={"argv": ["a"], "pty": "yes"}))
+
+    def test_non_string_cwd_is_error(self) -> None:
+        self.assertTrue(self._errors(command={"argv": ["a"], "cwd": 5}))
+
+    def test_null_cwd_is_allowed(self) -> None:
+        self.assertEqual([], self._errors(command={"argv": ["a"], "cwd": None}))
+
+    def test_non_positive_timeout_is_error(self) -> None:
+        self.assertTrue(self._errors(timeout_seconds=0))
+
+    def test_bool_timeout_is_error(self) -> None:
+        self.assertTrue(self._errors(timeout_seconds=True))
+
+    def test_non_positive_cols_is_error(self) -> None:
+        self.assertTrue(self._errors(cols=0))
+
+    def test_bool_rows_is_error(self) -> None:
+        self.assertTrue(self._errors(rows=True))
+
+    def test_non_integer_expect_exit_code_is_error(self) -> None:
+        self.assertTrue(self._errors(expect_exit_code=1.5))
+
+    def test_null_expect_exit_code_is_allowed(self) -> None:
+        self.assertEqual([], self._errors(expect_exit_code=None))
+
+    def test_non_string_list_checks_is_error(self) -> None:
+        self.assertTrue(self._errors(checks=[1]))
+
+    def test_non_string_list_ci_paths_is_error(self) -> None:
+        self.assertTrue(self._errors(ci_paths="a"))
+
+    def test_non_object_operator_is_error(self) -> None:
+        self.assertTrue(self._errors(operator=[]))
+
+    def test_non_list_renderer_argv_is_error(self) -> None:
+        self.assertTrue(self._errors(renderers={"default": "x"}))
+
+    def test_non_positive_step_timeout_is_error(self) -> None:
+        self.assertTrue(
+            self._errors(
+                steps=[{"action": "wait_for_text", "text": "ok", "timeout_seconds": 0}]
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_termproof_rename.py
+++ b/tests/test_termproof_rename.py
@@ -32,28 +32,33 @@ class TermProofRenameTest(unittest.TestCase):
                 directory.mkdir(parents=True)
 
             (legacy_user / "config.yaml").write_text(
-                "defaults:\n  timeout_seconds: 10\n  rows: 40\n",
+                "docker:\n  workdir: /legacy-user\n  image: persist-image\n",
                 encoding="utf-8",
             )
             (current_user / "config.yaml").write_text(
-                "defaults:\n  timeout_seconds: 20\n",
+                "docker:\n  workdir: /current-user\n",
                 encoding="utf-8",
             )
             (legacy_project / "config.yaml").write_text(
-                "defaults:\n  cols: 110\n",
+                "docker:\n  volumes:\n    - host: legacy\n      container: /x\n",
                 encoding="utf-8",
             )
             (current_project / "config.yaml").write_text(
-                "defaults:\n  cols: 120\n",
+                "docker:\n  volumes:\n    - host: current\n      container: /x\n",
                 encoding="utf-8",
             )
 
             with patch("termproof.config.Path.home", return_value=home):
                 config = load_config(project_path=project)
 
-            self.assertEqual(20.0, config.defaults.timeout_seconds)
-            self.assertEqual(40, config.defaults.rows)
-            self.assertEqual(120, config.defaults.cols)
+            # current user config wins over legacy user config
+            self.assertEqual("/current-user", config.docker.workdir)
+            # legacy user supplies a value neither newer file overrides
+            self.assertEqual("persist-image", config.docker.image)
+            # current project config wins over legacy project config
+            self.assertEqual(
+                [{"host": "current", "container": "/x"}], config.docker.volumes
+            )
 
     def test_legacy_plugin_references_resolve_through_compatibility_alias(self) -> None:
         from termproof.config import VerifierConfig


### PR DESCRIPTION
[Assisted by CLAUDE]

Behavior-preserving (Tidy First: structural only). STACKED on #89 — base is `refactor/dedupe-report-helpers-drop-dead-defaults`, NOT main. This continues #80 after #89 extracted the shared report helpers.

## What was unified

### 1. RunResult (de)serialization (was duplicated in 3 places)
- Added canonical `to_dict`/`from_dict` on `RunResult`, `StepResult`, and `AssertionResult` in `termproof/models.py` as the single source of truth.
- `termproof/run_cache.py` and `termproof/ci_evidence.py` now call `RunResult.from_dict` instead of hand-rolling `_result_from_dict` / `_result_from_mapping` (both removed).
- `RunResult.to_dict` no longer relies on `step.__dict__` on frozen dataclasses; each model owns its own `to_dict`. Output/round-trip is byte-identical.
- **Discrepancy found & preserved:** the two old deserializers disagreed on one field — `run_cache` used `data.get("exit_code")` (defaults to `None`), `ci_evidence` used `data["exit_code"]` (KeyError if missing). Serialized `result.json` always contains `exit_code`, so they agreed in practice. The canonical `from_dict` adopts the safer superset (`.get`), preserving observable behavior.
- Added `tests/test_models.py` (shape, lossless round-trip, missing-field defaults).

### 2. Recipe validation against the canonical JSON schema
- `termproof/recipe_schema.py` now validates recipe structure against the canonical `docs/recipe-schema-v1.json` via `jsonschema`, loaded as a **package resource**. The schema is force-included into the wheel at `termproof/_resources/recipe-schema-v1.json` (see `pyproject.toml`), with a source-tree `docs/` fallback — no content duplication of the schema file.
- Removed the hand-written `_validate_*` structural checks that duplicated the schema (name/command/argv/env/pty/cwd/timeouts/cols/rows/expect_exit_code/checks/ci_paths/operator/renderers/step timeouts).
- Preserved the `ValidationIssue(path, message, severity)` output shape and the error-vs-warning distinction the tests expect.
- Added tests locking in the structural verdicts against the canonical schema (`RecipeSchemaStructuralTest`).

## Deliberately deferred (kept in Python, cannot be expressed in JSON Schema)
- **Legacy `recipe_version` warning**: missing `recipe_version` → `warning` (not error). JSON Schema has no warning concept, so this stays manual; `recipe_version` schema errors are filtered so it is handled in one place.
- **Plugin-registry membership**: `steps[].action` must be in `config.steps` and `assertions[].type` in `config.assertions` ("unknown step action" / "unknown assertion type"). These are runtime/config-driven and not encodable in the static schema.
- Structural **error message text** now comes from `jsonschema` (which inputs pass/fail is unchanged; only wording/paths differ for structural errors).

## Validation
- `uv sync`, `uv run python -c "import termproof"` — OK
- `uv run python -m unittest tests.test_recipe_validation tests.test_run_cache tests.test_ci_evidence tests.test_json_schema_assertion tests.test_models` — 52 passed
- Full suite: `uv run python -m unittest discover -s tests` — 248 passed (runner/asciinema/ffmpeg tests ran clean in this environment). No previously-passing test now fails.
- Wheel build verified to include `termproof/_resources/recipe-schema-v1.json`.

Closes #80
