### PR TITLE
chore: add community-health & GitHub template files (replacement for #84)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for TermProof.
+# These owners are requested for review automatically on matching changes.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repo.
+*       @md-mt

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,10 @@
+# Funding / sponsorship configuration for GitHub's "Sponsor" button.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# No sponsorship accounts are configured yet. Uncomment and fill in a handle
+# to enable the Sponsor button.
+#
+# github: [md-mt]              # up to 4 GitHub Sponsors usernames/orgs
+# ko_fi: your-handle           # a single Ko-fi username
+# open_collective: your-handle # an Open Collective slug
+# custom: ["https://example.com/donate"]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,10 +1,12 @@
 # Funding / sponsorship configuration for GitHub's "Sponsor" button.
 # Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 #
-# No sponsorship accounts are configured yet. Uncomment and fill in a handle
-# to enable the Sponsor button.
+# No sponsorship accounts are configured yet, so this file is an empty
+# mapping: GitHub shows no Sponsor button until a platform is enabled.
+# Uncomment and fill in a handle to enable the Sponsor button.
 #
 # github: [md-mt]              # up to 4 GitHub Sponsors usernames/orgs
 # ko_fi: your-handle           # a single Ko-fi username
 # open_collective: your-handle # an Open Collective slug
 # custom: ["https://example.com/donate"]
+{}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,68 @@
+---
+name: Bug report
+about: Report a reproducible bug in TermProof
+title: "bug: <short description>"
+labels: ["bug"]
+assignees: []
+---
+
+<!--
+Before filing: please search existing issues first (open and closed).
+For security vulnerabilities, do NOT open a public issue — use the private
+reporting path in SECURITY.md.
+-->
+
+## What happened
+
+A clear description of the bug: what you observed vs. what you expected.
+
+**Observed:**
+
+**Expected:**
+
+## Reproduction recipe
+
+The `*.recipe.json` (or a minimal reduction of it) that triggers the bug.
+Reproductions must be deterministic and runnable in CI. Recipes use
+`command.argv` — a command array is not valid TermProof syntax.
+
+```json
+{
+  "recipe_version": 1,
+  "name": "repro",
+  "command": {
+    "argv": ["python3", "your_tui.py"]
+  },
+  "steps": []
+}
+```
+
+## `termproof --help` output
+
+<details>
+<summary>termproof --help</summary>
+
+```text
+$ termproof --help
+...paste output here...
+```
+
+</details>
+
+## Environment
+
+- TermProof version: <!-- e.g. 0.2.0 (run `termproof --version`) -->
+- Python version: <!-- run `python --version` -->
+- OS / architecture: <!-- e.g. macOS 14 arm64, Ubuntu 24.04 x86_64 -->
+- `ffmpeg` / `agg` available: <!-- yes/no, only relevant for --video/render -->
+
+## Additional context
+
+Logs, a `.cast` file, screenshots, or anything else that helps. Avoid
+attaching large binaries — link to a gist or trimmed artifact instead.
+
+## Area (optional)
+
+If you know which area this touches, add one of the area labels:
+`area:core`, `area:cli`, `area:ci`, `area:docs`, `area:community`,
+`area:distro`, `area:plugins`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussion
+    url: https://github.com/md-mt/termproof/issues
+    about: Ask questions, share recipes, and propose ideas by opening an issue.
+  - name: Support & getting help
+    url: https://github.com/md-mt/termproof/blob/main/SUPPORT.md
+    about: Where and how to get help with TermProof.
+  - name: Report a security vulnerability
+    url: https://github.com/md-mt/termproof/security/policy
+    about: Do not open public issues for security reports — use the private reporting path in SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: Feature request
+about: Propose an enhancement or new capability for TermProof
+title: "feat: <short description>"
+labels: ["enhancement"]
+assignees: []
+---
+
+<!--
+Before filing: please search existing issues first.
+Questions and open-ended ideas are welcome as GitHub issues — see SUPPORT.md.
+-->
+
+## Problem / motivation
+
+What problem are you trying to solve? What is the current behavior and why is
+it insufficient? Link any related issues.
+
+## Proposed solution
+
+Describe the feature or change you'd like. If it affects recipe semantics or
+artifact contracts, note that explicitly (these require a minor/major version
+bump per `docs/releases.md`).
+
+## Alternatives considered
+
+Other approaches you evaluated and why you didn't choose them.
+
+## Scope / contribution ladder
+
+Where does this land on the contribution ladder (see CONTRIBUTING.md)?
+
+- [ ] Recipe (an `examples/*.recipe.json`)
+- [ ] Plugin (external step / assertion / backend / reporter)
+- [ ] Core change (`termproof/` internals)
+
+## Additional context
+
+Mockups, example recipes, prior art, or anything else that clarifies the ask.
+
+## Area (optional)
+
+Add one of the area labels if you know which area this touches:
+`area:core`, `area:cli`, `area:ci`, `area:docs`, `area:community`,
+`area:distro`, `area:plugins`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+Thanks for contributing to TermProof! Please read CONTRIBUTING.md.
+All changes go through pull requests — no direct commits to `main`.
+Open as a draft early and request review when CI is green.
+-->
+
+## Summary
+
+What does this PR do and why? Keep changes small and incremental
+(~100 lines of logic, <200 with tests). Split larger work into stacked PRs.
+
+## Linked issue
+
+<!-- Use a closing keyword so the issue auto-closes on merge. -->
+
+Closes #
+
+## Test plan
+
+How did you verify this change?
+
+```bash
+uv run python -m unittest discover -s tests
+uv build
+# if you touched runner/renderer/video:
+uv run termproof run examples/generic --video --out .termproof/ci
+```
+
+- [ ] Added/updated unit tests for behavioral changes
+- [ ] Screenshots / evidence attached (if UX or output changed)
+
+## Tidy First
+
+Following Tidy First, structural moves and behavioral changes are not mixed in
+the same diff.
+
+- [ ] This PR is a **structural** change only (renames/moves/formatting), OR
+- [ ] This PR is a **behavioral** change only, OR
+- [ ] N/A (docs / chore)
+
+## Checklist
+
+- [ ] Title and commits follow Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`)
+- [ ] No comments/docstrings/type hints added to untouched code
+- [ ] Branch follows naming convention (`feat/`, `fix/`, `docs/`, `refactor/`, `chore/`)
+- [ ] No large binaries checked in (`examples/artifacts/` kept lean)
+- [ ] Backward-compatibility contract respected (legacy `tui-verifier` paths / plugin prefix — see CONTRIBUTING.md)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Python dependencies declared in the root pyproject.toml.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "area:distro"
+    commit-message:
+      prefix: "chore"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "area:ci"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run unit tests
         run: uv run python -m unittest discover -s tests
 
+      - name: Run community-health validation harness
+        run: uv run python scripts/validate_community_health.py
+
       - name: Run plugin-template unit tests
         run: |
           PYTHONPATH=plugin-template/src uv run --no-project --with . --with pytest --with pyyaml \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,4 +142,4 @@ By contributing, you agree that your contributions will be licensed under the MI
 
 ## Questions?
 
-Open a discussion or draft PR — maintainers respond faster to concrete code than abstract questions.
+Open an issue or draft PR — maintainers respond faster to concrete code than abstract questions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,8 @@ We aim to acknowledge reports within 48 hours and provide an initial assessment 
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.2.x   | :white_check_mark: |
+| 0.1.x   | :x:                |
 
 ## Disclosure
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,38 @@
+# Getting help with TermProof
+
+Thanks for using TermProof! Here's where to go depending on what you need.
+
+## Questions & ideas
+
+For usage questions, "how do I verify X?", recipe help, and open-ended
+proposals, open a **[GitHub issue](https://github.com/md-mt/termproof/issues)**
+using the closest template. Issues are searchable and let the whole community
+benefit from answers.
+
+## Bug reports & feature requests
+
+Open a **[GitHub issue](https://github.com/md-mt/termproof/issues)** using the
+appropriate template:
+
+- **Bug report** — include a reproduction recipe (JSON), `termproof --help`
+  output, your Python version, OS, and observed vs. expected behavior.
+- **Feature request** — describe the problem, proposed solution, and where it
+  lands on the contribution ladder.
+
+Please search existing issues (open and closed) before filing a new one.
+
+## Security issues
+
+**Do not** open a public issue for security vulnerabilities. Use the private
+reporting path in [SECURITY.md](SECURITY.md) — the reporting email is listed
+there. See SECURITY.md for the full policy and what to include.
+
+## Contributing
+
+Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution
+ladder, local setup, and the PR-only process. All participants are expected to
+follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Documentation
+
+Start with the [README](README.md) and the guides under [`docs/`](docs/).

--- a/docs/launch/runbook.md
+++ b/docs/launch/runbook.md
@@ -10,7 +10,7 @@ TermProof public launch touchpoints:
 1. **HN Show** — high visibility, technical audience, rapid comments
 2. **X/Twitter + Mastodon + Bluesky** — announcement threads, retweets, replies
 3. **Framework maintainer DMs** — Textual, Bubble Tea, Ratatui, Ink — one per day
-4. **GitHub repo** — stars, issues, PRs, discussions
+4. **GitHub repo** — stars, issues, PRs
 
 Goal: respond with technical depth, capture feedback, convert "tried it" into guides or plugins, avoid spam.
 
@@ -172,7 +172,7 @@ Record in `docs/launch/checklist.md` final section or swarm ledger — do not em
 ## After Week 1 — Transition to Normal Operations
 
 - Convert this runbook into lightweight `docs/community.md` or integrate into `docs/recipe-packs.md` + `docs/plugins.md`
-- Archive launch kit thread to GitHub Discussion "TermProof v0.2 Launch Retrospective" — capture what worked, what was missed
+- Open a labeled GitHub issue for the retrospective (e.g. title "TermProof v0.2 Launch Retrospective", label `launch-retrospective`) — capture what worked, what was missed
 - Update `docs/launch/README.md` canonical links after Pages demo live (#16)
 - Open follow-up tasks: actual social handle URLs, guide co-authoring, badge adoptions
 

--- a/scripts/schemas/PROVENANCE.md
+++ b/scripts/schemas/PROVENANCE.md
@@ -1,0 +1,24 @@
+# Vendored SchemaStore schemas
+
+`scripts/validate_community_health.py` validates community-health YAML against
+pinned copies of the SchemaStore schemas so the harness is hermetic on a fresh
+checkout (no network, no `/tmp` preseed required).
+
+| File | Source | SHA-256 |
+| --- | --- | --- |
+| `github-issue-config.json` | https://www.schemastore.org/schemas/json/github-issue-config.json | `899e718f4b8c965413b07ec63d8f089792a10c42409270db560b9a7ec0224a5a` |
+| `github-funding.json` | https://www.schemastore.org/schemas/json/github-funding.json | `90d83f41c25a0029653a7ba64080aa6f3973527eed533f18f5b932a425bc802b` |
+
+Retrieved 2026-08-01. To re-pin against the live SchemaStore copies:
+
+```sh
+curl -fsSL https://www.schemastore.org/schemas/json/github-issue-config.json \
+  -o scripts/schemas/github-issue-config.json
+curl -fsSL https://www.schemastore.org/schemas/json/github-funding.json \
+  -o scripts/schemas/github-funding.json
+shasum -a 256 scripts/schemas/*.json
+```
+
+Update the table above when re-pinning. To validate against the live schema
+without re-vendoring, pass `--issue-config-schema <url-or-path>` /
+`--funding-schema <url-or-path>` to the harness.

--- a/scripts/schemas/github-funding.json
+++ b/scripts/schemas/github-funding.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/github-funding.json",
+  "$comment": "https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository",
+  "additionalProperties": false,
+  "description": "You can add a sponsor button in your repository to increase the visibility of funding options for your open source project.",
+  "properties": {
+    "community_bridge": {
+      "title": "LFX Mentorship (formerly CommunityBridge)",
+      "description": "Project name on CommunityBridge.",
+      "type": "string",
+      "minLength": 1
+    },
+    "github": {
+      "title": "GitHub Sponsors",
+      "description": "You can add one organization and up to four sponsored developers.",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
+    "issuehunt": {
+      "title": "IssueHunt",
+      "description": "Username on IssueHunt.",
+      "type": "string",
+      "minLength": 1
+    },
+    "ko_fi": {
+      "title": "Ko-fi",
+      "description": "Username on Ko-fi.",
+      "type": "string",
+      "minLength": 1
+    },
+    "liberapay": {
+      "title": "Liberapay",
+      "description": "Username on Liberapay.",
+      "type": "string",
+      "minLength": 1
+    },
+    "open_collective": {
+      "title": "Open Collective",
+      "description": "Username on Open Collective.",
+      "type": "string",
+      "minLength": 1
+    },
+    "patreon": {
+      "title": "Patreon",
+      "description": "Username on Patreon.",
+      "type": "string",
+      "minLength": 1
+    },
+    "tidelift": {
+      "title": "Tidelift",
+      "description": "Platform and package on Tidelift, following the format `PLATFORM-NAME/PACKAGE-NAME`.",
+      "type": "string",
+      "pattern": "^(npm|pypi|rubygems|maven|packagist|nuget)/.+$"
+    },
+    "polar": {
+      "title": "Polar",
+      "description": "Username on Polar.",
+      "type": "string",
+      "minLength": 1
+    },
+    "buy_me_a_coffee": {
+      "title": "Buy Me a Coffee",
+      "description": "Username on Buy Me a Coffee.",
+      "type": "string",
+      "minLength": 1
+    },
+    "thanks_dev": {
+      "title": "thanks.dev",
+      "description": "Maintainer profile on thanks.dev",
+      "type": "string",
+      "pattern": "^u/gh/.+$"
+    },
+    "custom": {
+      "title": "Custom URL or URL's",
+      "description": "Link or links where funding is accepted on external locations.",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "format": "uri-reference"
+          }
+        }
+      ]
+    }
+  },
+  "title": "GitHub Funding",
+  "type": "object"
+}

--- a/scripts/schemas/github-issue-config.json
+++ b/scripts/schemas/github-issue-config.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/github-issue-config.json",
+  "$comment": "https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",
+  "properties": {
+    "blank_issues_enabled": {
+      "description": "Specify whether allow blank issue creation\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",
+      "type": "boolean"
+    },
+    "contact_links": {
+      "title": "contact links",
+      "description": "Contact links\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "url", "about"],
+        "properties": {
+          "name": {
+            "description": "A link title\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",
+            "type": "string",
+            "minLength": 1,
+            "examples": ["Sample name"]
+          },
+          "url": {
+            "description": "A link URL\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",
+            "type": "string",
+            "pattern": "^https?://",
+            "examples": ["https://sample/url"]
+          },
+          "about": {
+            "description": "A link description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",
+            "type": "string",
+            "minLength": 1,
+            "examples": ["Sample description"]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "title": "GitHub issue template chooser config file schema",
+  "type": "object"
+}

--- a/scripts/validate_community_health.py
+++ b/scripts/validate_community_health.py
@@ -12,8 +12,12 @@
 The schemas are vendored in-repo so the harness is hermetic on a fresh
 checkout. To validate against a different copy (e.g. the live SchemaStore
 version), pass --issue-config-schema <url-or-path> and/or
---funding-schema <url-or-path>. A schema that cannot be read, or that is not
-itself a valid JSON Schema, is a clean validation failure, never a traceback.
+--funding-schema <url-or-path>.
+
+The accepted schema root contract is a JSON object (mapping). A schema that
+cannot be read, cannot be decoded as UTF-8, is not valid JSON, or whose root
+is not an object (number, string, array, null, boolean) is a clean validation
+failure ([FAIL], exit 1, zero stderr), never a traceback.
 """
 from __future__ import annotations
 
@@ -48,21 +52,35 @@ def check(name: str, ok: bool, detail: str = "") -> None:
 
 
 def load_schema(location: str) -> dict | None:
-    """Load a schema from a local path or URL; None on any failure."""
+    """Load a schema from a local path or URL; None on any failure.
+
+    The accepted schema root contract is a JSON object (mapping). A schema
+    file that cannot be read (missing file, permission, network error),
+    cannot be decoded as UTF-8, is not valid JSON, or whose root is not an
+    object is a clean failure: ``None`` is returned and a reason is printed.
+    Callers treat ``None`` as a ``[FAIL]`` check — never a traceback.
+    """
     try:
         if re.match(r"^https?://", location):
             with urllib.request.urlopen(location, timeout=30) as response:
                 raw = response.read().decode("utf-8")
         else:
             raw = Path(location).read_text(encoding="utf-8")
-    except (OSError, urllib.error.URLError) as error:
+    except (OSError, urllib.error.URLError, UnicodeDecodeError) as error:
         print(f"  could not read schema {location}: {error}")
         return None
     try:
-        return json.loads(raw)
+        schema = json.loads(raw)
     except json.JSONDecodeError as error:
         print(f"  schema {location} is not valid JSON: {error}")
         return None
+    if not isinstance(schema, dict):
+        print(
+            f"  schema {location} root must be a JSON object (mapping), "
+            f"got {type(schema).__name__}"
+        )
+        return None
+    return schema
 
 
 def validate_against_schema(name: str, instance: object, location: str) -> None:

--- a/scripts/validate_community_health.py
+++ b/scripts/validate_community_health.py
@@ -3,16 +3,27 @@
 
 1. Copy/paste-check the bug_report.md recipe through TermProof's actual
    loader/schema (validate_recipe_file via the CLI entry point).
-2. Validate .github/ISSUE_TEMPLATE/config.yml against the SchemaStore
-   github-issue-config.json schema (downloaded to /tmp).
-3. Parse every YAML under .github/ and all template frontmatter.
+2. Validate .github/ISSUE_TEMPLATE/config.yml against the pinned SchemaStore
+   github-issue-config schema (vendored under scripts/schemas/).
+3. Validate .github/FUNDING.yml against the pinned SchemaStore github-funding
+   schema.
+4. Parse every YAML under .github/ and all template frontmatter.
+
+The schemas are vendored in-repo so the harness is hermetic on a fresh
+checkout. To validate against a different copy (e.g. the live SchemaStore
+version), pass --issue-config-schema <url-or-path> and/or
+--funding-schema <url-or-path>. A schema that cannot be read is a clean
+validation failure, never a traceback.
 """
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import jsonschema
@@ -21,7 +32,10 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 BUG_REPORT = ROOT / ".github" / "ISSUE_TEMPLATE" / "bug_report.md"
 CONFIG_YML = ROOT / ".github" / "ISSUE_TEMPLATE" / "config.yml"
-SCHEMA = Path("/tmp/github-issue-config.schema.json")
+FUNDING_YML = ROOT / ".github" / "FUNDING.yml"
+SCHEMA_DIR = Path(__file__).resolve().parent / "schemas"
+DEFAULT_ISSUE_CONFIG_SCHEMA = SCHEMA_DIR / "github-issue-config.json"
+DEFAULT_FUNDING_SCHEMA = SCHEMA_DIR / "github-funding.json"
 
 failures = []
 
@@ -33,7 +47,52 @@ def check(name: str, ok: bool, detail: str = "") -> None:
         failures.append(name)
 
 
+def load_schema(location: str) -> dict | None:
+    """Load a schema from a local path or URL; None on any failure."""
+    try:
+        if re.match(r"^https?://", location):
+            with urllib.request.urlopen(location, timeout=30) as response:
+                raw = response.read().decode("utf-8")
+        else:
+            raw = Path(location).read_text(encoding="utf-8")
+    except (OSError, urllib.error.URLError) as error:
+        print(f"  could not read schema {location}: {error}")
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as error:
+        print(f"  schema {location} is not valid JSON: {error}")
+        return None
+
+
+def validate_against_schema(name: str, instance: object, location: str) -> None:
+    schema = load_schema(location)
+    if schema is None:
+        check(f"{name} schema available ({location})", False)
+        return
+    try:
+        jsonschema.validate(instance=instance, schema=schema)
+        check(f"{name} validates against SchemaStore schema", True)
+    except jsonschema.ValidationError as error:
+        check(f"{name} validates against SchemaStore schema", False, str(error)[:300])
+
+
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--issue-config-schema",
+        default=str(DEFAULT_ISSUE_CONFIG_SCHEMA),
+        help="path or URL of the github-issue-config schema "
+        f"(default: {DEFAULT_ISSUE_CONFIG_SCHEMA})",
+    )
+    parser.add_argument(
+        "--funding-schema",
+        default=str(DEFAULT_FUNDING_SCHEMA),
+        help="path or URL of the github-funding schema "
+        f"(default: {DEFAULT_FUNDING_SCHEMA})",
+    )
+    args = parser.parse_args()
+
     # 1. Extract the recipe from bug_report.md and run it through the real CLI.
     text = BUG_REPORT.read_text(encoding="utf-8")
     match = re.search(r"```json\n(.*?)```", text, re.DOTALL)
@@ -55,24 +114,35 @@ def main() -> int:
         (proc.stdout + proc.stderr).strip()[-300:],
     )
 
-    # 2. Validate config.yml against the real SchemaStore schema.
+    # 2. Validate config.yml against the pinned SchemaStore issue-config schema.
     config = yaml.safe_load(CONFIG_YML.read_text(encoding="utf-8"))
-    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
-    try:
-        jsonschema.validate(instance=config, schema=schema)
-        check("config.yml validates against SchemaStore issue-config schema", True)
-    except jsonschema.ValidationError as error:
-        check("config.yml validates against SchemaStore issue-config schema", False, str(error)[:300])
+    if not isinstance(config, dict):
+        check("config.yml is a mapping", False, f"got {type(config).__name__}")
+    else:
+        check("config.yml is a mapping", True)
+        validate_against_schema("config.yml (issue-config)", config, args.issue_config_schema)
 
-    # 3. Contact URLs are HTTP(S).
-    urls = [link.get("url", "") for link in config.get("contact_links", [])]
-    check(
-        "all contact_links urls are http(s)",
-        all(re.match(r"^https?://", url) for url in urls),
-        str(urls),
-    )
+        # 3. Contact URLs are HTTP(S).
+        urls = [link.get("url", "") for link in config.get("contact_links", [])]
+        check(
+            "all contact_links urls are http(s)",
+            all(re.match(r"^https?://", url) for url in urls),
+            str(urls),
+        )
 
-    # 4. Every YAML under .github parses.
+    # 4. FUNDING.yml must be a valid funding mapping (SchemaStore).
+    funding = yaml.safe_load(FUNDING_YML.read_text(encoding="utf-8"))
+    if not isinstance(funding, dict):
+        check(
+            "FUNDING.yml is a mapping (not comments-only)",
+            False,
+            f"got {type(funding).__name__}",
+        )
+    else:
+        check("FUNDING.yml is a mapping (not comments-only)", True)
+        validate_against_schema("FUNDING.yml (funding)", funding, args.funding_schema)
+
+    # 5. Every YAML under .github parses.
     yaml_ok = True
     for path in sorted((ROOT / ".github").rglob("*.yml")) + sorted((ROOT / ".github").rglob("*.yaml")):
         try:

--- a/scripts/validate_community_health.py
+++ b/scripts/validate_community_health.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Validation harness for the community-health remediation.
+
+1. Copy/paste-check the bug_report.md recipe through TermProof's actual
+   loader/schema (validate_recipe_file via the CLI entry point).
+2. Validate .github/ISSUE_TEMPLATE/config.yml against the SchemaStore
+   github-issue-config.json schema (downloaded to /tmp).
+3. Parse every YAML under .github/ and all template frontmatter.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+BUG_REPORT = ROOT / ".github" / "ISSUE_TEMPLATE" / "bug_report.md"
+CONFIG_YML = ROOT / ".github" / "ISSUE_TEMPLATE" / "config.yml"
+SCHEMA = Path("/tmp/github-issue-config.schema.json")
+
+failures = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    status = "PASS" if ok else "FAIL"
+    print(f"[{status}] {name}" + (f" — {detail}" if detail else ""))
+    if not ok:
+        failures.append(name)
+
+
+def main() -> int:
+    # 1. Extract the recipe from bug_report.md and run it through the real CLI.
+    text = BUG_REPORT.read_text(encoding="utf-8")
+    match = re.search(r"```json\n(.*?)```", text, re.DOTALL)
+    assert match is not None, "no json block in bug_report.md"
+    recipe = json.loads(match.group(1))
+    recipe_path = ROOT / ".termproof" / "repro-recipe-from-template.json"
+    recipe_path.parent.mkdir(parents=True, exist_ok=True)
+    recipe_path.write_text(json.dumps(recipe, indent=2), encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "termproof", "validate", str(recipe_path)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    check(
+        "recipe from bug_report.md validates via termproof CLI",
+        proc.returncode == 0,
+        (proc.stdout + proc.stderr).strip()[-300:],
+    )
+
+    # 2. Validate config.yml against the real SchemaStore schema.
+    config = yaml.safe_load(CONFIG_YML.read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    try:
+        jsonschema.validate(instance=config, schema=schema)
+        check("config.yml validates against SchemaStore issue-config schema", True)
+    except jsonschema.ValidationError as error:
+        check("config.yml validates against SchemaStore issue-config schema", False, str(error)[:300])
+
+    # 3. Contact URLs are HTTP(S).
+    urls = [link.get("url", "") for link in config.get("contact_links", [])]
+    check(
+        "all contact_links urls are http(s)",
+        all(re.match(r"^https?://", url) for url in urls),
+        str(urls),
+    )
+
+    # 4. Every YAML under .github parses.
+    yaml_ok = True
+    for path in sorted((ROOT / ".github").rglob("*.yml")) + sorted((ROOT / ".github").rglob("*.yaml")):
+        try:
+            yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as error:
+            yaml_ok = False
+            print(f"  YAML ERROR in {path}: {error}")
+    check("all .github YAML files parse", yaml_ok)
+
+    print()
+    if failures:
+        print(f"FAILED: {len(failures)} validation check(s) failed")
+        return 1
+    print("ALL VALIDATION CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_community_health.py
+++ b/scripts/validate_community_health.py
@@ -12,8 +12,8 @@
 The schemas are vendored in-repo so the harness is hermetic on a fresh
 checkout. To validate against a different copy (e.g. the live SchemaStore
 version), pass --issue-config-schema <url-or-path> and/or
---funding-schema <url-or-path>. A schema that cannot be read is a clean
-validation failure, never a traceback.
+--funding-schema <url-or-path>. A schema that cannot be read, or that is not
+itself a valid JSON Schema, is a clean validation failure, never a traceback.
 """
 from __future__ import annotations
 
@@ -73,7 +73,7 @@ def validate_against_schema(name: str, instance: object, location: str) -> None:
     try:
         jsonschema.validate(instance=instance, schema=schema)
         check(f"{name} validates against SchemaStore schema", True)
-    except jsonschema.ValidationError as error:
+    except (jsonschema.ValidationError, jsonschema.SchemaError) as error:
         check(f"{name} validates against SchemaStore schema", False, str(error)[:300])
 
 

--- a/tests/test_community_health.py
+++ b/tests/test_community_health.py
@@ -204,23 +204,35 @@ class ValidationHarnessTest(unittest.TestCase):
         )
         self.assertIn("ALL VALIDATION CHECKS PASSED", proc.stdout)
 
+    def _schema_file(self, content: str | bytes) -> Path:
+        """Write arbitrary schema content (text or raw bytes) to a temp file."""
+        tmp = Path(tempfile.mkdtemp(prefix="termproof-bad-schema-"))
+        path = tmp / "bad-schema.json"
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+        return path
+
+    def _assert_clean_failure(
+        self, proc: subprocess.CompletedProcess[str], label: str
+    ) -> None:
+        """The override contract: exit != 0, [FAIL], zero stderr, no traceback."""
+        self.assertNotEqual(proc.returncode, 0, f"{label} must fail validation")
+        self.assertIn("FAIL", proc.stdout, f"{label} must print [FAIL]")
+        self.assertEqual(
+            proc.stderr,
+            "",
+            f"{label} must produce zero stderr (no traceback): {proc.stderr!r}",
+        )
+
     def test_harness_missing_schema_is_clean_failure(self) -> None:
         proc = self._run("--issue-config-schema", "/nonexistent/schema.json")
-        self.assertNotEqual(proc.returncode, 0, "missing schema must fail validation")
-        self.assertNotIn(
-            "Traceback", proc.stderr, "missing schema must be a clean failure, not a traceback"
-        )
-        self.assertIn("FAIL", proc.stdout)
+        self._assert_clean_failure(proc, "missing schema")
 
     def test_harness_missing_funding_schema_is_clean_failure(self) -> None:
         proc = self._run("--funding-schema", "/nonexistent/schema.json")
-        self.assertNotEqual(proc.returncode, 0, "missing funding schema must fail validation")
-        self.assertNotIn(
-            "Traceback",
-            proc.stderr,
-            "missing funding schema must be a clean failure, not a traceback",
-        )
-        self.assertIn("FAIL", proc.stdout)
+        self._assert_clean_failure(proc, "missing funding schema")
 
     def _malformed_schema_file(self) -> Path:
         """A valid JSON document that is not a valid JSON Schema.
@@ -228,34 +240,62 @@ class ValidationHarnessTest(unittest.TestCase):
         ``{"type": 12}`` is readable JSON but an invalid schema: jsonschema
         raises ``SchemaError`` (not ``ValidationError``) when it is used.
         """
-        tmp = Path(tempfile.mkdtemp(prefix="termproof-bad-schema-"))
-        path = tmp / "malformed-schema.json"
-        path.write_text('{"type": 12}', encoding="utf-8")
-        return path
+        return self._schema_file('{"type": 12}')
 
     def test_harness_malformed_issue_schema_is_clean_failure(self) -> None:
         proc = self._run("--issue-config-schema", str(self._malformed_schema_file()))
-        self.assertNotEqual(
-            proc.returncode, 0, "malformed issue schema must fail validation"
-        )
-        self.assertNotIn(
-            "Traceback",
-            proc.stderr,
-            "malformed issue schema must be a clean failure, not a traceback",
-        )
-        self.assertIn("FAIL", proc.stdout)
+        self._assert_clean_failure(proc, "malformed issue schema")
 
     def test_harness_malformed_funding_schema_is_clean_failure(self) -> None:
         proc = self._run("--funding-schema", str(self._malformed_schema_file()))
-        self.assertNotEqual(
-            proc.returncode, 0, "malformed funding schema must fail validation"
+        self._assert_clean_failure(proc, "malformed funding schema")
+
+    def test_harness_numeric_root_issue_schema_is_clean_failure(self) -> None:
+        proc = self._run("--issue-config-schema", str(self._schema_file("42")))
+        self._assert_clean_failure(proc, "numeric-root issue schema")
+
+    def test_harness_numeric_root_funding_schema_is_clean_failure(self) -> None:
+        proc = self._run("--funding-schema", str(self._schema_file("42")))
+        self._assert_clean_failure(proc, "numeric-root funding schema")
+
+    def test_harness_array_root_issue_schema_is_clean_failure(self) -> None:
+        proc = self._run("--issue-config-schema", str(self._schema_file("[]")))
+        self._assert_clean_failure(proc, "array-root issue schema")
+
+    def test_harness_array_root_funding_schema_is_clean_failure(self) -> None:
+        proc = self._run("--funding-schema", str(self._schema_file("[]")))
+        self._assert_clean_failure(proc, "array-root funding schema")
+
+    def test_harness_scalar_root_issue_schema_is_clean_failure(self) -> None:
+        proc = self._run("--issue-config-schema", str(self._schema_file('"scalar"')))
+        self._assert_clean_failure(proc, "scalar-root issue schema")
+
+    def test_harness_scalar_root_funding_schema_is_clean_failure(self) -> None:
+        proc = self._run("--funding-schema", str(self._schema_file('"scalar"')))
+        self._assert_clean_failure(proc, "scalar-root funding schema")
+
+    def test_harness_non_utf8_issue_schema_is_clean_failure(self) -> None:
+        proc = self._run(
+            "--issue-config-schema", str(self._schema_file(b'{"type": "\xff\xfe"}'))
         )
-        self.assertNotIn(
-            "Traceback",
-            proc.stderr,
-            "malformed funding schema must be a clean failure, not a traceback",
+        self._assert_clean_failure(proc, "non-UTF-8 issue schema")
+
+    def test_harness_non_utf8_funding_schema_is_clean_failure(self) -> None:
+        proc = self._run(
+            "--funding-schema", str(self._schema_file(b'{"type": "\xff\xfe"}'))
         )
-        self.assertIn("FAIL", proc.stdout)
+        self._assert_clean_failure(proc, "non-UTF-8 funding schema")
+
+    def test_schema_root_contract_rejects_non_mapping_roots_in_source(self) -> None:
+        """The accepted schema root contract is an object/mapping.
+
+        The harness source must state the contract and reject non-dict roots
+        (number, string, array, null, boolean) as a clean failure instead of
+        letting them reach jsonschema, where they raise TypeError/SchemaError.
+        """
+        source = self.SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("isinstance(schema, dict)", source)
+        self.assertIn("JSON object", source)
 
 
 class SupportRoutingTest(unittest.TestCase):

--- a/tests/test_community_health.py
+++ b/tests/test_community_health.py
@@ -12,10 +12,14 @@ Run: uv run python -m unittest tests.test_community_health -v
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
+import sys
 import unittest
 from pathlib import Path
 
+import jsonschema
 import yaml
 
 from termproof.config import VerifierConfig
@@ -122,15 +126,90 @@ class TemplateFrontmatterTest(unittest.TestCase):
 
 
 class GitHubYamlParseTest(unittest.TestCase):
-    def test_every_github_yaml_file_parses(self) -> None:
+    def test_every_github_yaml_file_parses_to_mapping(self) -> None:
         self.assertTrue(GITHUB_YAML_FILES, "expected .github YAML files")
         for path in GITHUB_YAML_FILES:
             with self.subTest(file=str(path.relative_to(ROOT))):
                 data = _load_yaml(path)  # raises on syntax error
-                self.assertTrue(
-                    data is None or isinstance(data, dict),
-                    f"{path.name} must be a mapping or empty (got {type(data).__name__})",
+                self.assertIsInstance(
+                    data,
+                    dict,
+                    f"{path.name} must be a mapping (got {type(data).__name__}); "
+                    "comments-only YAML parses to None and is not a valid config",
                 )
+
+
+class FundingConfigTest(unittest.TestCase):
+    """FUNDING.yml must be a valid GitHub funding mapping (SchemaStore)."""
+
+    FUNDING_YML = ROOT / ".github" / "FUNDING.yml"
+    FUNDING_SCHEMA = ROOT / "scripts" / "schemas" / "github-funding.json"
+
+    def setUp(self) -> None:
+        self.funding = _load_yaml(self.FUNDING_YML)
+
+    def test_funding_yml_is_a_mapping(self) -> None:
+        self.assertIsInstance(
+            self.funding,
+            dict,
+            "FUNDING.yml must be a mapping ({} while no sponsor is configured), "
+            "not comments-only (which parses to None and fails the Funding schema)",
+        )
+
+    def test_funding_yml_validates_against_funding_schema(self) -> None:
+        schema_path = self.FUNDING_SCHEMA
+        self.assertTrue(
+            schema_path.is_file(),
+            f"funding schema must be vendored in-repo at {schema_path}",
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=self.funding, schema=schema)
+
+
+class ValidationHarnessTest(unittest.TestCase):
+    """scripts/validate_community_health.py must be hermetic and fail cleanly."""
+
+    SCRIPT = ROOT / "scripts" / "validate_community_health.py"
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        # No pre-seeded /tmp schema and no schema-related env leakage: the
+        # harness must work on a fresh checkout with nothing but the repo.
+        env.pop("TERMPROOF_ISSUE_CONFIG_SCHEMA", None)
+        env.pop("TERMPROOF_FUNDING_SCHEMA", None)
+        return subprocess.run(
+            [sys.executable, str(self.SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+            env=env,
+            timeout=180,
+        )
+
+    def test_harness_does_not_hardcode_tmp_schema(self) -> None:
+        source = self.SCRIPT.read_text(encoding="utf-8")
+        self.assertNotIn(
+            "/tmp/",
+            source,
+            "harness must use an in-repo vendored schema, not a /tmp path",
+        )
+
+    def test_harness_passes_hermetically_on_fresh_checkout(self) -> None:
+        proc = self._run()
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"harness should pass with only vendored schemas:\n{proc.stdout}\n{proc.stderr}",
+        )
+        self.assertIn("ALL VALIDATION CHECKS PASSED", proc.stdout)
+
+    def test_harness_missing_schema_is_clean_failure(self) -> None:
+        proc = self._run("--issue-config-schema", "/nonexistent/schema.json")
+        self.assertNotEqual(proc.returncode, 0, "missing schema must fail validation")
+        self.assertNotIn(
+            "Traceback", proc.stderr, "missing schema must be a clean failure, not a traceback"
+        )
+        self.assertIn("FAIL", proc.stdout)
 
 
 class SupportRoutingTest(unittest.TestCase):

--- a/tests/test_community_health.py
+++ b/tests/test_community_health.py
@@ -1,0 +1,157 @@
+"""Community-health / GitHub-template contract tests.
+
+These tests pin the review findings from the community-health remediation
+(md-mt/termproof#84 review, replacement PR): the bug-report recipe must be a
+valid TermProof recipe (``command.argv`` object, not a command array), the
+issue-template ``config.yml`` must satisfy GitHub's issue-config schema
+(contact links HTTP(S) only), and every YAML/template we ship must parse.
+
+Run: uv run python -m unittest tests.test_community_health -v
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+from termproof.config import VerifierConfig
+from termproof.recipe_schema import has_errors, validate_recipe_mapping
+
+ROOT = Path(__file__).resolve().parent.parent
+ISSUE_TEMPLATE_DIR = ROOT / ".github" / "ISSUE_TEMPLATE"
+GITHUB_YAML_FILES = sorted((ROOT / ".github").rglob("*.yml")) + sorted(
+    (ROOT / ".github").rglob("*.yaml")
+)
+
+# GitHub issue-template chooser schema (SchemaStore github-issue-config.json):
+# contact link URLs must be HTTP(S) only.
+CONTACT_URL_RE = re.compile(r"^https?://")
+
+
+def _extract_json_block(path: Path) -> dict:
+    """Extract the first ```json ... ``` block from a markdown template."""
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"```json\n(.*?)```", text, re.DOTALL)
+    if match is None:
+        raise AssertionError(f"no ```json block found in {path.name}")
+    return json.loads(match.group(1))
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _extract_frontmatter(path: Path) -> dict:
+    """Parse YAML frontmatter delimited by --- lines at the top of a file."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        raise AssertionError(f"no frontmatter in {path.name}")
+    end = text.index("\n---", 4)
+    return yaml.safe_load(text[4:end])
+
+
+class BugReportRecipeTest(unittest.TestCase):
+    """The bug-report template's sample recipe must be a valid TermProof recipe."""
+
+    def setUp(self) -> None:
+        self.recipe = _extract_json_block(ISSUE_TEMPLATE_DIR / "bug_report.md")
+
+    def test_recipe_uses_command_argv_object_not_array(self) -> None:
+        command = self.recipe.get("command")
+        self.assertIsInstance(command, dict, "command must be an object")
+        self.assertIsInstance(
+            command.get("argv"), list, "command.argv must be a list"
+        )
+        self.assertTrue(command.get("argv"), "command.argv must be non-empty")
+
+    def test_recipe_includes_recipe_version_one(self) -> None:
+        self.assertEqual(1, self.recipe.get("recipe_version"))
+
+    def test_recipe_validates_through_actual_loader(self) -> None:
+        issues = validate_recipe_mapping(self.recipe, VerifierConfig.builtin())
+        self.assertEqual([], issues, f"recipe should validate clean, got: {issues}")
+
+
+class IssueTemplateConfigTest(unittest.TestCase):
+    """config.yml must satisfy GitHub's issue-config schema."""
+
+    def setUp(self) -> None:
+        self.config = _load_yaml(ISSUE_TEMPLATE_DIR / "config.yml")
+
+    def test_blank_issues_flag_is_boolean(self) -> None:
+        self.assertIsInstance(self.config.get("blank_issues_enabled"), bool)
+
+    def test_contact_links_are_http_or_https(self) -> None:
+        links = self.config.get("contact_links")
+        self.assertIsInstance(links, list)
+        self.assertGreaterEqual(len(links), 1)
+        for link in links:
+            with self.subTest(link=link.get("name")):
+                self.assertIn("name", link)
+                self.assertIn("about", link)
+                url = link.get("url")
+                self.assertIsInstance(url, str)
+                self.assertRegex(
+                    url,
+                    CONTACT_URL_RE,
+                    f"contact link URL must be HTTP(S), got {url!r}",
+                )
+
+    def test_no_mailto_contact_links(self) -> None:
+        for link in self.config.get("contact_links", []):
+            self.assertNotIn("mailto:", link.get("url", ""))
+
+
+class TemplateFrontmatterTest(unittest.TestCase):
+    def test_bug_report_frontmatter(self) -> None:
+        fm = _extract_frontmatter(ISSUE_TEMPLATE_DIR / "bug_report.md")
+        self.assertEqual("Bug report", fm.get("name"))
+        self.assertIsInstance(fm.get("about"), str)
+        self.assertIn("bug", fm.get("labels", []))
+
+    def test_feature_request_frontmatter(self) -> None:
+        fm = _extract_frontmatter(ISSUE_TEMPLATE_DIR / "feature_request.md")
+        self.assertEqual("Feature request", fm.get("name"))
+        self.assertIsInstance(fm.get("about"), str)
+        self.assertIn("enhancement", fm.get("labels", []))
+
+
+class GitHubYamlParseTest(unittest.TestCase):
+    def test_every_github_yaml_file_parses(self) -> None:
+        self.assertTrue(GITHUB_YAML_FILES, "expected .github YAML files")
+        for path in GITHUB_YAML_FILES:
+            with self.subTest(file=str(path.relative_to(ROOT))):
+                data = _load_yaml(path)  # raises on syntax error
+                self.assertTrue(
+                    data is None or isinstance(data, dict),
+                    f"{path.name} must be a mapping or empty (got {type(data).__name__})",
+                )
+
+
+class SupportRoutingTest(unittest.TestCase):
+    """SUPPORT.md and config.yml must not route users to disabled Discussions."""
+
+    def test_support_md_has_no_discussions_link(self) -> None:
+        support = (ROOT / "SUPPORT.md").read_text(encoding="utf-8")
+        self.assertNotIn("discussions", support.lower())
+
+    def test_config_yml_has_no_discussions_link(self) -> None:
+        config = _load_yaml(ISSUE_TEMPLATE_DIR / "config.yml")
+        for link in config.get("contact_links", []):
+            self.assertNotIn("discussions", link.get("url", "").lower())
+
+
+class SecurityPolicyTest(unittest.TestCase):
+    def test_security_supported_versions_table_has_0_2(self) -> None:
+        security = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+        self.assertIn("0.2.x", security)
+        self.assertIn(":white_check_mark:", security)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_community_health.py
+++ b/tests/test_community_health.py
@@ -266,7 +266,6 @@ class SupportRoutingTest(unittest.TestCase):
     Discussions (feature disabled) are banned.
     """
 
-    OWN_REPO = "md-mt/termproof"
     OWN_DISCUSSIONS_URL = "github.com/md-mt/termproof/discussions"
     RUNBOOK = ROOT / "docs" / "launch" / "runbook.md"
 

--- a/tests/test_community_health.py
+++ b/tests/test_community_health.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -211,9 +212,73 @@ class ValidationHarnessTest(unittest.TestCase):
         )
         self.assertIn("FAIL", proc.stdout)
 
+    def test_harness_missing_funding_schema_is_clean_failure(self) -> None:
+        proc = self._run("--funding-schema", "/nonexistent/schema.json")
+        self.assertNotEqual(proc.returncode, 0, "missing funding schema must fail validation")
+        self.assertNotIn(
+            "Traceback",
+            proc.stderr,
+            "missing funding schema must be a clean failure, not a traceback",
+        )
+        self.assertIn("FAIL", proc.stdout)
+
+    def _malformed_schema_file(self) -> Path:
+        """A valid JSON document that is not a valid JSON Schema.
+
+        ``{"type": 12}`` is readable JSON but an invalid schema: jsonschema
+        raises ``SchemaError`` (not ``ValidationError``) when it is used.
+        """
+        tmp = Path(tempfile.mkdtemp(prefix="termproof-bad-schema-"))
+        path = tmp / "malformed-schema.json"
+        path.write_text('{"type": 12}', encoding="utf-8")
+        return path
+
+    def test_harness_malformed_issue_schema_is_clean_failure(self) -> None:
+        proc = self._run("--issue-config-schema", str(self._malformed_schema_file()))
+        self.assertNotEqual(
+            proc.returncode, 0, "malformed issue schema must fail validation"
+        )
+        self.assertNotIn(
+            "Traceback",
+            proc.stderr,
+            "malformed issue schema must be a clean failure, not a traceback",
+        )
+        self.assertIn("FAIL", proc.stdout)
+
+    def test_harness_malformed_funding_schema_is_clean_failure(self) -> None:
+        proc = self._run("--funding-schema", str(self._malformed_schema_file()))
+        self.assertNotEqual(
+            proc.returncode, 0, "malformed funding schema must fail validation"
+        )
+        self.assertNotIn(
+            "Traceback",
+            proc.stderr,
+            "malformed funding schema must be a clean failure, not a traceback",
+        )
+        self.assertIn("FAIL", proc.stdout)
+
 
 class SupportRoutingTest(unittest.TestCase):
-    """SUPPORT.md and config.yml must not route users to disabled Discussions."""
+    """Routing docs must not send users to TermProof's own disabled Discussions.
+
+    External projects' Discussion channels (Textualize, Bubble Tea, Ratatui,
+    Ink) are legitimate and must not be flagged; only ``md-mt/termproof``'s own
+    Discussions (feature disabled) are banned.
+    """
+
+    OWN_REPO = "md-mt/termproof"
+    OWN_DISCUSSIONS_URL = "github.com/md-mt/termproof/discussions"
+    RUNBOOK = ROOT / "docs" / "launch" / "runbook.md"
+
+    # External projects' Discussion channels are legitimate outreach targets
+    # and must never be flagged; only md-mt/termproof's own (disabled)
+    # Discussions are banned. A line is external when it names one of the
+    # framework projects or contains any URL (an own-repo route would be
+    # caught by OWN_DISCUSSIONS_URL first).
+    EXTERNAL_PROJECT_RE = re.compile(
+        r"\b(textual(?:ize)?|bubble tea|ratatui|ink)\b", re.IGNORECASE
+    )
+    URL_RE = re.compile(r"https?://")
 
     def test_support_md_has_no_discussions_link(self) -> None:
         support = (ROOT / "SUPPORT.md").read_text(encoding="utf-8")
@@ -223,6 +288,48 @@ class SupportRoutingTest(unittest.TestCase):
         config = _load_yaml(ISSUE_TEMPLATE_DIR / "config.yml")
         for link in config.get("contact_links", []):
             self.assertNotIn("discussions", link.get("url", "").lower())
+
+    def test_no_own_repo_discussions_url_repository_wide(self) -> None:
+        """No tracked document may link to md-mt/termproof's own Discussions."""
+        tracked = subprocess.run(
+            ["git", "ls-files", "*.md", "*.yml", "*.yaml"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.splitlines()
+        self.assertTrue(tracked, "expected tracked markdown/yaml documents")
+        for rel in tracked:
+            path = ROOT / rel
+            with self.subTest(file=rel):
+                text = path.read_text(encoding="utf-8", errors="replace").lower()
+                self.assertNotIn(
+                    self.OWN_DISCUSSIONS_URL,
+                    text,
+                    f"{rel} must not route to TermProof's own disabled Discussions",
+                )
+
+    def test_runbook_has_no_own_repo_discussions_routing(self) -> None:
+        """The runbook must not list or instruct TermProof's own Discussions.
+
+        External projects' Discussion channels (Textualize, Bubble Tea,
+        Ratatui, Ink) are legitimate and preserved; only routing that points
+        at md-mt/termproof's own (disabled) Discussions is banned.
+        """
+        runbook = self.RUNBOOK.read_text(encoding="utf-8")
+        for line in runbook.splitlines():
+            lowered = line.lower()
+            self.assertNotIn(self.OWN_DISCUSSIONS_URL, lowered)
+            if "discussion" not in lowered:
+                continue
+            is_external = bool(
+                self.EXTERNAL_PROJECT_RE.search(lowered)
+            ) or bool(self.URL_RE.search(lowered))
+            if not is_external:
+                self.fail(
+                    "runbook routes TermProof content to its own disabled "
+                    f"Discussions: {line!r}"
+                )
 
 
 class SecurityPolicyTest(unittest.TestCase):


### PR DESCRIPTION
## Supersedes legacy PR #84

This pull request **replaces** [md-mt/termproof#84](https://github.com/md-mt/termproof/pull/84)
(chore: add community-health & GitHub template files, reviewed head
`6bddf279d1966a17f0f59481dcecdba13e9f589d`). It recreates the useful
community-health/template changes on fresh `origin/main` (`4f2c314`) as a new
branch (`wt/prep-84-replacement`); the legacy branch was not pushed to or
rewritten. Every formal review finding from the `CHANGES_REQUESTED` review is
fixed; no new scope was added.

## What this adds

- `.github/ISSUE_TEMPLATE/bug_report.md` — reproducible-bug template (labeled `bug`)
- `.github/ISSUE_TEMPLATE/feature_request.md` — enhancement template (labeled `enhancement`)
- `.github/ISSUE_TEMPLATE/config.yml` — template chooser config
- `.github/PULL_REQUEST_TEMPLATE.md` — PR body checklist matching CONTRIBUTING.md
- `.github/CODEOWNERS` — default owner `@md-mt`
- `.github/FUNDING.yml` — valid empty funding mapping (`{}`, no sponsor handle configured), schema-validated
- `.github/dependabot.yml` — weekly `pip` + `github-actions` updates
- `SUPPORT.md` — help routing (issues, bug/feature reports, security, contributing)
- `SECURITY.md` — supported-versions table updated to 0.2.x supported / 0.1.x unsupported
- `scripts/validate_community_health.py` — hermetic community-health validation harness (vendored SchemaStore schemas under `scripts/schemas/`)
- `tests/test_community_health.py` — contract tests for the templates, funding config, and the harness

## Review findings fixed

**Blocking — bug_report.md recipe syntax (mw-ding)**
The sample recipe previously used `"command": ["..."]`, which is not valid
TermProof recipe syntax and would fail validation when copied. The sample now
uses the canonical shape:

```json
{
  "recipe_version": 1,
  "name": "repro",
  "command": {
    "argv": ["python3", "your_tui.py"]
  },
  "steps": []
}
```

`recipe_version: 1` avoids the legacy-version warning. The exact JSON block is
extracted and validated through TermProof's real loader (`termproof validate`)
by `scripts/validate_community_health.py`.

**Blocking — config.yml contact link schema (mw-ding)**
The security contact link used `mailto:md@mt.com`, which fails GitHub's
issue-config schema (`contact_links.url` must match `^https?://`). It now
points to the repository security-policy page
(`https://github.com/md-mt/termproof/security/policy`), which carries the
private-reporting email; `SUPPORT.md` likewise routes security reports to the
email in SECURITY.md rather than inlining it in the config.

**Comment — disabled GitHub Discussions (md-mt)**
`config.yml`, `SUPPORT.md`, and the feature-request template previously routed
users to `…/discussions`, but Discussions are disabled on this repository
(`hasDiscussionsEnabled=false`). With `blank_issues_enabled: false` that would
send users to an unavailable destination. All question/idea routing now points
at GitHub Issues (enabled) and SUPPORT.md. `CONTRIBUTING.md` likewise points
question routing at issues/draft PRs.

## Verifier pass 2 findings fixed

**Blocking — FUNDING.yml must be a valid funding mapping (verifier)**
`.github/FUNDING.yml` was comments-only, so `yaml.safe_load` returned `None`,
which fails the SchemaStore GitHub Funding schema (`None is not of type
'object'`). It is now an empty mapping (`{}`) — the correct shape while no
sponsor handle is configured — and is validated against the pinned
`github-funding.json` schema by both the unit tests and the harness. The YAML
parse test no longer permits `None`.

**Blocking — validation harness must be hermetic (verifier)**
`scripts/validate_community_health.py` hardcoded
`/tmp/github-issue-config.schema.json` but never downloaded, vendored, or
accepted the schema, so on a fresh checkout it crashed with a
`FileNotFoundError` traceback. The harness now uses SchemaStore schemas
vendored in-repo under `scripts/schemas/` (with provenance), accepts explicit
`--issue-config-schema` / `--funding-schema` overrides (path or URL), treats an
unreadable schema as a clean `[FAIL]` validation check (no traceback), and also
validates `FUNDING.yml` against the funding schema. The harness runs in CI
(`ci.yml`) and is covered by hermetic subprocess tests.

**Comment — CONTRIBUTING.md disabled-Discussions routing (verifier)**
`CONTRIBUTING.md` still told users to "Open a discussion or draft PR" even
though Discussions are disabled. It now routes questions to issues/draft PRs.

## Verifier re-review findings fixed (mw-ding CHANGES_REQUESTED)

**Blocking — repository-own disabled-Discussions routing in the launch runbook**
`docs/launch/runbook.md` still listed Discussions as a TermProof repository
touchpoint and instructed maintainers to archive the v0.2 launch retrospective
to a TermProof GitHub Discussion, but Discussions are disabled on this
repository (`hasDiscussionsEnabled=false`). The touchpoint list now reads
"stars, issues, PRs" (no discussions), and the retrospective is routed to an
enabled destination: a labeled GitHub issue (`launch-retrospective`). External
projects' Discussion channels (Textual, Bubble Tea, Ratatui, Ink outreach) are
legitimate and are preserved unchanged. `SupportRoutingTest` now covers the
runbook plus repository-wide own-routes (`git ls-files` scan for the own
`github.com/md-mt/termproof/discussions` URL, and a per-line runbook check that
flags only own-repo routes, never external outreach).

**Non-blocking — malformed schema override hardening (robustness)**
`scripts/validate_community_health.py` caught `jsonschema.ValidationError` but
not `jsonschema.SchemaError`; an explicit override with valid JSON but an
invalid schema (e.g. `{"type": 12}`) crashed with a traceback. The harness now
catches both and reports a clean `[FAIL]`, exit 1, zero stderr. Added
subprocess coverage for malformed issue-config and funding schema overrides,
plus the missing-funding-schema path.

## Verifier re-review (pass 3) findings fixed (mw-ding CHANGES_REQUESTED)

**Blocking — schema override loading/validation is fully hardened**

`load_schema` previously only caught read/network and JSON-parse failures.
Two malformed-override classes still escaped as tracebacks, violating the
harness's stated "clean failure, never a traceback" contract:

- A valid JSON numeric root (`42`) reached `jsonschema.validator_for`, which
  raised an uncaught `TypeError` ("argument of type 'int' is not a container
  or iterable").
- A non-UTF-8 schema file raised an uncaught `UnicodeDecodeError` from
  `Path.read_text(encoding="utf-8")` (decode failures are `ValueError`
  subclasses, not `OSError`, so the old read handler missed them).

The accepted schema root contract is now explicit and enforced: **a schema
override must be a JSON object (mapping)**. `load_schema` now:

- catches `UnicodeDecodeError` alongside `OSError`/`urllib.error.URLError`
  at the read boundary,
- reports a clean `[FAIL]` (exit 1, zero stderr, no traceback) for any schema
  that cannot be read, decoded, parsed as JSON, or whose root is not an
  object (number, string, array, null, boolean all covered),
- never lets a non-object root reach `jsonschema` (which raised
  `TypeError`/`SchemaError` depending on the shape).

The error handling stays at the correct boundary — decode/read/JSON errors in
`load_schema`, `jsonschema.SchemaError`/`ValidationError` in
`validate_against_schema` — without a blanket `except Exception` that would
swallow unrelated defects.

Added subprocess coverage for **both** override paths
(`--issue-config-schema` and `--funding-schema`): numeric root, array root,
scalar root, and invalid-UTF-8 bytes, all asserting exit 1, `[FAIL]`, and
empty stderr; plus a source-level test pinning the object/mapping root
contract. Array/scalar roots were already clean (via `SchemaError`) and are
now also rejected explicitly by the root contract.

## Validation

- `uv run python -m unittest tests.test_community_health -v` — **31 tests pass**
  (recipe copy/paste shape, `recipe_version`, config.yml HTTP(S) contact links,
  no-mailto, frontmatter, all `.github` YAML parses as mappings, FUNDING.yml
  mapping + funding-schema validation, no disabled-Discussions routes including
  the launch runbook and repository-wide own-routes, SECURITY.md versions,
  harness hermeticity + clean-failure behavior for missing, malformed
  (SchemaError), numeric-root, array-root, scalar-root, and non-UTF-8
  issue/funding schema overrides, and the object/mapping schema root contract).
- `uv run python scripts/validate_community_health.py` — **all checks pass**:
  - recipe extracted from `bug_report.md` validates via `termproof validate` (real loader/schema)
  - `config.yml` validates against the vendored SchemaStore `github-issue-config.json` schema (jsonschema)
  - all contact-link URLs are HTTP(S)
  - `FUNDING.yml` is a mapping and validates against the vendored SchemaStore `github-funding.json` schema
  - every `.github` YAML file parses
- `uv run python scripts/validate_community_health.py` runs in CI on every PR.
- `uv run python -m unittest discover -s tests` — **252 tests pass** (full suite).

Closes #72

---
*Built by eng-web (deepseek-v4-flash)*
