### PR TITLE
test(examples): add a colour-stress recipe so colour loss is detectable

### DIFF
--- a/docs/ci/evidence-receipt.json
+++ b/docs/ci/evidence-receipt.json
@@ -6,6 +6,7 @@
       "out": ".termproof/ci",
       "recipes": [
         "examples/generic",
+        "examples/colorstress",
         "examples/multi_turn_conversation.recipe.json",
         "examples/pi_workflow_readonly_review.recipe.json",
         "examples/pi_workflow_guarded_edit.recipe.json",
@@ -21,6 +22,7 @@
       "out": ".termproof/release",
       "recipes": [
         "examples/generic",
+        "examples/colorstress",
         "examples/multi_turn_conversation.recipe.json",
         "examples/pi_workflow_readonly_review.recipe.json",
         "examples/pi_workflow_guarded_edit.recipe.json",

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,8 @@ the leading `v`.
 ```bash
 uv run python -m unittest discover -s tests
 uv build
-uv run termproof run examples/generic examples/multi_turn_conversation.recipe.json \
+uv run termproof run examples/generic examples/colorstress \
+  examples/multi_turn_conversation.recipe.json \
   examples/pi_workflow_readonly_review.recipe.json \
   examples/pi_workflow_guarded_edit.recipe.json \
   examples/pi_workflow_session_resume_export.recipe.json \

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -40,7 +40,8 @@ uv run termproof run examples/generic examples/colorstress \
 The release evidence receipt lives at
 [`docs/ci/evidence-receipt.json`](ci/evidence-receipt.json). Update that receipt
 whenever the release or PR evidence suite changes; CI tests fail if the
-workflows stop using the receipt-backed runner.
+workflows stop using the receipt-backed runner, or if the Local Release Check
+command above drifts from the receipt's `release` target.
 
 ## PyPI Trusted Publishing
 

--- a/examples/colorstress/README.md
+++ b/examples/colorstress/README.md
@@ -1,0 +1,18 @@
+# Colour Stress Recipe Pack
+
+Every other recipe in `examples/` drives a monochrome TUI, so the corpus cannot
+distinguish a renderer that reproduces colour from one that throws it away.
+This pack exists to make that difference visible: the fixture emits 16-colour,
+256-colour and 24-bit truecolour cells, the full set of SGR text attributes,
+box drawing, wide CJK characters and an animated progress bar.
+
+```bash
+uv run termproof run examples/colorstress --video
+```
+
+Today's screen renderers draw it in flat monochrome. That is the defect this
+fixture exists to expose, not a bug in the fixture: `termproof/screen.py`
+flattens the terminal buffer to plain text, so colour and attributes are
+discarded before any renderer is called. Fixing that needs an additive change
+to the renderer interface and is deliberately not done here — this pack is the
+regression surface that has to exist first.

--- a/examples/colorstress/colorstress.recipe.json
+++ b/examples/colorstress/colorstress.recipe.json
@@ -1,0 +1,94 @@
+{
+  "name": "colour-stress",
+  "description": "Colour and attribute stress fixture; the only example whose screen is not monochrome.",
+  "priority": "P1",
+  "execution": "scripted",
+  "determinism": "deterministic",
+  "checks": [
+    "16/256/truecolour palettes render",
+    "text attributes render",
+    "animation produces motion",
+    "wide characters and emoji render"
+  ],
+  "renderers": {
+    "default": []
+  },
+  "command": {
+    "argv": ["python3", "examples/colorstress/colorstress_tui.py"],
+    "pty": true
+  },
+  "timeout_seconds": 40,
+  "cols": 100,
+  "rows": 32,
+  "steps": [
+    {
+      "name": "wait for prompt",
+      "action": "wait_for_text",
+      "text": "colour>",
+      "timeout_seconds": 5
+    },
+    {
+      "name": "show palette",
+      "action": "send_line",
+      "text": "palette"
+    },
+    {
+      "name": "wait for palette",
+      "action": "wait_for_text",
+      "text": "PALETTE READY",
+      "timeout_seconds": 10
+    },
+    {
+      "name": "show attributes",
+      "action": "send_line",
+      "text": "attrs"
+    },
+    {
+      "name": "wait for attributes",
+      "action": "wait_for_text",
+      "text": "ATTRS READY",
+      "timeout_seconds": 10
+    },
+    {
+      "name": "animate",
+      "action": "send_line",
+      "text": "animate"
+    },
+    {
+      "name": "wait for animation",
+      "action": "wait_for_text",
+      "text": "ANIMATE READY",
+      "timeout_seconds": 15
+    },
+    {
+      "name": "close session",
+      "action": "send_line",
+      "text": "exit"
+    },
+    {
+      "name": "wait for close",
+      "action": "wait_for_text",
+      "text": "COLOUR STRESS COMPLETE",
+      "timeout_seconds": 5
+    }
+  ],
+  "assertions": [
+    {
+      "type": "output_contains",
+      "value": "PALETTE READY"
+    },
+    {
+      "type": "output_contains",
+      "value": "ATTRS READY"
+    },
+    {
+      "type": "output_contains",
+      "value": "ANIMATE READY"
+    },
+    {
+      "type": "output_contains",
+      "value": "COLOUR STRESS COMPLETE"
+    }
+  ],
+  "expect_exit_code": 0
+}

--- a/examples/colorstress/colorstress_tui.py
+++ b/examples/colorstress/colorstress_tui.py
@@ -1,0 +1,163 @@
+"""Colour-stress TUI fixture.
+
+Every other example in this corpus is monochrome, so none of them can tell a
+renderer that reproduces colour from one that discards it. This one can.
+
+Deliberately exercises everything the current pipeline throws away:
+
+  * 16-colour foreground + background (normal and bright)
+  * 256-colour indexed palette (the 6x6x6 cube and the greyscale ramp)
+  * 24-bit truecolour foreground + background gradients
+  * bold / dim / italic / underline / reverse / strikethrough
+  * Unicode box drawing
+  * an animated spinner and progress bar (redraws in place -> video motion)
+  * CJK wide characters and an emoji
+
+Driven the same way as examples/generic/generic_tui.py: line commands on stdin.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+CSI = "\x1b["
+RESET = f"{CSI}0m"
+
+
+def sgr(*codes: object) -> str:
+    return CSI + ";".join(str(c) for c in codes) + "m"
+
+
+def out(text: str = "", end: str = "\n") -> None:
+    sys.stdout.write(text + end)
+    sys.stdout.flush()
+
+
+# -- panels -----------------------------------------------------------------
+
+
+def banner() -> None:
+    title = " TERMPROOF COLOUR STRESS FIXTURE "
+    out(f"{sgr(1, 97, 44)}┌" + "─" * 62 + f"┐{RESET}")
+    out(f"{sgr(1, 97, 44)}│{title:^62}│{RESET}")
+    out(f"{sgr(1, 97, 44)}└" + "─" * 62 + f"┘{RESET}")
+
+
+def panel_16() -> None:
+    out(f"{sgr(1, 4)}16-colour{RESET}  fg 30-37 / bright 90-97, bg 40-47 / bright 100-107")
+    fg = "".join(f"{sgr(c)}██{RESET}" for c in range(30, 38))
+    fgb = "".join(f"{sgr(c)}██{RESET}" for c in range(90, 98))
+    bg = "".join(f"{sgr(c)} {c} {RESET}" for c in range(40, 48))
+    bgb = "".join(f"{sgr(30, c)}{c}{RESET}" for c in range(100, 108))
+    out(f"  fg {fg}  bright {fgb}")
+    out(f"  bg {bg}")
+    out(f"  bgbright {bgb}")
+
+
+def panel_256() -> None:
+    out(f"{sgr(1, 4)}256-colour{RESET}  6x6x6 cube (16-231) then greyscale ramp (232-255)")
+    for row_start in (16, 88, 160):
+        row = "".join(f"{sgr(48, 5, n)} {RESET}" for n in range(row_start, row_start + 72))
+        out("  " + row)
+    grey = "".join(f"{sgr(48, 5, n)}  {RESET}" for n in range(232, 256))
+    out("  " + grey)
+
+
+def panel_truecolour() -> None:
+    out(f"{sgr(1, 4)}24-bit truecolour{RESET}  bg sweep then fg sweep")
+    width = 72
+    bg = "".join(
+        f"{sgr(48, 2, int(255 * i / width), int(120 + 100 * (1 - i / width)), int(255 * (1 - i / width)))} {RESET}"
+        for i in range(width)
+    )
+    out("  " + bg)
+    fg = "".join(
+        f"{sgr(38, 2, int(255 * (1 - i / width)), int(40 + 200 * i / width), 200)}█{RESET}"
+        for i in range(width)
+    )
+    out("  " + fg)
+
+
+def panel_attributes() -> None:
+    out(f"{sgr(1, 4)}attributes{RESET}")
+    cells = [
+        (sgr(1), "bold"),
+        (sgr(2), "dim"),
+        (sgr(3), "italic"),
+        (sgr(4), "underline"),
+        (sgr(7), "reverse"),
+        (sgr(9), "strike"),
+        (sgr(1, 31), "bold-red"),
+        (sgr(2, 32), "dim-green"),
+        (sgr(4, 38, 2, 255, 170, 0), "ul-truecolour"),
+    ]
+    out("  " + "  ".join(f"{code}{label}{RESET}" for code, label in cells))
+
+
+def panel_unicode() -> None:
+    out(f"{sgr(1, 4)}unicode{RESET}  box drawing, CJK wide cells, emoji")
+    out(f"  {sgr(36)}┏━━━┳━━━┓  ╔═╗  ╭─╮{RESET}")
+    out(f"  {sgr(36)}┃ A ┃ B ┃  ║ ║  │ │{RESET}")
+    out(f"  {sgr(36)}┗━━━┻━━━┛  ╚═╝  ╰─╯{RESET}")
+    out(f"  {sgr(33)}中文宽字符{RESET} | {sgr(35)}日本語テキスト{RESET} | {sgr(32)}한국어{RESET} | \U0001f680 ✔ ✗")
+
+
+def spinner(cycles: int = 12, delay: float = 0.08) -> None:
+    """Animate in place. Produces motion for the video and a settled final frame."""
+    frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    for i in range(cycles):
+        pct = int(100 * (i + 1) / cycles)
+        filled = pct * 40 // 100
+        bar = (
+            f"{sgr(48, 2, 40, 200, 120)}" + " " * filled + RESET
+            + f"{sgr(48, 2, 45, 50, 60)}" + " " * (40 - filled) + RESET
+        )
+        sys.stdout.write(
+            f"\r  {sgr(96)}{frames[i % len(frames)]}{RESET} indexing {bar} {sgr(1)}{pct:3d}%{RESET}"
+        )
+        sys.stdout.flush()
+        time.sleep(delay)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def prompt() -> None:
+    sys.stdout.write(f"{sgr(1, 92)}colour>{RESET} ")
+    sys.stdout.flush()
+
+
+# -- driver -----------------------------------------------------------------
+
+
+def main() -> int:
+    out(f"{sgr(2)}colour stress fixture ready; commands: palette, attrs, animate, exit{RESET}")
+    prompt()
+    for raw in sys.stdin:
+        cmd = raw.strip().lower()
+        out()
+        if cmd == "exit":
+            out(f"{sgr(1, 92)}COLOUR STRESS COMPLETE{RESET}")
+            return 0
+        if cmd == "palette":
+            banner()
+            panel_16()
+            panel_256()
+            panel_truecolour()
+            out(f"{sgr(1, 92)}PALETTE READY{RESET}")
+        elif cmd == "attrs":
+            panel_attributes()
+            panel_unicode()
+            out(f"{sgr(1, 92)}ATTRS READY{RESET}")
+        elif cmd == "animate":
+            spinner()
+            out(f"{sgr(1, 92)}ANIMATE READY{RESET}")
+        else:
+            out(f"{sgr(31)}unknown command{RESET}")
+        out()
+        prompt()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/colorstress/colorstress_tui.py
+++ b/examples/colorstress/colorstress_tui.py
@@ -113,18 +113,16 @@ def spinner(cycles: int = 12, delay: float = 0.08) -> None:
             f"{sgr(48, 2, 40, 200, 120)}" + " " * filled + RESET
             + f"{sgr(48, 2, 45, 50, 60)}" + " " * (40 - filled) + RESET
         )
-        sys.stdout.write(
-            f"\r  {sgr(96)}{frames[i % len(frames)]}{RESET} indexing {bar} {sgr(1)}{pct:3d}%{RESET}"
+        out(
+            f"\r  {sgr(96)}{frames[i % len(frames)]}{RESET} indexing {bar} {sgr(1)}{pct:3d}%{RESET}",
+            end="",
         )
-        sys.stdout.flush()
         time.sleep(delay)
-    sys.stdout.write("\n")
-    sys.stdout.flush()
+    out()
 
 
 def prompt() -> None:
-    sys.stdout.write(f"{sgr(1, 92)}colour>{RESET} ")
-    sys.stdout.flush()
+    out(f"{sgr(1, 92)}colour>{RESET} ", end="")
 
 
 # -- driver -----------------------------------------------------------------

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,6 +17,7 @@ class ExampleRecipeTest(unittest.TestCase):
         self.assertIn("pi-workflow-session-resume-export", names)
         self.assertIn("pi-workflow-model-context", names)
         self.assertIn("generic-tui-workflow", names)
+        self.assertIn("colour-stress", names)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_docs.py
+++ b/tests/test_release_docs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import shlex
 import unittest
 from pathlib import Path
 
@@ -8,9 +10,34 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs" / "releases.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+RECEIPT = ROOT / "docs" / "ci" / "evidence-receipt.json"
+
+
+def _documented_release_command() -> list[str]:
+    """Parse the `termproof run` invocation from the Local Release Check block."""
+    text = DOCS.read_text(encoding="utf-8")
+    block = text.split("## Local Release Check", 1)[1].split("```", 2)[1]
+    for line in block.replace("\\\n", " ").splitlines():
+        if "termproof run" in line:
+            return shlex.split(line)
+    raise AssertionError("no `termproof run` command in the Local Release Check block")
 
 
 class ReleaseDocsTest(unittest.TestCase):
+    def test_local_release_check_matches_release_receipt(self) -> None:
+        argv = _documented_release_command()
+        release = json.loads(RECEIPT.read_text(encoding="utf-8"))["targets"]["release"]
+
+        self.assertEqual("run", argv[argv.index("termproof") + 1])
+        recipes = argv[argv.index("termproof") + 2 :]
+        flags = recipes[next(i for i, arg in enumerate(recipes) if arg.startswith("-")) :]
+        recipes = recipes[: len(recipes) - len(flags)]
+
+        self.assertEqual(release["recipes"], recipes)
+        self.assertEqual(release["video"], "--video" in flags)
+        self.assertEqual(str(release["video_fps"]), flags[flags.index("--video-fps") + 1])
+        self.assertEqual(release["out"], flags[flags.index("--out") + 1])
+
     def test_pypi_trusted_publisher_values_are_documented(self) -> None:
         text = DOCS.read_text(encoding="utf-8")
 

--- a/tests/test_sdist_artifact_content.py
+++ b/tests/test_sdist_artifact_content.py
@@ -32,6 +32,9 @@ _NEW_TEST_PATHS = {
     "docs/case-studies/README.md",
     "docs/case-studies/TEMPLATE.md",
     "docs/case-studies/_meta.json",
+    "examples/colorstress/README.md",
+    "examples/colorstress/colorstress.recipe.json",
+    "examples/colorstress/colorstress_tui.py",
 }
 
 


### PR DESCRIPTION
## Intent

Land a colour-stress example recipe so that TermProof's example corpus can detect a renderer that discards colour.

Background: research found that termproof/screen.py flattens pyte's terminal buffer to plain text, discarding every colour and text attribute before any ScreenRenderer is called. This went unnoticed for a long time because the entire existing example corpus is 100% monochrome — zero coloured cells across roughly 13,500 — so no test in the project could possibly detect it. This change adds the missing regression surface: examples/colorstress/, driven by line commands on stdin exactly like examples/generic/generic_tui.py, emitting 16-colour, 256-colour and 24-bit truecolour cells, the full SGR attribute set, Unicode box drawing, wide CJK characters and an animated progress bar. It is wired into the ci and release recipe lists in docs/ci/evidence-receipt.json, into tests/test_examples.py, and into the _NEW_TEST_PATHS allowlist in tests/test_sdist_artifact_content.py.

Deliberate decisions a reviewer would not know from the diff:

1. This change contains ZERO production code by design. Today's renderers draw this fixture in flat monochrome, and that is the expected, accepted outcome — it is the defect being made visible, not a bug in the fixture. Fixing screen.py requires an additive change to the ScreenRenderer interface (an attributed-grid path) and is explicitly out of scope here; it is a separate, later change. Do not flag the absence of a renderer fix, and do not flag that the fixture's colour output is not asserted on — nothing in the current pipeline can assert on colour yet.

2. This is the first of three deliberately split changes, in this order: (1) this fixture, (2) an evidence-rendering config surface making all hardcoded renderer/video parameters configurable with byte-identical defaults, (3) step-screenshot dedup plus a findings document at docs/evidence-quality.md. The split was requested explicitly to keep each diff reviewable. Consequently this change deliberately does NOT reference docs/evidence-quality.md anywhere, because that file lands in change 3 and a dangling link would break a reader of this change alone.

3. The fixture is intentionally elaborate rather than a minimal colour smoke test. Each panel targets a distinct failure mode found in the research (indexed vs truecolour, background vs foreground, attribute handling, wide-character grid alignment, and in-place redraws that produce video motion). It must not be 'simplified' to a plain TUI or it stops discharging its purpose.

4. British spelling ('colour') is used in prose and in the recipe name 'colour-stress'; the directory and module use 'colorstress'. This is carried over deliberately from the research fixture it was copied from.

Known pre-existing failures in this environment, not caused by this change and not mine to fix: tests/test_sdist_artifact_content.py SdistRustIsolationTest.setUpClass fails because 'cargo test --workspace' exits 101 when the cli_baseline test binary is SIGKILLed by the sandbox; and 'mypy termproof' reports a syntax error inside numpy's bundled .pyi stubs. Both reproduce on a clean checkout of origin/main with this change stashed, and this change is Python/JSON/Markdown only.

## What Changed

- Adds `examples/colorstress/` — a `colour-stress` recipe plus a stdin-driven TUI fixture (same line-command shape as `examples/generic/generic_tui.py`) that emits 16-colour, 256-colour and 24-bit truecolour cells, the full SGR attribute set, box drawing, wide CJK characters and an animated progress bar, with a README stating that today's monochrome rendering is the defect being exposed rather than a fixture bug.
- Wires the new recipe into both the `ci` and `release` targets of `docs/ci/evidence-receipt.json`, the Local Release Check command in `docs/releases.md`, `tests/test_examples.py`'s recipe-name assertions, and the `_NEW_TEST_PATHS` allowlist in `tests/test_sdist_artifact_content.py`.
- Adds `test_local_release_check_matches_release_receipt` to `tests/test_release_docs.py`, which parses the documented `termproof run` invocation and asserts its recipe list, `--video`, `--video-fps` and `--out` values match the receipt's `release` target, so the two can no longer drift.

## Risk Assessment

✅ Low: Fixture, docs, and test-only change with zero production code; both fix-round edits are byte-identical refactors or verified docs/receipt syncs, the new recipe integrates cleanly with recipe discovery, assertion evaluation, and the sdist allowlist, and every stated intent constraint is satisfied.

## Testing

Exercised the new recipe through the real `termproof run` CLI (SVG and PNG renderers) and confirmed it passes every step and assertion, then measured the actual product claim: a pyte-based colour census shows the 11 pre-existing example casts contain zero coloured cells while the new colour-stress cast peaks at 884 coloured cells, 343 attributed cells and 419 distinct colours, so the corpus now has a fixture that a colour-discarding renderer would visibly fail. Captured reviewer-visible visual evidence as a side-by-side of the agg-replayed real terminal frame against TermProof's own PNG step screenshot of the identical frame, which renders flat monochrome with the colour-only rows blank — the expected, deliberately-deferred defect. Targeted unit tests for the examples registry, the new release-docs/receipt reconciliation and the CI evidence receipt all pass; since the sdist allowlist test is gated behind a cargo build that is a known pre-existing failure here, I built the sdist directly and verified the three colorstress paths ship with no unlisted additions. The worktree is clean and the cargo/mypy pre-existing failures were left untouched as out of targeted scope.

- Evidence: Side-by-side: real terminal vs TermProof artifact for the same colour-stress frame (local file: <code>/var/folders/00/dn1zh_wx3ys5gq4f1dtgpp8h0000gn/T/no-mistakes-evidence/01KZKX8F35KEAY7XJ2F09TB53C/colour-loss-comparison.png</code>)
- Evidence: Full colour-stress session replayed as an animated GIF (real terminal colours + progress-bar motion) (local file: <code>/var/folders/00/dn1zh_wx3ys5gq4f1dtgpp8h0000gn/T/no-mistakes-evidence/01KZKX8F35KEAY7XJ2F09TB53C/colorstress-real-terminal.gif</code>)
<details>
<summary>Evidence: Colour census across the whole example corpus</summary>

<code>recipe cells peak colour peak attrs colours&#10;---------------------------------------------------------------------------&#10;generic-tui-workflow 2400 0 0 0&#10;multi-turn-conversation 2800 0 0 0&#10;pi-help 4620 0 25 0&#10;pi-list 1200 0 6 0&#10;pi-version 1200 0 0 0&#10;pi-workflow-cli-capability-map 5520 0 0 0&#10;pi-workflow-guarded-edit 3300 0 0 0&#10;pi-workflow-model-context 3248 0 0 0&#10;pi-workflow-package-lifecycle 4484 0 0 0&#10;pi-workflow-readonly-review 3300 0 0 0&#10;pi-workflow-session-resume-export 3080 0 0 0&#10;colour-stress (NEW) 3200 884 343 419</code>

```text
recipe                              cells  peak colour  peak attrs  colours
---------------------------------------------------------------------------
generic-tui-workflow                 2400            0           0        0
multi-turn-conversation              2800            0           0        0
pi-help                              4620            0          25        0
pi-list                              1200            0           6        0
pi-version                           1200            0           0        0
pi-workflow-cli-capability-map       5520            0           0        0
pi-workflow-guarded-edit             3300            0           0        0
pi-workflow-model-context            3248            0           0        0
pi-workflow-package-lifecycle        4484            0           0        0
pi-workflow-readonly-review          3300            0           0        0
pi-workflow-session-resume-export    3080            0           0        0
colour-stress (NEW)                  3200          884         343      419
---------------------------------------------------------------------------
TOTAL                               38352          884

{
  "generic-tui-workflow": {
    "cells_on_screen": 2400,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "multi-turn-conversation": {
    "cells_on_screen": 2800,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-help": {
    "cells_on_screen": 4620,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 25,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-list": {
    "cells_on_screen": 1200,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 6,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-version": {
    "cells_on_screen": 1200,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-workflow-cli-capability-map": {
    "cells_on_screen": 5520,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-workflow-guarded-edit": {
    "cells_on_screen": 3300,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-workflow-model-context": {
    "cells_on_screen": 3248,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-workflow-package-lifecycle": {
    "cells_on_screen": 4484,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-workflow-readonly-review": {
    "cells_on_screen": 3300,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "pi-workflow-session-resume-export": {
    "cells_on_screen": 3080,
    "peak_coloured_cells": 0,
    "peak_attributed_cells": 0,
    "final_coloured_cells": 0,
    "distinct_colours": 0,
    "sample_colours": []
  },
  "colour-stress (NEW)": {
    "cells_on_screen": 3200,
    "peak_coloured_cells": 884,
    "peak_attributed_cells": 343,
    "final_coloured_cells": 702,
    "distinct_colours": 419,
    "sample_colours": [
      "bg:000000",
      "bg:00005f",
      "bg:000087",
      "bg:0000af",
      "bg:0000d7",
      "bg:0000ff",
      "bg:005f00",
      "bg:005f5f"
    ]
  }
}
```
</details>
<details>
<summary>Evidence: termproof run examples/colorstress — CLI transcript and report</summary>

```text
$ uv run termproof run examples/colorstress
1/1 passed
PASS colour-stress [default] video: -

# TUI Verification - 1/1 Passed
| Recipe | Renderer | Priority | Execution | Result | Score |
| `colour-stress` | `default` | `P1` | `scripted` | PASS | 1.00 |

### Assertions
- PASS `output_contains` - contains 'PALETTE READY'
- PASS `output_contains` - contains 'ATTRS READY'
- PASS `output_contains` - contains 'ANIMATE READY'
- PASS `output_contains` - contains 'COLOUR STRESS COMPLETE'
- PASS `exit_code` - expected 0, got 0

### Steps
- PASS `wait for prompt` - found 'colour>'
- PASS `show palette` - sent line
- PASS `wait for palette` - found 'PALETTE READY'
- PASS `show attributes` - sent line
- PASS `wait for attributes` - found 'ATTRS READY'
- PASS `animate` - sent line
- PASS `wait for animation` - found 'ANIMATE READY'
- PASS `close session` - sent line
- PASS `wait for close` - found 'COLOUR STRESS COMPLETE'
```
</details>
<details>
<summary>Evidence: sdist allowlist verification (build + path diff against base fixture)</summary>

```text
paths in sdist: 149
unexpected (not in base fixture):
ALLOWED docs/case-studies/CONSENT.md
ALLOWED docs/case-studies/README.md
ALLOWED docs/case-studies/TEMPLATE.md
ALLOWED docs/case-studies/_meta.json
ALLOWED docs/rust-gates.md
ALLOWED examples/colorstress/README.md
ALLOWED examples/colorstress/colorstress.recipe.json
ALLOWED examples/colorstress/colorstress_tui.py
ALLOWED tests/fixtures/base_sdist_paths.txt
ALLOWED tests/fixtures/base_wheel_paths.txt
ALLOWED tests/test_sdist_artifact_content.py
missing vs base: none
allowlist entries not shipped: none
```
</details>
- Evidence: TermProof evidence bundle for the colour-stress run (cast, final.svg/.txt, per-step screenshots, result.json, report.md) (local file: <code>/var/folders/00/dn1zh_wx3ys5gq4f1dtgpp8h0000gn/T/no-mistakes-evidence/01KZKX8F35KEAY7XJ2F09TB53C/run</code>)
<details>
<summary>Evidence: Colour census script used to produce the corpus measurement</summary>

```text
"""Census the TermProof example corpus for coloured / attributed terminal cells.

Replays every asciinema cast through pyte (the same library termproof/screen.py
uses) and counts cells whose foreground, background or SGR attributes differ
from the terminal default. Reports the peak per-frame count and the set of
distinct colours seen, so a recipe that never emits colour scores zero.
"""

from __future__ import annotations

import json
import sys
from pathlib import Path

import pyte

ATTRS = ("bold", "italics", "underscore", "reverse", "strikethrough", "blink")


def coloured_cells(screen: pyte.Screen) -> tuple[int, set[str], int]:
    count = 0
    colours: set[str] = set()
    attributed = 0
    for row in range(screen.lines):
        line = screen.buffer[row]
        for col in range(screen.columns):
            cell = line[col]
            fg = cell.fg
            bg = cell.bg
            has_colour = fg != "default" or bg != "default"
            has_attr = any(getattr(cell, name) for name in ATTRS)
            if has_colour:
                count += 1
                if fg != "default":
                    colours.add(f"fg:{fg}")
                if bg != "default":
                    colours.add(f"bg:{bg}")
            if has_attr:
                attributed += 1
    return count, colours, attributed


def census(cast_path: Path) -> dict:
    with cast_path.open(encoding="utf-8") as handle:
        header = json.loads(handle.readline())
        screen = pyte.Screen(int(header.get("width", 100)), int(header.get("height", 30)))
        stream = pyte.Stream(screen)
        peak = 0
        peak_attr = 0
        colours: set[str] = set()
        for line in handle:
            event = json.loads(line)
            if len(event) >= 3 and event[1] == "o":
                stream.feed(event[2])
                count, seen, attributed = coloured_cells(screen)
                peak = max(peak, count)
                peak_attr = max(peak_attr, attributed)
                colours |= seen
        final, final_colours, final_attr = coloured_cells(screen)
    return {
        "cells_on_screen": screen.lines * screen.columns,
        "peak_coloured_cells": peak,
        "peak_attributed_cells": peak_attr,
        "final_coloured_cells": final,
        "distinct_colours": len(colours),
        "sample_colours": sorted(colours)[:8],
    }


def main(argv: list[str]) -> int:
    rows = []
    for spec in argv:
        label, _, path = spec.partition("=")
        rows.append((label, census(Path(path))))

    width = max(len(label) for label, _ in rows)
    print(f"{'recipe'.ljust(width)}  {'cells':>6}  {'peak colour':>11}  {'peak attrs':>10}  {'colours':>7}")
    print("-" * (width + 42))
    total_colour = 0
    total_cells = 0
    for label, data in rows:
        total_colour += data["peak_coloured_cells"]
        total_cells += data["cells_on_screen"]
        print(
            f"{label.ljust(width)}  {data['cells_on_screen']:>6}  "
            f"{data['peak_coloured_cells']:>11}  {data['peak_attributed_cells']:>10}  "
            f"{data['distinct_colours']:>7}"
        )
    print("-" * (width + 42))
    print(f"{'TOTAL'.ljust(width)}  {total_cells:>6}  {total_colour:>11}")
    print()
    print(json.dumps({label: data for label, data in rows}, indent=2))
    return 0


if __name__ == "__main__":
    raise SystemExit(main(sys.argv[1:]))
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `docs/ci/evidence-receipt.json:25` - The release target gained `examples/colorstress`, but the hand-maintained &#34;Local Release Check&#34; command in docs/releases.md:20-25 still enumerates only the previous six recipes. Before this diff that snippet mirrored the receipt&#39;s release list exactly; now a maintainer following the documented pre-release check runs a strictly smaller suite than the release workflow, so a colour-stress failure would first surface in the tagged release run instead of locally. Fix: add `examples/colorstress` to the recipe list in the docs/releases.md snippet.
- ℹ️ `docs/ci/evidence-receipt.json:9` - Expected transient, no action needed in this diff. The ci.yml step &#34;Run base TUI verification for PR comparison&#34; calls `ci_evidence run ci --repo ../termproof-base` with the default receipt path, which resolves against the head checkout — so the base worktree is driven with the head recipe list. `examples/colorstress` does not exist at the base commit, and `registry.load_recipes` treats a non-existent path as a file and lets `load_recipe` raise FileNotFoundError before any recipe runs (termproof/registry.py:41-51, termproof/cli.py:113), aborting the whole base run rather than skipping the one missing recipe. Consequence for this PR only: `.termproof/pr-base` contains just the copied receipt, so the PR comment&#39;s &#34;Before&#34; report and the entire behavioural delta come back empty for every recipe, not only the new one. The step is `continue-on-error: true` with `--continue-on-fail`, so CI stays green, and it self-heals once this lands. Making `load_recipes` tolerant of missing paths is a separate change, not this one.
- ℹ️ `examples/colorstress/colorstress_tui.py:32` - `out()` takes an `end` parameter that is never passed a non-default value, while the two call sites that need no trailing newline — `prompt()` (line 126) and `spinner()` (lines 116-122) — bypass the helper and re-implement `sys.stdout.write(...)` + `flush()`. Either drop the unused `end` parameter or route those two sites through `out(..., end=&#34;&#34;)`; both are byte-identical to the current output.

🔧 Fix: sync release docs recipe list, route fixture writes through out()
1 info still open:
- ℹ️ `tests/test_release_docs.py:34` - The new guard re-implements the receipt-&gt;argv mapping that termproof/ci_evidence.py:29-34 owns (`uv run termproof run &lt;recipes&gt; --video --video-fps &lt;n&gt; --out &lt;out&gt;`) instead of exercising it. It currently matches run_target exactly, so it does catch the drift it was added for. But if run_target later changes which flags it derives from the receipt (say it stops passing --video-fps, or adds --reporter), this test keeps passing while docs/releases.md no longer describes what the release actually runs — the exact class of drift it exists to prevent. Invoking the real consumer isn&#39;t feasible today because the argv construction is inline in run_target and run_target immediately subprocesses. Follow-up (not this change, which is deliberately zero-production-code): extract the argv builder from run_target and assert the documented command equals it.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run termproof run examples/colorstress --out &lt;evidence&gt;/run` — real CLI run, 1/1 passed, 9/9 steps, 5/5 assertions, exit 0</code>
- <code>`uv run termproof run examples/colorstress --screen-renderer png --out &lt;evidence&gt;/run-png` — produced the raster step screenshots TermProof ships</code>
- <code>`uv run termproof run examples/generic --out &lt;evidence&gt;/run` — monochrome control run for comparison</code>
- <code>Colour census: replayed all 11 checked-in `examples/artifacts/*/session.cast` plus the new colour-stress cast through pyte, counting non-default fg/bg/SGR cells (`colour_census.py`)</code>
- <code>`agg --theme asciinema --font-size 16 session.cast colorstress-real-terminal.gif` — rendered the cast to a colour GIF, extracted the matching frame for the side-by-side</code>
- <code>`uv run python -m unittest tests.test_examples tests.test_release_docs -v` — 6 tests, all pass</code>
- <code>`uv run python -m unittest tests.test_ci_evidence` — 10 tests, all pass</code>
- <code>`uv build --sdist` + diff of the 149 archive paths against `tests/fixtures/base_sdist_paths.txt` and `_NEW_TEST_PATHS` — verifies the sdist allowlist contract that `tests/test_sdist_artifact_content.py` cannot check locally behind its cargo gate</code>
- <code>`git status --porcelain` — worktree clean, no transient artifacts left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
