### PR TITLE
fix: loud missing-video warnings + configurable idle cap (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,15 +216,10 @@ Plugin references using `tui_verifier.*:ClassName` are translated to `termproof.
 
 ## Configuration
 
-Optional configuration lives in `~/.config/termproof/config.yaml` (user) or `.termproof/config.yaml` (project). The `defaults` block mirrors the recipe defaults:
+Optional configuration lives in `~/.config/termproof/config.yaml` (user) or `.termproof/config.yaml` (project). The `defaults` block currently exposes the post-script idle wait cap:
 
 ```yaml
 defaults:
-  timeout_seconds: 30
-  cols: 100
-  rows: 30
-  video_fps: 60
-  out_dir: ".termproof/runs"
   # Cap (seconds) for the post-script idle wait in PTY mode. After the last
   # step, TermProof waits for the screen to quiesce before capturing the
   # final state. Slow-quiescing TUIs may need a larger cap; set to null to
@@ -232,7 +227,7 @@ defaults:
   idle_cap_seconds: 3.0
 ```
 
-`idle_cap_seconds` is the documented replacement for the former hard-coded 3-second idle cap in `runner.py`. Defaults to `3.0` to preserve existing behavior; raise it (or set `null`) for TUIs that take longer to settle.
+`idle_cap_seconds` is the documented replacement for the former hard-coded 3-second idle cap in `runner.py`. Defaults to `3.0` to preserve existing behavior; raise it (or set `null`) for TUIs that take longer to settle. The value must be a finite, nonnegative number: negative, NaN, or infinite values are rejected at config load.
 
 ## Packaging
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,26 @@ Existing project and user configuration remains readable without being modified.
 
 Plugin references using `tui_verifier.*:ClassName` are translated to `termproof.*:ClassName` at load time. This narrow compat path is intentionally limited to configured plugin references; the legacy CLI and import package are not shipped.
 
+## Configuration
+
+Optional configuration lives in `~/.config/termproof/config.yaml` (user) or `.termproof/config.yaml` (project). The `defaults` block mirrors the recipe defaults:
+
+```yaml
+defaults:
+  timeout_seconds: 30
+  cols: 100
+  rows: 30
+  video_fps: 60
+  out_dir: ".termproof/runs"
+  # Cap (seconds) for the post-script idle wait in PTY mode. After the last
+  # step, TermProof waits for the screen to quiesce before capturing the
+  # final state. Slow-quiescing TUIs may need a larger cap; set to null to
+  # wait up to the recipe's timeout_seconds instead of a fixed cap.
+  idle_cap_seconds: 3.0
+```
+
+`idle_cap_seconds` is the documented replacement for the former hard-coded 3-second idle cap in `runner.py`. Defaults to `3.0` to preserve existing behavior; raise it (or set `null`) for TUIs that take longer to settle.
+
 ## Packaging
 
 ```bash

--- a/termproof/builtin_video.py
+++ b/termproof/builtin_video.py
@@ -9,6 +9,10 @@ class AggFfmpegBackend:
     """agg + ffmpeg video backend (current behavior)."""
 
     name = "agg_ffmpeg"
+    # Distinguishes the built-in backend from caller-supplied custom
+    # VideoBackend plugins: the built-in path is gated on host tools
+    # (agg/ffmpeg), while custom plugin dispatch remains ungated.
+    builtin = True
 
     def render(
         self,

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -58,10 +58,20 @@ BUILTIN_DEFAULTS: dict[str, Any] = {
         "volumes": [{"host": ".", "container": "/workspace"}],
         "env": {},
     },
+    "defaults": {
+        "idle_cap_seconds": 3.0,
+    },
 }
 
 
 # -- config model -----------------------------------------------------------
+
+@dataclass(frozen=True)
+class GlobalDefaults:
+    # Cap for the post-script idle wait in PTY mode. None means wait for
+    # quiescence up to the recipe timeout instead of a fixed cap.
+    idle_cap_seconds: float | None = 3.0
+
 
 @dataclass(frozen=True)
 class DockerBackendConfig:
@@ -84,6 +94,7 @@ class VerifierConfig:
     video_backends: dict[str, str]
     session_backend: str
     docker: DockerBackendConfig
+    defaults: GlobalDefaults
 
     @classmethod
     def builtin(cls) -> VerifierConfig:
@@ -144,6 +155,7 @@ def load_config(
 # -- internal helpers --------------------------------------------------------
 
 def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
+    defaults_raw = data.get("defaults", {})
     docker_raw = data.get("docker", {})
     docker_volumes = docker_raw.get("volumes", [{"host": ".", "container": "/workspace"}])
     return VerifierConfig(
@@ -163,6 +175,14 @@ def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
                 str(key): str(value)
                 for key, value in dict(docker_raw.get("env", {})).items()
             },
+        ),
+        defaults=GlobalDefaults(
+            idle_cap_seconds=(
+                None
+                if "idle_cap_seconds" in defaults_raw
+                and defaults_raw["idle_cap_seconds"] is None
+                else float(defaults_raw.get("idle_cap_seconds", 3.0))
+            ),
         ),
     )
 

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -154,6 +155,28 @@ def load_config(
 
 # -- internal helpers --------------------------------------------------------
 
+def _parse_idle_cap_seconds(value: Any) -> float | None:
+    """Parse ``idle_cap_seconds``, rejecting non-finite or negative values.
+
+    A negative or NaN/Inf value would silently eliminate idle waiting (a
+    ``min()`` cap of ``-1`` or ``nan`` never waits), so config loading must
+    refuse it instead of degrading behavior invisibly.
+    """
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"idle_cap_seconds must be a finite nonnegative number, got {value!r}"
+        ) from error
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValueError(
+            f"idle_cap_seconds must be a finite nonnegative number, got {value!r}"
+        )
+    return parsed
+
+
 def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
     defaults_raw = data.get("defaults", {})
     docker_raw = data.get("docker", {})
