### PR TITLE
test: allow docs/case-studies paths in the sdist allowlist

### DIFF
--- a/tests/test_sdist_artifact_content.py
+++ b/tests/test_sdist_artifact_content.py
@@ -25,6 +25,10 @@ _NEW_TEST_PATHS = {
     "tests/fixtures/base_sdist_paths.txt",
     "tests/fixtures/base_wheel_paths.txt",
     "docs/rust-gates.md",
+    "docs/case-studies/CONSENT.md",
+    "docs/case-studies/README.md",
+    "docs/case-studies/TEMPLATE.md",
+    "docs/case-studies/_meta.json",
 }
 
 

--- a/tests/test_sdist_artifact_content.py
+++ b/tests/test_sdist_artifact_content.py
@@ -17,9 +17,12 @@ FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 # without either tool skip the gate; CI and Rust-enabled dev machines enforce it.
 _HAVE_TOOLS = shutil.which("cargo") is not None and shutil.which("uv") is not None
 
-# Paths added by the RUST-002 regression suite itself and the RUST-023
-# version/drift + RUST-025 evidence-hosting docs. Everything else in the
-# sdist must be byte-for-byte identical to the pre-Rust base revision.
+# Paths added by the RUST-002 regression suite itself, the RUST-023
+# version/drift + RUST-025 evidence-hosting docs, and the RUST-030
+# case-study scaffolding. `docs` is an unanchored sdist include, so any new
+# file under docs/ ships in the sdist and must be listed here. Everything
+# else in the sdist must be byte-for-byte identical to the pre-Rust base
+# revision.
 _NEW_TEST_PATHS = {
     "tests/test_sdist_artifact_content.py",
     "tests/fixtures/base_sdist_paths.txt",


### PR DESCRIPTION
## What Changed

- Added the four tracked `docs/case-studies/` files (`CONSENT.md`, `README.md`, `TEMPLATE.md`, `_meta.json`) to `_NEW_TEST_PATHS` in `tests/test_sdist_artifact_content.py`, so the sdist content comparison against the pre-Rust base revision no longer flags them as unexpected additions.
- Expanded the accompanying comment to note the RUST-030 case-study scaffolding and to record that `docs` is an unanchored sdist include, meaning any new file under `docs/` ships in the sdist and must be listed in this allowlist.

## Risk Assessment

✅ Low: Four-line, test-only allowlist addition that restores an existing gate; static simulation of the hatch include/exclude patterns confirms the allowlist is now exactly complete against HEAD, with no missing or over-broad entries.

## Testing

Ran the targeted sdist-artifact test at HEAD (all 5 pass, exercising real cargo builds and `uv build`), then reproduced the original CI failure by reverse-applying the allowlist lines — the gate fails with exactly the four `docs/case-studies/*` paths, giving a clean fail-before/pass-after regression proof. Beyond the assertion, I built the actual source distribution and inspected the tarball to show those four files are genuine intended sdist payload (146 members, zero `rust/` entries) and absent from the wheel, confirming the allowlist entry documents real shipped content rather than masking a packaging leak. No UI surface is involved in this change, so no visual artifact applies; evidence is the failure transcript and the sdist content listing. All transient build outputs were removed and the worktree is clean.

<details>
<summary>Evidence: Reproduced CI failure with allowlist reverted (fail-before)</summary>

<code>AssertionError: Lists differ: [] != [&#39;docs/case-studies/CONSENT.md&#39;, ...]&#10;+ [&#39;docs/case-studies/CONSENT.md&#39;,&#10;+ &#39;docs/case-studies/README.md&#39;,&#10;+ &#39;docs/case-studies/TEMPLATE.md&#39;,&#10;+ &#39;docs/case-studies/_meta.json&#39;] : sdist gained non-Rust paths beyond the RUST-002 regression tests&#10;1 failed</code>

```text
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-8.4.1, pluggy-1.5.0 -- /Users/mengwei/homebrew/Caskroom/miniconda/base/bin/python3
cachedir: .pytest_cache
rootdir: /Users/mengwei/.no-mistakes/worktrees/32a742fa334a/01KZDC1ZP36EDWPQE7H2M7ARV1
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 1 item

tests/test_sdist_artifact_content.py::SdistRustIsolationTest::test_sdist_adds_only_regression_test_paths FAILED [100%]

=================================== FAILURES ===================================
______ SdistRustIsolationTest.test_sdist_adds_only_regression_test_paths _______

self = <test_sdist_artifact_content.SdistRustIsolationTest testMethod=test_sdist_adds_only_regression_test_paths>

    def test_sdist_adds_only_regression_test_paths(self) -> None:
        base_paths = _load_fixture("base_sdist_paths.txt")
        head_paths = self._sdist_relative_names()
        unexpected = sorted((head_paths - base_paths) - _NEW_TEST_PATHS)
>       self.assertEqual(
            [],
            unexpected,
            "sdist gained non-Rust paths beyond the RUST-002 regression tests: "
            f"{unexpected}",
        )
E       AssertionError: Lists differ: [] != ['docs/case-studies/CONSENT.md', 'docs/cas[81 chars]son']
E       
E       Second list contains 4 additional elements.
E       First extra element 0:
E       'docs/case-studies/CONSENT.md'
E       
E       - []
E       + ['docs/case-studies/CONSENT.md',
E       +  'docs/case-studies/README.md',
E       +  'docs/case-studies/TEMPLATE.md',
E       +  'docs/case-studies/_meta.json'] : sdist gained non-Rust paths beyond the RUST-002 regression tests: ['docs/case-studies/CONSENT.md', 'docs/case-studies/README.md', 'docs/case-studies/TEMPLATE.md', 'docs/case-studies/_meta.json']

tests/test_sdist_artifact_content.py:171: AssertionError
=========================== short test summary info ============================
FAILED tests/test_sdist_artifact_content.py::SdistRustIsolationTest::test_sdist_adds_only_regression_test_paths
============================== 1 failed in 9.57s ===============================
```
</details>
<details>
<summary>Evidence: Built sdist contents showing docs/case-studies as real payload</summary>

<code>$ uv build --out-dir &lt;tmp&gt;&#10;built: termproof-0.2.1.tar.gz&#10;&#10;$ tar -tzf termproof-0.2.1.tar.gz | grep docs/case-studies&#10;termproof-0.2.1/docs/case-studies/CONSENT.md&#10;termproof-0.2.1/docs/case-studies/README.md&#10;termproof-0.2.1/docs/case-studies/TEMPLATE.md&#10;termproof-0.2.1/docs/case-studies/_meta.json&#10;&#10;total sdist members: 146&#10;rust/ entries in sdist: 0&#10;case-studies entries in wheel: 0</code>

```text
$ uv build --out-dir <tmp>
built: termproof-0.2.1.tar.gz

$ tar -tzf termproof-0.2.1.tar.gz | grep docs/case-studies
termproof-0.2.1/docs/case-studies/CONSENT.md
termproof-0.2.1/docs/case-studies/README.md
termproof-0.2.1/docs/case-studies/TEMPLATE.md
termproof-0.2.1/docs/case-studies/_meta.json

$ tar -tzf ... | grep -c '^' ; total sdist members:
146

rust/ entries in sdist (expect none):
0
0

$ unzip -l <wheel> | grep case-studies  (docs are not wheel payload; expect none)
0
0
```
</details>
<details>
<summary>Evidence: Targeted test run at HEAD (pass-after)</summary>

```text
$ python3 -m pytest tests/test_sdist_artifact_content.py -v
test_sdist_adds_only_regression_test_paths PASSED
test_sdist_contains_no_rust_entries_after_cargo_build_test_doc PASSED
test_sdist_preserves_base_non_rust_payload_paths PASSED
test_wheel_contains_no_rust_entries_after_cargo_build_test_doc PASSED
test_wheel_path_set_matches_base PASSED
5 passed in 84.55s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/test_sdist_artifact_content.py:23` - `_NEW_TEST_PATHS` is an exact enumeration, so `test_sdist_adds_only_regression_test_paths` fails for any file added under `docs/` or `tests/` that isn&#39;t hand-registered — a class of failure unrelated to the RUST-002 invariant (no `rust/` leakage, no dropped base payload). This has already fired twice: 2bac2c6 for `docs/rust-gates.md` and now 04b91dd for the four `docs/case-studies/` files, in both cases breaking CI at a distance from the commit that added the docs. Every future test or doc file will trip it the same way. If the intent is only to prevent Rust artifacts and payload regressions, the two existing assertions (`test_sdist_contains_no_rust_entries...` and `test_sdist_preserves_base_non_rust_payload_paths`) already cover it and the additive-path assertion could be dropped or relaxed to a prefix rule; if the intent really is to gate all sdist payload growth, keeping the enumeration is correct and this is just the cost. That&#39;s a product-intent call, not something to change silently. The current fix is complete and correct for HEAD either way.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python3 -m pytest tests/test_sdist_artifact_content.py -v` at HEAD — 5 passed in 84.55s (runs real `cargo build/test/doc --workspace` and `uv build`)</code>
- <code>Reverse-applied the commit&#39;s 4 allowlist lines, then ran `python3 -m pytest tests/test_sdist_artifact_content.py::SdistRustIsolationTest::test_sdist_adds_only_regression_test_paths` — fails with exactly the four `docs/case-studies/*` paths; restored the file with `git checkout --` afterward</code>
- <code>`uv build --out-dir &lt;tmp&gt;` then `tar -tzf termproof-0.2.1.tar.gz | grep docs/case-studies` — confirmed CONSENT.md, README.md, TEMPLATE.md, _meta.json are real sdist payload</code>
- <code>`tar -tzf termproof-0.2.1.tar.gz` member count (146) and `grep -c &#39;/rust/&#39;` (0) — sdist has no Rust leakage</code>
- <code>`unzip -l &lt;wheel&gt; | grep -c case-studies` (0) — docs are not wheel payload, consistent with the unchanged wheel path set</code>
- <code>Post-test cleanup: removed `rust/target` (972M), `.pytest_cache`, and `__pycache__`; verified `git status --ignored --porcelain` is empty</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `tests/test_sdist_artifact_content.py:23` - The _NEW_TEST_PATHS allowlist is hand-maintained, so every new file under docs/ breaks CI until someone appends it (this change is the second such fix, after PR #144). I documented the constraint in the comment rather than changing the mechanism, since altering test logic is out of scope for a documentation pass. Worth a follow-up: either derive the allowed-additions set from the docs/ tree, or allow a docs/ path prefix so the gate keeps enforcing the Rust-isolation invariant without failing on ordinary documentation additions.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
