### PR TITLE
ci: group GitHub Actions dependabot updates into one pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    # A single catch-all group means this ecosystem can only ever open one PR.
+    open-pull-requests-limit: 1
     labels:
       - "area:ci"
     commit-message:
       prefix: "chore"
+    # Batch every action bump into one PR: "are our CI actions current" is one
+    # question, and separate PRs overlap heavily across the workflow files.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+          - "major"

--- a/tests/test_dependabot_config.py
+++ b/tests/test_dependabot_config.py
@@ -1,0 +1,221 @@
+"""Contract tests for ``.github/dependabot.yml``.
+
+The consumer of this file is Dependabot, which we cannot run locally, so the
+tests parse the config into a semantic model and replay Dependabot's documented
+grouping rules over it: every pending update is matched against the declared
+groups (first match wins, wildcard patterns, ``update-types`` filter), grouped
+updates collapse into one pull request per group, and anything left ungrouped
+gets a pull request of its own.
+
+What is pinned here is the *stream shape* each ecosystem produces:
+
+* ``github-actions`` batches every action bump -- patch, minor and major --
+  into a single pull request, so the six-PR first sweep cannot recur.
+* ``pip`` stays deliberately ungrouped: one pull request per dependency. The
+  asymmetry between the two ecosystems is intentional.
+
+Run: uv run python -m unittest tests.test_dependabot_config -v
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+DEPENDABOT_YML = ROOT / ".github" / "dependabot.yml"
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+
+UPDATE_TYPES = ("patch", "minor", "major")
+
+
+@dataclass(frozen=True)
+class Update:
+    """A single pending dependency bump Dependabot has detected."""
+
+    dependency: str
+    update_type: str
+
+
+@dataclass
+class PullRequest:
+    """A pull request Dependabot would open for one ecosystem entry."""
+
+    group: str | None
+    updates: list[Update] = field(default_factory=list)
+
+    @property
+    def title(self) -> str:
+        if self.group is not None:
+            return f"bump the {self.group} group with {len(self.updates)} updates"
+        only = self.updates[0]
+        return f"bump {only.dependency}"
+
+
+def load_config() -> dict:
+    with DEPENDABOT_YML.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def entry_for(config: dict, ecosystem: str) -> dict:
+    matches = [e for e in config["updates"] if e["package-ecosystem"] == ecosystem]
+    if len(matches) != 1:
+        raise AssertionError(f"expected exactly one {ecosystem!r} entry, found {len(matches)}")
+    return matches[0]
+
+
+def _matches_group(group: dict, update: Update) -> bool:
+    """Replay Dependabot's group matching for one pending update."""
+    patterns = group.get("patterns") or ["*"]
+    if not any(fnmatch.fnmatch(update.dependency, pattern) for pattern in patterns):
+        return False
+    excludes = group.get("exclude-patterns") or []
+    if any(fnmatch.fnmatch(update.dependency, pattern) for pattern in excludes):
+        return False
+    update_types = group.get("update-types")
+    return update_types is None or update.update_type in update_types
+
+
+def _is_ignored(entry: dict, update: Update) -> bool:
+    for rule in entry.get("ignore") or []:
+        if fnmatch.fnmatch(update.dependency, rule.get("dependency-name", "*")):
+            return True
+    return False
+
+
+def plan_pull_requests(entry: dict, updates: list[Update]) -> list[PullRequest]:
+    """Return the pull requests Dependabot would open for ``updates``.
+
+    Grouped updates collapse into one pull request per group (declaration
+    order, first match wins); ungrouped updates each get their own.
+    """
+    groups: dict[str, dict] = entry.get("groups") or {}
+    grouped: dict[str, PullRequest] = {}
+    solo: list[PullRequest] = []
+
+    for update in updates:
+        if _is_ignored(entry, update):
+            continue
+        for name, group in groups.items():
+            if _matches_group(group, update):
+                grouped.setdefault(name, PullRequest(group=name)).updates.append(update)
+                break
+        else:
+            solo.append(PullRequest(group=None, updates=[update]))
+
+    return list(grouped.values()) + solo
+
+
+def workflow_actions() -> list[str]:
+    """Every action referenced by ``uses:`` across the shipped workflows."""
+    names: set[str] = set()
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job in (workflow.get("jobs") or {}).values():
+            for step in job.get("steps") or []:
+                uses = step.get("uses")
+                if uses and not uses.startswith("./"):
+                    names.add(uses.split("@", 1)[0])
+    return sorted(names)
+
+
+class GitHubActionsStreamTest(unittest.TestCase):
+    """The actions stream must arrive as exactly one pull request."""
+
+    def setUp(self) -> None:
+        self.entry = entry_for(load_config(), "github-actions")
+
+    def test_every_action_in_the_repo_lands_in_one_pull_request(self) -> None:
+        """The real first sweep opened six PRs; the same bumps must now open one."""
+        actions = workflow_actions()
+        self.assertGreaterEqual(len(actions), 6, "expected the workflows to reference several actions")
+        # Cycle the update types so patch, minor and major are all represented.
+        updates = [
+            Update(name, UPDATE_TYPES[index % len(UPDATE_TYPES)])
+            for index, name in enumerate(actions)
+        ]
+
+        plan = plan_pull_requests(self.entry, updates)
+
+        self.assertEqual(len(plan), 1, f"expected one pull request, got {[pr.title for pr in plan]}")
+        self.assertIsNotNone(plan[0].group, "the single pull request must be a grouped one")
+        self.assertEqual(
+            sorted(u.dependency for u in plan[0].updates),
+            actions,
+            "every action bump must be batched into the group",
+        )
+
+    def test_the_six_pr_sweep_collapses_to_one(self) -> None:
+        """The concrete bumps from the ungrouped sweep (#151-#155) batch together."""
+        sweep = [
+            Update("actions/upload-artifact", "major"),
+            Update("actions/setup-python", "major"),
+            Update("docker/build-push-action", "major"),
+            Update("actions/checkout", "minor"),
+            Update("astral-sh/setup-uv", "minor"),
+            Update("actions/cache", "patch"),
+        ]
+
+        plan = plan_pull_requests(self.entry, sweep)
+
+        self.assertEqual([pr.title for pr in plan], ["bump the github-actions group with 6 updates"])
+
+    def test_no_update_type_escapes_the_group(self) -> None:
+        for update_type in UPDATE_TYPES:
+            with self.subTest(update_type=update_type):
+                plan = plan_pull_requests(self.entry, [Update("some-org/some-action", update_type)])
+                self.assertEqual(len(plan), 1)
+                self.assertIsNotNone(
+                    plan[0].group,
+                    f"a {update_type} bump must be grouped, not opened on its own",
+                )
+
+    def test_no_bump_is_silently_dropped(self) -> None:
+        """Grouping must batch the stream, not suppress parts of it."""
+        updates = [Update(name, "major") for name in workflow_actions()]
+
+        planned = [u for pr in plan_pull_requests(self.entry, updates) for u in pr.updates]
+
+        self.assertCountEqual(planned, updates, "no action bump may be filtered out of the stream")
+
+    def test_plan_fits_within_the_open_pull_request_limit(self) -> None:
+        limit = self.entry["open-pull-requests-limit"]
+        self.assertLessEqual(limit, 10, "the open-pull-requests-limit must not be raised")
+
+        updates = [Update(name, "major") for name in workflow_actions()]
+
+        self.assertLessEqual(len(plan_pull_requests(self.entry, updates)), limit)
+
+    def test_stream_stays_enabled_and_weekly(self) -> None:
+        self.assertEqual(self.entry["schedule"]["interval"], "weekly")
+        self.assertNotEqual(self.entry.get("open-pull-requests-limit"), 0, "the stream must not be disabled")
+
+
+class PipStreamTest(unittest.TestCase):
+    """pip is deliberately left ungrouped -- one pull request per dependency."""
+
+    def setUp(self) -> None:
+        self.entry = entry_for(load_config(), "pip")
+
+    def test_each_dependency_still_gets_its_own_pull_request(self) -> None:
+        updates = [
+            Update("pyyaml", "minor"),
+            Update("jsonschema", "patch"),
+            Update("ruff", "major"),
+        ]
+
+        plan = plan_pull_requests(self.entry, updates)
+
+        self.assertEqual(len(plan), 3, "grouping pip is a separate judgement; it must stay ungrouped")
+        self.assertEqual([pr.group for pr in plan], [None, None, None])
+
+    def test_limit_is_untouched(self) -> None:
+        self.assertEqual(self.entry["open-pull-requests-limit"], 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -35,7 +35,8 @@ class DockerImageTest(unittest.TestCase):
         text = WORKFLOW.read_text(encoding="utf-8")
 
         self.assertIn("pull_request", workflow[True])
-        self.assertIn("docker/build-push-action@v6", text)
+        # Allow major bumps via dependabot — pin must stay on the correct action, not a fixed major.
+        self.assertRegex(text, r"docker/build-push-action@v\d+")
         self.assertIn("ghcr.io/${{ github.repository_owner }}/termproof", text)
         self.assertIn("github.event_name != 'pull_request'", text)
 

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -108,8 +108,8 @@ class DocsSiteDeployTest(unittest.TestCase):
 
     def test_docs_site_workflow_pins_pages_actions(self) -> None:
         text = WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("uses: actions/configure-pages@v5", text)
         # Allow major bumps via dependabot — pin must stay on the correct action, not a fixed major.
+        self.assertRegex(text, r"uses: actions/configure-pages@v\d+")
         self.assertRegex(text, r"uses: actions/upload-pages-artifact@v\d+")
         self.assertRegex(text, r"uses: actions/deploy-pages@v\d+")
 


### PR DESCRIPTION
## Intent

Follow-up commit on the same branch as the dependabot grouping change (PR #157), which already passed a full pipeline run.

ORIGINAL WORK (already validated in run 01KZM4ZBC2VBWTVP8NAHNBSW8X, checks-passed): change .github/dependabot.yml so the GitHub Actions update stream arrives as one grouped PR instead of one PR per action. The config was added 2026-08-01 ungrouped; its first sweep opened six PRs at once, which meant six triage decisions for one question ('are our CI actions current') over heavily overlapping workflow files. I added a single catch-all group covering patch/minor/major, kept the weekly interval (grouping already caps the stream at one open PR, so a shorter interval no longer multiplies triage), lowered open-pull-requests-limit from 10 to 1 (a reduction, not a raise -- with one catch-all group nothing is ungrouped, so 10 asserted a bound that cannot happen), and kept the 'chore' commit-message prefix (Dependabot already titles grouped PRs 'bump the github-actions group ...'). The pip ecosystem entry is deliberately left ungrouped and untouched -- it has not opened a PR yet, its failure modes differ from workflow actions, and grouping it is a separate judgement. That asymmetry between the two entries is intentional, not an oversight. The user explicitly ruled out raising the limit, adding ignore rules, and disabling the stream.

NEW WORK IN THIS RUN (the reason for re-validating): the user found, while checking the open Dependabot bumps, that two tests hardcode exact action major versions -- tests/test_docs_site.py asserted the literal string 'uses: actions/configure-pages@v5' and tests/test_docker_image.py asserted 'docker/build-push-action@v6'. That is the actual cause of those two Dependabot PRs being red; it is NOT a stale base. Every future bump of those actions would fail identically, which defeats the point of grouping -- the grouped PR would be permanently red for a reason unrelated to whether the bump is safe.

The user asked specifically to loosen both to assert the action is pinned to SOME version rather than a specific major, keeping the pinning intent and dropping only the version coupling, and to match the style of the sibling assertions that already do this: test_docs_site.py lines 155/174/215/246 and test_docs_pages.py line 196. I used assertRegex against @v\d+, which is exactly the form the two adjacent assertions in test_docs_site.py already use for upload-pages-artifact and deploy-pages, and I moved the existing 'Allow major bumps via dependabot' comment so it now covers all three. Deliberate choice: I used the @v\d+ regex rather than a bare 'action@' substring check because it keeps the assertion strict about pinning -- I verified it still fails on @main and @latest and still fails if the step stops referencing the right action -- while accepting any future major.

The user asked for this as a separate commit from the config change on the same branch, which is how it is committed.

Verification already done: ran tests/test_docs_site.py and tests/test_docker_image.py under unittest -- 26 tests, all pass. Separately checked the two regexes accept v5/v9 and v6/v7 and reject @main/@latest.

Scope note: the user scoped this tightly to the config file plus these two test assertions. tests/test_dependabot_config.py in the branch was added by the previous pipeline run's own document/test step, not by me. Also relevant: a concurrent change removed the Rust workspace from this repo and pushes directly to the default branch, so the base moves today.

## What Changed

- `.github/dependabot.yml`: added a single catch-all `github-actions` group covering patch/minor/major updates so the whole action update stream arrives as one PR, and lowered `open-pull-requests-limit` from 10 to 1 to match (weekly interval, `chore` prefix, and the ungrouped `pip` entry are unchanged).
- Added `tests/test_dependabot_config.py` covering the grouped GitHub Actions entry — that every action in the repo lands in one PR, that no update type escapes the group, that the plan fits the limit, that the stream stays enabled and weekly — plus assertions that the `pip` entry remains ungrouped with its own limit.
- Loosened two hardcoded action-major assertions to `assertRegex(..., r"...@v\d+")`: `actions/configure-pages` in `tests/test_docs_site.py` and `docker/build-push-action` in `tests/test_docker_image.py`, matching the sibling `upload-pages-artifact`/`deploy-pages` assertions, so tests still require the action to be pinned to a version but no longer fail on a major bump.

## Risk Assessment

✅ Low: The change is two narrowly scoped test-assertion loosenings that preserve pinning strictness and match an existing sibling pattern, layered on an already-validated declarative config change with no production code touched.

## Testing

Ran the two targeted modules on the branch as a baseline (26 tests pass), then reproduced the reported red by simulating the actual Dependabot bumps against base-commit copies of both tests — they fail on the literal-major assertions while the loosened versions pass, which is the before/after the change is meant to deliver. Verified the `@v\d+` form is still strict by rewriting the pins to `@main`/`@latest` and to a different action; the fixed tests fail in all four negative cases. For end-to-end proof that a merged grouped bump would not be permanently red, bumped every action major across all workflow files and ran the six workflow-reading modules (70 tests, all pass), and confirmed no other test hardcodes a major. Also re-checked the config half by replaying the real six-PR sweep through the config model at base vs branch, which shows 6 separate PRs collapsing to one grouped PR with pip deliberately untouched. One environment fix was needed: bare python3 lacks pexpect, so the broader module set was run under `uv run --frozen` with the venv outside the worktree. No UI surface is involved, so evidence is CLI transcripts. Worktree restored clean.

<details>
<summary>Evidence: Before/after regression matrix for the loosened action-pin assertions</summary>

<code>=== Scenario 2: simulate the grouped Dependabot bump (configure-pages v5-&gt;v9, build-push-action v6-&gt;v7) ===&#10;51: uses: actions/configure-pages@v9&#10;48: uses: docker/build-push-action@v7&#10;BEFORE fix: docs-site pin test FAIL&#10;-&gt; AssertionError: &#39;uses: actions/configure-pages@v5&#39; not found in ...&#10;AFTER fix: docs-site pin test PASS&#10;BEFORE fix: docker pin test FAIL&#10;-&gt; AssertionError: &#39;docker/build-push-action@v6&#39; not found in ...&#10;AFTER fix: docker pin test PASS&#10;&#10;=== Scenario 3: pin dropped (@main / @latest) -- fixed tests must still fail ===&#10;AFTER fix: docs-site pin test FAIL&#10;AFTER fix: docker pin test FAIL&#10;&#10;=== Scenario 4: step points at the wrong action -- fixed tests must still fail ===&#10;AFTER fix: docs-site pin test FAIL&#10;AFTER fix: docker pin test FAIL</code>

```text
=== Scenario 1: current workflow pins (configure-pages@v5, build-push-action@v6) ===
  51:        uses: actions/configure-pages@v5
  48:        uses: docker/build-push-action@v6
  BEFORE fix: docs-site pin test PASS
  AFTER  fix: docs-site pin test PASS
  BEFORE fix: docker pin test  PASS
  AFTER  fix: docker pin test  PASS

=== Scenario 2: simulate the grouped Dependabot bump (configure-pages v5->v9, build-push-action v6->v7) ===
  51:        uses: actions/configure-pages@v9
  48:        uses: docker/build-push-action@v7
  BEFORE fix: docs-site pin test FAIL
      -> AssertionError: 'uses: actions/configure-pages@v5' not found in 'name: Documentation Site\n\non:\n  pull_reque
  AFTER  fix: docs-site pin test PASS
  BEFORE fix: docker pin test  FAIL
      -> AssertionError: 'docker/build-push-action@v6' not found in 'name: Docker Image\n\non:\n  pull_request:\n  push
  AFTER  fix: docker pin test  PASS

=== Scenario 3: pin dropped (@main / @latest) -- fixed tests must still fail ===
  51:        uses: actions/configure-pages@main
  48:        uses: docker/build-push-action@latest
  AFTER  fix: docs-site pin test FAIL
      -> AssertionError: Regex didn't match: 'uses: actions/configure-pages@v\\d+' not found in 'name: Documentation Si
  AFTER  fix: docker pin test  FAIL
      -> AssertionError: Regex didn't match: 'docker/build-push-action@v\\d+' not found in 'name: Docker Image\n\non:\n

=== Scenario 4: step points at the wrong action -- fixed tests must still fail ===
  51:        uses: actions/setup-pages@v5
  48:        uses: docker/build-action@v6
  AFTER  fix: docs-site pin test FAIL
      -> AssertionError: Regex didn't match: 'uses: actions/configure-pages@v\\d+' not found in 'name: Documentation Si
  AFTER  fix: docker pin test  FAIL
      -> AssertionError: Regex didn't match: 'docker/build-push-action@v\\d+' not found in 'name: Docker Image\n\non:\n

worktree restored: 0 modified files
```
</details>
<details>
<summary>Evidence: Merged grouped-PR simulation: every action major bumped, workflow tests stay green</summary>

<code>Simulating the merged grouped Dependabot PR: bump every action major by +1 across .github/workflows&#10;actions/cache@v6 -&gt; @v7&#10;actions/checkout@v7 -&gt; @v8&#10;actions/configure-pages@v5 -&gt; @v6&#10;actions/deploy-pages@v5 -&gt; @v6&#10;actions/github-script@v9 -&gt; @v10&#10;actions/setup-node@v7 -&gt; @v8&#10;actions/setup-python@v7 -&gt; @v8&#10;actions/upload-artifact@v4 -&gt; @v5&#10;actions/upload-pages-artifact@v5 -&gt; @v6&#10;astral-sh/setup-uv@v7 -&gt; @v8&#10;docker/build-push-action@v6 -&gt; @v7&#10;docker/login-action@v4 -&gt; @v5&#10;docker/metadata-action@v6 -&gt; @v7&#10;docker/setup-buildx-action@v4 -&gt; @v5&#10;softprops/action-gh-release@v3 -&gt; @v4&#10;&#10;Workflow-reading test modules against the bumped workflows:&#10;Ran 70 tests in 0.271s&#10;OK&#10;&#10;Baseline (workflows unmodified): Ran 70 tests — OK</code>

```text
Simulating the merged grouped Dependabot PR: bump every action major by +1 across .github/workflows
  actions/cache@v6 -> @v7
  actions/checkout@v7 -> @v8
  actions/configure-pages@v5 -> @v6
  actions/deploy-pages@v5 -> @v6
  actions/github-script@v9 -> @v10
  actions/setup-node@v7 -> @v8
  actions/setup-python@v7 -> @v8
  actions/upload-artifact@v4 -> @v5
  actions/upload-pages-artifact@v5 -> @v6
  astral-sh/setup-uv@v7 -> @v8
  docker/build-push-action@v6 -> @v7
  docker/login-action@v4 -> @v5
  docker/metadata-action@v6 -> @v7
  docker/setup-buildx-action@v4 -> @v5
  softprops/action-gh-release@v3 -> @v4

Workflow-reading test modules against the bumped workflows:
----------------------------------------------------------------------
Ran 70 tests in 0.271s

OK

worktree restored: 0 modified files
Baseline (workflows unmodified, branch fm/dependabot-group-g4):
Ran 70 tests in 0.300s

OK

Modules exercised: test_ci_evidence, test_dependabot_config, test_docs_pages, test_docker_image, test_docs_site, test_release_docs
```
</details>
<details>
<summary>Evidence: Dependabot PR queue for the real six-PR sweep: base config vs branch config</summary>

<code>--- BEFORE (base commit b252252) ---&#10;github-actions: interval=weekly open-pull-requests-limit=10 groups=none&#10;Dependabot would open 6 PR(s) for 6 pending bump(s):&#10;* chore: bump actions/upload-artifact&#10;* chore: bump actions/setup-python&#10;* chore: bump docker/build-push-action&#10;* chore: bump actions/checkout&#10;* chore: bump astral-sh/setup-uv&#10;* chore: bump actions/cache&#10;pip: 2 PR(s) for 2 pending bump(s)&#10;&#10;--- AFTER (branch fm/dependabot-group-g4) ---&#10;github-actions: interval=weekly open-pull-requests-limit=1 groups=[&#39;github-actions&#39;]&#10;Dependabot would open 1 PR(s) for 6 pending bump(s):&#10;* chore: bump the github-actions group with 6 updates&#10;- actions/upload-artifact (major)&#10;- actions/setup-python (major)&#10;- docker/build-push-action (major)&#10;- actions/checkout (minor)&#10;- astral-sh/setup-uv (minor)&#10;- actions/cache (patch)&#10;pip: 2 PR(s) for 2 pending bump(s) [deliberately ungrouped]</code>

```text
Pending bumps replayed: the six actions from the ungrouped first sweep (PRs #151-#156)

--- BEFORE (base commit b252252) ---
  github-actions: interval=weekly open-pull-requests-limit=10 groups=none
  Dependabot would open 6 PR(s) for 6 pending bump(s):
    * chore: bump actions/upload-artifact
        - actions/upload-artifact (major)
    * chore: bump actions/setup-python
        - actions/setup-python (major)
    * chore: bump docker/build-push-action
        - docker/build-push-action (major)
    * chore: bump actions/checkout
        - actions/checkout (minor)
    * chore: bump astral-sh/setup-uv
        - astral-sh/setup-uv (minor)
    * chore: bump actions/cache
        - actions/cache (patch)
  pip: interval=weekly open-pull-requests-limit=10 groups=none
  Dependabot would open 2 PR(s) for 2 pending bump(s):
    * chore: bump pyyaml
        - pyyaml (minor)
    * chore: bump jsonschema
        - jsonschema (patch)

--- AFTER (branch fm/dependabot-group-g4) ---
  github-actions: interval=weekly open-pull-requests-limit=1 groups=['github-actions']
  Dependabot would open 1 PR(s) for 6 pending bump(s):
    * chore: bump the github-actions group with 6 updates
        - actions/upload-artifact (major)
        - actions/setup-python (major)
        - docker/build-push-action (major)
        - actions/checkout (minor)
        - astral-sh/setup-uv (minor)
        - actions/cache (patch)
  pip: interval=weekly open-pull-requests-limit=10 groups=none
  Dependabot would open 2 PR(s) for 2 pending bump(s):
    * chore: bump pyyaml
        - pyyaml (minor)
    * chore: bump jsonschema
        - jsonschema (patch)

Actions referenced across .github/workflows: 17
  actions/cache, actions/checkout, actions/configure-pages, actions/deploy-pages, actions/github-script, actions/setup-node, actions/setup-python, actions/upload-artifact, actions/upload-pages-artifact, astral-sh/setup-uv, docker/build-push-action, docker/login-action, docker/metadata-action, docker/setup-buildx-action, dtolnay/rust-toolchain, pypa/gh-action-pypi-publish, softprops/action-gh-release
```
</details>
<details>
<summary>Evidence: Script that replays the sweep through the config&#39;s semantic model</summary>

```text
"""Replay the real first Dependabot sweep against the base and new configs."""
import subprocess, sys, yaml
sys.path.insert(0, ".")
from tests.test_dependabot_config import Update, entry_for, plan_pull_requests, workflow_actions

BASE = "b252252d19a7b375d54328af462f6d113c426e45"
SWEEP = [
    Update("actions/upload-artifact", "major"),   # PR #151
    Update("actions/setup-python", "major"),      # PR #152
    Update("docker/build-push-action", "major"),  # PR #153
    Update("actions/checkout", "minor"),          # PR #154
    Update("astral-sh/setup-uv", "minor"),        # PR #155
    Update("actions/cache", "patch"),             # PR #156
]

def show(label, cfg):
    print(f"--- {label} ---")
    for eco, updates in (("github-actions", SWEEP),
                         ("pip", [Update("pyyaml", "minor"), Update("jsonschema", "patch")])):
        entry = entry_for(cfg, eco)
        plan = plan_pull_requests(entry, updates)
        print(f"  {eco}: interval={entry['schedule']['interval']} "
              f"open-pull-requests-limit={entry['open-pull-requests-limit']} "
              f"groups={list((entry.get('groups') or {}).keys()) or 'none'}")
        print(f"  Dependabot would open {len(plan)} PR(s) for {len(updates)} pending bump(s):")
        for pr in plan:
            prefix = entry["commit-message"]["prefix"]
            print(f"    * {prefix}: {pr.title}")
            for u in pr.updates:
                print(f"        - {u.dependency} ({u.update_type})")
    print()

base_cfg = yaml.safe_load(subprocess.run(
    ["git", "show", f"{BASE}:.github/dependabot.yml"], capture_output=True, text=True, check=True).stdout)
new_cfg = yaml.safe_load(open(".github/dependabot.yml", encoding="utf-8"))

print("Pending bumps replayed: the six actions from the ungrouped first sweep (PRs #151-#156)\n")
show("BEFORE (base commit b252252)", base_cfg)
show("AFTER (branch fm/dependabot-group-g4)", new_cfg)
print(f"Actions referenced across .github/workflows: {len(workflow_actions())}")
print("  " + ", ".join(workflow_actions()))
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `tests/test_dependabot_config.py:187` - The guard `assertLessEqual(limit, 10, &#34;the open-pull-requests-limit must not be raised&#34;)` no longer enforces what its message claims: the config now sets `open-pull-requests-limit: 1`, so this assertion would still pass if someone raised it back to 10 — exactly the change the intent says the user ruled out. The following assertion (`len(plan) &lt;= limit`) is the one doing real work. Tightening the bound to the current value (e.g. `assertEqual(limit, 1)`) would make the stated invariant enforceable.
- ℹ️ `.github/dependabot.yml:20` - Operational note, not a code defect: two ungrouped Dependabot PRs for this ecosystem are currently open (#151 actions/upload-artifact, #153 docker/build-push-action). With `open-pull-requests-limit: 1`, the ecosystem is already over capacity until Dependabot closes them as superseded by the new group; if it does not, the first grouped PR may not appear until they are closed manually.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python3 -m unittest tests.test_docs_site tests.test_docker_image -v` — baseline on the branch, 26 tests pass</code>
- <code>Regression matrix: restored base-commit copies of both test files, then simulated the Dependabot bump (`actions/configure-pages@v5`→`@v9`, `docker/build-push-action@v6`→`@v7`) in the workflow files and ran `tests.zz_base_test_docs_site...test_docs_site_workflow_pins_pages_actions` and `tests.zz_base_test_docker_image...test_workflow_builds_and_publishes_ghcr_image` (FAIL) against the fixed `tests.test_docs_site...` / `tests.test_docker_image...` (PASS)</code>
- <code>Negative cases: rewrote the pins to `actions/configure-pages@main` / `docker/build-push-action@latest`, then to a wrong action (`actions/setup-pages@v5` / `docker/build-action@v6`) — the fixed tests fail in both, confirming the `@v\d+` regex keeps the pinning contract</code>
- <code>End-to-end grouped-PR simulation: bumped all 15 action majors by +1 across `.github/workflows/*.yml`, then `uv run --frozen python -m unittest tests.test_ci_evidence tests.test_dependabot_config tests.test_docs_pages tests.test_docker_image tests.test_docs_site tests.test_release_docs` — 70 tests pass (same 70 pass unbumped)</code>
- <code>`grep -rn &#39;@v&#39; tests/*.py` — confirmed no remaining test hardcodes an exact action major</code>
- <code>`python3 -m unittest tests.test_dependabot_config -v` — 8 tests pass</code>
- <code>Replayed the real first sweep (PRs #151–#156) through the config&#39;s semantic model at the base commit vs the branch via `pr_queue.py`, showing 6 PRs → 1 grouped PR for github-actions and pip unchanged at 2 PRs</code>
- <code>`git status --porcelain` — worktree clean after removing all simulation edits and temp test copies</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