@@ -177,11 +200,8 @@ def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
             },
         ),
         defaults=GlobalDefaults(
-            idle_cap_seconds=(
-                None
-                if "idle_cap_seconds" in defaults_raw
-                and defaults_raw["idle_cap_seconds"] is None
-                else float(defaults_raw.get("idle_cap_seconds", 3.0))
+            idle_cap_seconds=_parse_idle_cap_seconds(
+                defaults_raw.get("idle_cap_seconds", 3.0)
             ),
         ),
     )

--- a/termproof/evidence.py
+++ b/termproof/evidence.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .agg_bundle import resolve_agg
+from .builtin_video import AggFfmpegBackend
 from .models import RunResult, StepResult
 from .screen import render_svg, replay_cast
 
@@ -63,12 +64,16 @@ def render_artifacts(
             artifacts[name.removesuffix(".md").removesuffix(".json")] = str(path)
     if render_video:
         mp4_path = run_dir / "session.mp4"
-        if video_backend is not None:
-            # A caller-supplied backend owns its own dependency requirements;
-            # do not impose host tool checks on the plugin boundary.
+        if video_backend is not None and not isinstance(video_backend, AggFfmpegBackend):
+            # A caller-supplied custom backend owns its own dependency
+            # requirements; do not impose host tool checks on the plugin
+            # boundary.
             video_backend.render(cast_path, mp4_path, video_fps)
             artifacts["video"] = str(mp4_path)
         else:
+            # The built-in agg_ffmpeg backend (or no backend at all) cannot
+            # satisfy a --video request without the host tools; warn loudly
+            # and omit the artifact instead of recording a nonexistent file.
             missing = _missing_video_tools()
             if missing:
                 warnings.warn(
@@ -78,7 +83,10 @@ def render_artifacts(
                     stacklevel=2,
                 )
             else:
-                render_mp4(cast_path, mp4_path, video_fps)
+                if video_backend is not None:
+                    video_backend.render(cast_path, mp4_path, video_fps)
+                else:
+                    render_mp4(cast_path, mp4_path, video_fps)
                 artifacts["video"] = str(mp4_path)
     return artifacts
 

--- a/termproof/evidence.py
+++ b/termproof/evidence.py
@@ -61,15 +61,44 @@ def render_artifacts(
         path = run_dir / name
         if path.exists():
             artifacts[name.removesuffix(".md").removesuffix(".json")] = str(path)
-    agg_path = resolve_agg()
-    if render_video and agg_path:
+    if render_video:
         mp4_path = run_dir / "session.mp4"
         if video_backend is not None:
+            # A caller-supplied backend owns its own dependency requirements;
+            # do not impose host tool checks on the plugin boundary.
             video_backend.render(cast_path, mp4_path, video_fps)
+            artifacts["video"] = str(mp4_path)
         else:
-            render_mp4(cast_path, mp4_path, video_fps)
-        artifacts["video"] = str(mp4_path)
+            missing = _missing_video_tools()
+            if missing:
+                warnings.warn(
+                    "video evidence was requested (--video) but "
+                    f"{' and '.join(missing)} could not be resolved; skipping video. "
+                    "Install the missing tool(s) or use a platform wheel that bundles agg.",
+                    stacklevel=2,
+                )
+            else:
+                render_mp4(cast_path, mp4_path, video_fps)
+                artifacts["video"] = str(mp4_path)
     return artifacts
+
+
+def _missing_video_tools() -> list[str]:
+    """Return the names of video tools that cannot be resolved on this system."""
+    missing = []
+    if not resolve_agg():
+        missing.append("agg")
+    if _resolve_ffmpeg() is None:
+        missing.append("ffmpeg")
+    return missing
+
+
+def _resolve_ffmpeg() -> str | None:
+    """Resolve ffmpeg without raising, returning None when it is unavailable."""
+    try:
+        return find_ffmpeg()
+    except Exception:
+        return None
 
 
 def _render_step_screens(

--- a/termproof/evidence.py
+++ b/termproof/evidence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -234,7 +234,13 @@ class VerificationRunner:
             if recipe.expect_exit_code is not None:
                 session.wait_for_exit(recipe.timeout_seconds)
             else:
-                session.wait_for_idle(0.5, min(3, recipe.timeout_seconds))
+                idle_cap = self.config.defaults.idle_cap_seconds
+                idle_timeout = (
+                    min(idle_cap, recipe.timeout_seconds)
+                    if idle_cap is not None
+                    else recipe.timeout_seconds
+                )
+                session.wait_for_idle(0.5, idle_timeout)
             return steps, session.raw_output, session.exit_code, session.screen
 
     def run_process(

--- a/tests/test_bundled_video.py
+++ b/tests/test_bundled_video.py
@@ -108,6 +108,53 @@ class ResolveAggFallbackTests(unittest.TestCase):
         backend.render.assert_called_once()
         self.assertIn("video", artifacts)
 
+    # -- built-in backend distinction regression tests -----------------------
+
+    @patch("termproof.evidence._resolve_ffmpeg", return_value=None)
+    @patch("termproof.evidence.resolve_agg", return_value=None)
+    def test_builtin_backend_warns_and_omits_when_tools_missing(
+        self, resolve_agg, resolve_ffmpeg
+    ) -> None:
+        """The built-in agg_ffmpeg backend must warn + omit when tools are absent.
+
+        Unlike a caller-supplied custom plugin, the built-in backend cannot
+        satisfy a --video request on a host without agg/ffmpeg; it must not
+        record a nonexistent video artifact.
+        """
+        from termproof.builtin_video import AggFfmpegBackend
+
+        backend = AggFfmpegBackend()
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            self._write_cast(run_dir)
+            with self.assertWarns(UserWarning) as caught:
+                artifacts = evidence.render_artifacts(
+                    run_dir, render_video=True, video_fps=60, video_backend=backend
+                )
+        self.assertNotIn("video", artifacts)
+        message = str(caught.warning)
+        self.assertIn("agg", message)
+        self.assertIn("--video", message)
+
+    @patch("termproof.evidence.find_ffmpeg", return_value="ffmpeg")
+    @patch("termproof.evidence.subprocess.run")
+    @patch("termproof.evidence.resolve_agg", return_value="/wheel/agg")
+    def test_builtin_backend_renders_when_tools_present(
+        self, resolve_agg, subprocess_run, find_ffmpeg
+    ) -> None:
+        """The built-in agg_ffmpeg backend still records video when tools exist."""
+        from termproof.builtin_video import AggFfmpegBackend
+
+        backend = AggFfmpegBackend()
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            self._write_cast(run_dir)
+            artifacts = evidence.render_artifacts(
+                run_dir, render_video=True, video_fps=60, video_backend=backend
+            )
+        self.assertIn("video", artifacts)
+        self.assertTrue(subprocess_run.called)
+
     # -- helper unit tests --------------------------------------------------
 
     @patch("termproof.evidence._resolve_ffmpeg", return_value=None)

--- a/tests/test_bundled_video.py
+++ b/tests/test_bundled_video.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
+import warnings
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from termproof import evidence
 
@@ -21,25 +23,110 @@ class RenderMp4Tests(unittest.TestCase):
 
 
 class ResolveAggFallbackTests(unittest.TestCase):
+    @staticmethod
+    def _write_cast(run_dir: Path) -> None:
+        run_dir.mkdir()
+        # Create a minimal cast file so replay_cast doesn't crash.
+        (run_dir / "session.cast").write_text(
+            '{"version":2,"width":100,"height":30}\n'
+            '[0.1,"o","hello\\n"]\n',
+            encoding="utf-8",
+        )
+
     @patch("termproof.evidence.resolve_agg", return_value=None)
-    def test_render_artifacts_skips_video_when_no_agg(self, resolve_agg) -> None:
-        """Video rendering should be silently skipped when no agg is available."""
-        import tempfile
-
-        from termproof.evidence import render_artifacts
-
+    def test_render_artifacts_omits_video_when_no_agg(self, resolve_agg) -> None:
+        """Video must be omitted gracefully when the built-in agg is unavailable."""
         with tempfile.TemporaryDirectory() as tmp:
             run_dir = Path(tmp) / "run"
-            run_dir.mkdir()
-            # Create a minimal cast file so replay_cast doesn't crash
-            cast_path = run_dir / "session.cast"
-            cast_path.write_text(
-                '{"version":2,"width":100,"height":30}\n'
-                '[0.1,"o","hello\\n"]\n',
-                encoding="utf-8",
-            )
-            artifacts = render_artifacts(run_dir, render_video=True, video_fps=60)
+            self._write_cast(run_dir)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                artifacts = evidence.render_artifacts(run_dir, render_video=True, video_fps=60)
             self.assertNotIn("video", artifacts)
+
+    @patch("termproof.evidence.resolve_agg", return_value=None)
+    def test_render_artifacts_warns_when_video_requested_without_tools(self, resolve_agg) -> None:
+        """An explicit --video request must not be silently dropped."""
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            self._write_cast(run_dir)
+            with self.assertWarns(UserWarning) as caught:
+                artifacts = evidence.render_artifacts(run_dir, render_video=True, video_fps=60)
+
+        message = str(caught.warning)
+        self.assertIn("agg", message)
+        self.assertIn("--video", message)
+        self.assertIn("skipping video", message)
+        self.assertNotIn("video", artifacts)
+
+    @patch("termproof.evidence.resolve_agg", return_value=None)
+    def test_render_artifacts_no_warning_when_video_not_requested(self, resolve_agg) -> None:
+        """No warning should be emitted when video was not requested."""
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            self._write_cast(run_dir)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                artifacts = evidence.render_artifacts(run_dir, render_video=False, video_fps=60)
+            self.assertNotIn("video", artifacts)
+
+    # -- adversarial plugin-boundary regression tests -----------------------
+
+    @patch("termproof.evidence._resolve_ffmpeg", return_value=None)
+    @patch("termproof.evidence.resolve_agg", return_value=None)
+    def test_custom_backend_runs_when_agg_and_ffmpeg_unavailable(
+        self, resolve_agg, resolve_ffmpeg
+    ) -> None:
+        """A caller-supplied VideoBackend must run even when no host video tools exist."""
+        backend = MagicMock()
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            self._write_cast(run_dir)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")  # custom path must stay quiet
+                artifacts = evidence.render_artifacts(
+                    run_dir, render_video=True, video_fps=60, video_backend=backend
+                )
+        backend.render.assert_called_once()
+        self.assertIn("video", artifacts)
+
+    @patch("termproof.evidence._resolve_ffmpeg", return_value=None)
+    @patch("termproof.evidence.resolve_agg", return_value="/wheel/agg")
+    def test_custom_backend_runs_when_ffmpeg_unavailable_but_agg_present(
+        self, resolve_agg, resolve_ffmpeg
+    ) -> None:
+        """A supplied backend must not be skipped merely because ffmpeg is absent."""
+        backend = MagicMock()
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            self._write_cast(run_dir)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                artifacts = evidence.render_artifacts(
+                    run_dir, render_video=True, video_fps=60, video_backend=backend
+                )
+        backend.render.assert_called_once()
+        self.assertIn("video", artifacts)
+
+    # -- helper unit tests --------------------------------------------------
+
+    @patch("termproof.evidence._resolve_ffmpeg", return_value=None)
+    @patch("termproof.evidence.resolve_agg", return_value=None)
+    def test_missing_video_tools_reports_agg_and_ffmpeg(self, resolve_agg, resolve_ffmpeg) -> None:
+        self.assertEqual(evidence._missing_video_tools(), ["agg", "ffmpeg"])
+
+    @patch("termproof.evidence._resolve_ffmpeg", return_value="/usr/bin/ffmpeg")
+    @patch("termproof.evidence.resolve_agg", return_value="/wheel/agg")
+    def test_missing_video_tools_empty_when_all_present(self, resolve_agg, resolve_ffmpeg) -> None:
+        self.assertEqual(evidence._missing_video_tools(), [])
+
+    @patch("termproof.evidence.find_ffmpeg", side_effect=RuntimeError("no ffmpeg"))
+    def test_resolve_ffmpeg_returns_none_when_find_raises(self, find_ffmpeg) -> None:
+        self.assertIsNone(evidence._resolve_ffmpeg())
+
+    @patch("termproof.evidence.find_ffmpeg", return_value="/usr/bin/ffmpeg")
+    def test_resolve_ffmpeg_returns_path(self, find_ffmpeg) -> None:
+        self.assertEqual(evidence._resolve_ffmpeg(), "/usr/bin/ffmpeg")
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,54 @@ class ConfigTest(unittest.TestCase):
             self.assertIn("wait_for_text", config.steps)
             self.assertIn("output_contains", config.assertions)
 
+    def test_builtin_config_defaults_idle_cap_seconds(self) -> None:
+        """The post-script idle wait cap is a documented, configurable default."""
+        config = VerifierConfig.builtin()
+        self.assertEqual(config.defaults.idle_cap_seconds, 3.0)
+
+    def test_load_config_parses_idle_cap_seconds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = tmp + "/user.yaml"
+            Path(user_yaml).write_text(
+                "defaults:\n  idle_cap_seconds: 7.5\n",
+                encoding="utf-8",
+            )
+            config = load_config(
+                project_path=Path(tmp),
+                user_path=Path(user_yaml),
+            )
+            self.assertEqual(config.defaults.idle_cap_seconds, 7.5)
+            # other config unchanged
+            self.assertEqual(config.docker.image, "")
+
+    def test_load_config_allows_null_idle_cap(self) -> None:
+        """Null idle cap means wait for quiescence up to the recipe timeout."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = tmp + "/user.yaml"
+            Path(user_yaml).write_text(
+                "defaults:\n  idle_cap_seconds:\n",
+                encoding="utf-8",
+            )
+            config = load_config(
+                project_path=Path(tmp),
+                user_path=Path(user_yaml),
+            )
+            self.assertIsNone(config.defaults.idle_cap_seconds)
+
+    def test_load_config_preserves_idle_cap_when_key_absent(self) -> None:
+        """A defaults block that omits idle_cap_seconds keeps the builtin cap."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = tmp + "/user.yaml"
+            Path(user_yaml).write_text(
+                "defaults:\n  video_fps: 30\n",
+                encoding="utf-8",
+            )
+            config = load_config(
+                project_path=Path(tmp),
+                user_path=Path(user_yaml),
+            )
+            self.assertEqual(config.defaults.idle_cap_seconds, 3.0)
+
     def test_load_config_cascades_user_over_builtin(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             user_yaml = tmp + "/user.yaml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,6 +66,62 @@ class ConfigTest(unittest.TestCase):
             )
             self.assertIsNone(config.defaults.idle_cap_seconds)
 
+    def test_load_config_rejects_negative_idle_cap(self) -> None:
+        """A negative idle cap would silently eliminate idle waiting; reject it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = tmp + "/user.yaml"
+            Path(user_yaml).write_text(
+                "defaults:\n  idle_cap_seconds: -1\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                load_config(
+                    project_path=Path(tmp),
+                    user_path=Path(user_yaml),
+                )
+
+    def test_load_config_rejects_nan_idle_cap(self) -> None:
+        """NaN is not a finite number of seconds; reject it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = tmp + "/user.yaml"
+            Path(user_yaml).write_text(
+                "defaults:\n  idle_cap_seconds: .nan\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                load_config(
+                    project_path=Path(tmp),
+                    user_path=Path(user_yaml),
+                )
+
+    def test_load_config_rejects_infinite_idle_cap(self) -> None:
+        """Infinity is not a finite number of seconds; reject it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = tmp + "/user.yaml"
+            Path(user_yaml).write_text(
+                "defaults:\n  idle_cap_seconds: .inf\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                load_config(
+                    project_path=Path(tmp),
+                    user_path=Path(user_yaml),
+                )
+
+    def test_load_config_accepts_zero_idle_cap(self) -> None:
+        """A zero idle cap is finite and nonnegative; it is a valid explicit choice."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = tmp + "/user.yaml"
+            Path(user_yaml).write_text(
+                "defaults:\n  idle_cap_seconds: 0\n",
+                encoding="utf-8",
+            )
+            config = load_config(
+                project_path=Path(tmp),
+                user_path=Path(user_yaml),
+            )
+            self.assertEqual(config.defaults.idle_cap_seconds, 0.0)
+
     def test_load_config_preserves_idle_cap_when_key_absent(self) -> None:
         """A defaults block that omits idle_cap_seconds keeps the builtin cap."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from termproof.config import VerifierConfig
+from termproof.config import VerifierConfig, load_config
 from termproof.models import CommandSpec, Recipe
 from termproof.runner import VerificationRunner
 
@@ -176,3 +176,151 @@ class RunnerTest(unittest.TestCase):
                 video_backend_name="agg_ffmpeg",
             )
             self.assertTrue(result.passed)
+
+
+class IdleCapWiringTest(unittest.TestCase):
+    """The post-script idle wait cap must come from config, not a magic 3."""
+
+    class _RecordingSession:
+        def __init__(self) -> None:
+            self.idle_calls: list[tuple[float, float]] = []
+
+        def __enter__(self) -> "IdleCapWiringTest._RecordingSession":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        @property
+        def raw_output(self) -> str:
+            return ""
+
+        @property
+        def exit_code(self) -> int | None:
+            return None
+
+        @property
+        def screen(self) -> str:
+            return ""
+
+        def wait_for_idle(self, stable_seconds: float, timeout_seconds: float) -> bool:
+            self.idle_calls.append((stable_seconds, timeout_seconds))
+            return True
+
+        def wait_for_exit(self, timeout_seconds: float) -> int | None:
+            return None
+
+    class _FakeBackend:
+        def __init__(self, session: "IdleCapWiringTest._RecordingSession") -> None:
+            self.session = session
+
+        def create_session(self, argv, cast_path, cwd, env, cols, rows):
+            return self.session
+
+    def _run_pty_with_config(self, idle_cap_seconds: float | None) -> list[tuple[float, float]]:
+        session = self._RecordingSession()
+        runner = VerificationRunner()
+        runner.session_backend = self._FakeBackend(session)
+        runner.config = load_config(
+            project_path=Path(tempfile.mkdtemp()),
+            user_path=Path(tempfile.mkdtemp()) / "nonexistent.yaml",
+        )
+        recipe = Recipe(
+            name="idle-cap",
+            command=CommandSpec(argv=[sys.executable, "-c", "import time; time.sleep(2)"]),
+            steps=[],
+            expect_exit_code=None,
+            timeout_seconds=30.0,
+        )
+        runner._run_pty(recipe, Path(tempfile.mkdtemp()))
+        return session.idle_calls
+
+    def test_default_idle_cap_is_three_seconds(self) -> None:
+        calls = self._run_pty_with_config(idle_cap_seconds=3.0)
+        # With the builtin default (3.0) the idle wait is capped at 3s.
+        self.assertEqual(calls, [(0.5, 3.0)])
+
+    def test_configured_idle_cap_is_used(self) -> None:
+        session = self._RecordingSession()
+        runner = VerificationRunner()
+        runner.session_backend = self._FakeBackend(session)
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text("defaults:\n  idle_cap_seconds: 7.5\n", encoding="utf-8")
+            runner.config = load_config(
+                project_path=Path(tmp),
+                user_path=user_yaml,
+            )
+            recipe = Recipe(
+                name="idle-cap",
+                command=CommandSpec(argv=[sys.executable, "-c", "import time; time.sleep(2)"]),
+                steps=[],
+                expect_exit_code=None,
+                timeout_seconds=30.0,
+            )
+            runner._run_pty(recipe, Path(tmp) / "run")
+        self.assertEqual(session.idle_calls, [(0.5, 7.5)])
+
+    def test_null_idle_cap_waits_up_to_recipe_timeout(self) -> None:
+        session = self._RecordingSession()
+        runner = VerificationRunner()
+        runner.session_backend = self._FakeBackend(session)
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text("defaults:\n  idle_cap_seconds:\n", encoding="utf-8")
+            runner.config = load_config(
+                project_path=Path(tmp),
+                user_path=user_yaml,
+            )
+            recipe = Recipe(
+                name="idle-cap",
+                command=CommandSpec(argv=[sys.executable, "-c", "import time; time.sleep(2)"]),
+                steps=[],
+                expect_exit_code=None,
+                timeout_seconds=30.0,
+            )
+            runner._run_pty(recipe, Path(tmp) / "run")
+        # No cap: wait up to the recipe timeout for quiescence.
+        self.assertEqual(session.idle_calls, [(0.5, 30.0)])
+
+
+class QuiescenceBehaviorTest(unittest.TestCase):
+    """wait_for_idle detects quiescence and respects timeouts on real sessions."""
+
+    def test_wait_for_idle_returns_true_when_screen_stabilizes(self) -> None:
+        runner = VerificationRunner()
+        session = runner.session_backend.create_session(
+            argv=[sys.executable, "-c", "print('hello'); import time; time.sleep(5)"],
+            cast_path=Path(tempfile.mkdtemp()) / "session.cast",
+            cwd=None,
+            env={},
+            cols=80,
+            rows=24,
+        )
+        try:
+            with session:
+                self.assertTrue(session.wait_for_idle(0.2, 3.0))
+        finally:
+            session.close()
+
+    def test_wait_for_idle_times_out_when_output_never_stable(self) -> None:
+        runner = VerificationRunner()
+        session = runner.session_backend.create_session(
+            # Prints a line every 50ms for ~2s: screen never stabilizes for
+            # 0.3s inside the 0.8s window, so wait_for_idle must time out.
+            argv=[
+                sys.executable,
+                "-c",
+                "import time; [print(i) or time.sleep(0.05) for i in range(40)]",
+            ],
+            cast_path=Path(tempfile.mkdtemp()) / "session.cast",
+            cwd=None,
+            env={},
+            cols=80,
+            rows=24,
+        )
+        try:
+            with session:
+                self.assertFalse(session.wait_for_idle(0.3, 0.8))
+        finally:
+            session.close()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -217,7 +217,7 @@ class IdleCapWiringTest(unittest.TestCase):
         def __init__(self) -> None:
             self.idle_calls: list[tuple[float, float]] = []
 
-        def __enter__(self) -> "IdleCapWiringTest._RecordingSession":
+        def __enter__(self) -> IdleCapWiringTest._RecordingSession:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -243,7 +243,7 @@ class IdleCapWiringTest(unittest.TestCase):
             return None
 
     class _FakeBackend:
-        def __init__(self, session: "IdleCapWiringTest._RecordingSession") -> None:
+        def __init__(self, session: IdleCapWiringTest._RecordingSession) -> None:
             self.session = session
 
         def create_session(self, argv, cast_path, cwd, env, cols, rows):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from termproof.config import VerifierConfig, load_config
 from termproof.models import CommandSpec, Recipe
@@ -176,6 +177,37 @@ class RunnerTest(unittest.TestCase):
                 video_backend_name="agg_ffmpeg",
             )
             self.assertTrue(result.passed)
+
+    @patch("termproof.evidence._resolve_ffmpeg", return_value=None)
+    @patch("termproof.evidence.resolve_agg", return_value=None)
+    def test_run_render_video_default_backend_warns_and_omits_when_tools_missing(
+        self, resolve_agg, resolve_ffmpeg
+    ) -> None:
+        """Runner-level regression: a normal --video run through the built-in
+        agg_ffmpeg backend must warn and omit the video artifact when the host
+        lacks agg/ffmpeg, instead of recording a nonexistent artifact."""
+        with tempfile.TemporaryDirectory() as tmp:
+            recipe = Recipe(
+                name="video-warn",
+                command=CommandSpec(
+                    argv=[sys.executable, "-c", "print('ok')"],
+                    pty=False,
+                ),
+                steps=[{"action": "wait_for_text", "text": "ok"}],
+                assertions=[{"type": "output_contains", "value": "ok"}],
+            )
+            with self.assertWarns(UserWarning) as caught:
+                result = VerificationRunner().run(
+                    recipe,
+                    Path(tmp),
+                    render_video=True,
+                    video_backend_name="agg_ffmpeg",
+                )
+            self.assertTrue(result.passed)
+            self.assertNotIn("video", result.artifacts)
+            message = str(caught.warning)
+            self.assertIn("agg", message)
+            self.assertIn("--video", message)
 
 
 class IdleCapWiringTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR **supersedes and replaces legacy PR #87** (`fix/loud-missing-video`, reviewed head `f01f0aac`), which received a formal CHANGES_REQUESTED review from mw-ding. The legacy branch is left untouched; this is a fresh branch (`wt/prep-87-replacement`) created from current `main`, recreating the correct legacy intent while fixing every review finding.

Closes #77.

> Post-merge remediation (round 2): after verifier approval at head `2654fac`, PR #90 merged to `main` (`e1df6c1`), adding ruff/mypy/coverage CI gates and touching overlapping files. This head was rebased onto current `main` (`e1df6c1`) and conflicts were resolved while preserving all reviewed behavior: the built-in `AggFfmpegBackend` stays gated in `render_artifacts` (loud warning + omitted artifact when agg/ffmpeg are missing), custom `VideoBackend` dispatch remains ungated, and `defaults.idle_cap_seconds` remains configurable/documented/validated — without resurrecting the dead `timeout_seconds`/`cols`/`rows`/`video_fps`/`out_dir` fields that #89 removed. The main-side test that silently skipped video when agg was missing (`test_render_artifacts_skips_video_when_no_agg`) was superseded by the approved loud-warning test (`test_render_artifacts_omits_video_when_no_agg`). Two merge-casualty fixes were folded in as a resolution commit: restored the `warnings` import in `evidence.py` (dropped by #90's lint pass but required by the approved loud-warning path) and unquoted forward refs in `IdleCapWiringTest` to satisfy the new ruff UP037 gate (behavior-neutral). The base note below reflects the rebased diff.

## Problem

Issue #77 has two halves:

1. Requesting `--video` on a host without the required tools silently dropped the video: the run still PASSed with only `video: -` in the output. An evidence tool must not silently omit requested evidence.
2. The post-script idle wait in `runner.py` was hard-capped at a magic 3 seconds (`min(3, recipe.timeout_seconds)`), which can truncate slow-quiescing TUIs.

## Changes

### Half 1: loud missing-video behavior (legacy intent, review-fixed)

`termproof/evidence.py::render_artifacts` emits a loud `UserWarning` when video is explicitly requested but the built-in video path cannot resolve its tools, naming the missing tool(s) (`agg`, `ffmpeg`) and stating that video was skipped. Behavior is unchanged when `--video` is not requested.

**Blocking review findings fixed:**

1. The legacy PR gated tool resolution *before* backend dispatch, so a caller-supplied custom `VideoBackend` was skipped whenever ffmpeg was absent — violating the plugin boundary. The first replacement attempt then over-corrected: it classified *every* non-None backend as custom, so the built-in `agg_ffmpeg` backend — which is what a normal Runner/CLI `--video` run resolves by default (`termproof/runner.py` resolves `video_backend_name="agg_ffmpeg"` from the registry) — bypassed the missing-tool gating entirely. `AggFfmpegBackend` delegates to `render_mp4`, which silently returns when agg is absent, so the run PASSed while recording a nonexistent `video` artifact. That was the original #77 failure.

   Now the built-in backend is distinguished from true custom plugins:
   - `AggFfmpegBackend` carries a `builtin = True` marker (`termproof/builtin_video.py`).
   - `render_artifacts` treats any backend that is *not* the built-in `AggFfmpegBackend` as a caller-supplied custom plugin: it is invoked directly, owns its own dependency requirements, and no host tool checks are imposed on the plugin boundary (custom dispatch remains ungated).
   - The built-in path (whether resolved as `agg_ffmpeg` or `None`) is gated by `_missing_video_tools()`; when agg/ffmpeg cannot be resolved it warns loudly and **omits** the `video` artifact instead of recording a nonexistent file.

**Adversarial regression tests added:**
- `tests/test_runner.py::RunnerTest::test_run_render_video_default_backend_warns_and_omits_when_tools_missing` — Runner-level `render_video=True` through the default `agg_ffmpeg` backend with agg/ffmpeg unavailable: run still passes, a `UserWarning` names the missing tools, and no `video` artifact is recorded.
- `tests/test_bundled_video.py::test_builtin_backend_warns_and_omits_when_tools_missing` — the built-in backend alone (agg/ffmpeg unavailable) warns and omits.
- `tests/test_bundled_video.py::test_builtin_backend_renders_when_tools_present` — the built-in backend still records video when tools exist.
- `test_custom_backend_runs_when_agg_and_ffmpeg_unavailable` — supplied custom backend runs with **no** host video tools present, no warning emitted, video artifact recorded.
- `test_custom_backend_runs_when_ffmpeg_unavailable_but_agg_present` — the exact reviewer reproduction (agg available, ffmpeg missing, custom backend) proves `backend.render` is still called.

### Half 2: configurable idle cap (issue #77)

Replaces the hard-coded 3-second idle cap in `runner.py` with a documented, configurable `defaults.idle_cap_seconds`:

- Default `3.0` preserves existing behavior exactly (no regression).
- `null` means wait for quiescence up to the recipe's `timeout_seconds` instead of a fixed cap — the escape hatch for slow-quiescing TUIs the issue calls for.
- The value is validated as a finite, nonnegative number at config load: negative, NaN, and infinite values are rejected with a `ValueError` instead of silently eliminating idle waiting.
- Documented in `README.md` (new Configuration section) and in the `GlobalDefaults` dataclass.

Tests:
- `tests/test_config.py` — builtin default is 3.0; YAML parses a value (`7.5`), explicit null (`None`), preserves the default when the key is absent, accepts `0`, and rejects negative / NaN / infinite values.
- `tests/test_runner.py::IdleCapWiringTest` — `_run_pty` passes the configured cap (default 3.0, custom 7.5, null → recipe timeout) to `wait_for_idle`.
- `tests/test_runner.py::QuiescenceBehaviorTest` — real-session tests: `wait_for_idle` returns True when the screen stabilizes and False when output never quiesces within the timeout.

## Validation

- Focused suites: `tests/test_bundled_video.py` (12 tests), `tests/test_config.py` (18 tests), `tests/test_runner.py` (16 tests) — all pass.
- Full suite: `uv run python -m unittest discover -s tests` — **376 tests, 376 passed** (baseline on current `main` `e1df6c1` was 352; 24 net new tests: +10 bundled_video, +8 config, +6 runner).
- Quality gates (new in #90): `ruff check .` — all checks passed; `mypy termproof` — no issues found in 35 source files.
- `uv build` succeeds (sdist + wheel).
- Developed test-first (RED → GREEN) per the repo's TDD convention; every new behavior was observed failing before implementation.

## Not touched

Legacy PR #87 and its branch are not modified. This PR does not merge itself; it is opened for review.

---
*Built by eng-backend (deepseek-v4-flash)*