### PR TITLE
feat(evidence): make screenshot and video rendering parameters configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Plugin references using `tui_verifier.*:ClassName` are translated to `termproof.
 
 ## Configuration
 
-Optional configuration lives in `~/.config/termproof/config.yaml` (user) or `.termproof/config.yaml` (project). The `defaults` block currently exposes the post-script idle wait cap:
+Optional configuration lives in `~/.config/termproof/config.yaml` (user) or `.termproof/config.yaml` (project). The `defaults` block exposes the post-script idle wait cap:
 
 ```yaml
 defaults:
@@ -230,6 +230,37 @@ defaults:
 `idle_cap_seconds` is the documented replacement for the former hard-coded 3-second idle cap in `runner.py`. Defaults to `3.0` to preserve existing behavior; raise it (or set `null`) for TUIs that take longer to settle. The value must be a finite, nonnegative number: negative, NaN, or infinite values are rejected at config load.
 
 The idle wait — both the `wait_for_idle` step and this post-script wait — starts measuring at the session's **first byte of output**, so a session that has produced no output is never treated as idle. The trade: a target that stays alive and never emits anything is never idle. A `wait_for_idle` step over such a target fails with `no output observed from the session` after its `timeout_seconds`, and the post-script wait burns its full budget — with `idle_cap_seconds: null` that is the whole recipe `timeout_seconds`, so prefer a finite cap for targets that may be silent. Once the first byte has arrived, quiescence is measured on rendered screen text only: terminal-title updates, colour changes, and repaints that redraw the same characters all count as quiet.
+
+### Evidence rendering
+
+The `evidence` block sets the screenshot and video parameters that used to be
+hard-coded in the renderers and the video pipeline, split into `svg`, `png`, and
+`video`:
+
+```yaml
+evidence:
+  svg:
+    font_size: 14
+    fg: "#e6edf3"
+    bg: "#101418"
+  png:
+    scale: 1
+    font_path: null
+  video:
+    fps: 60
+    pix_fmt: yuv420p
+    crf: null
+```
+
+`BUILTIN_DEFAULTS` in `termproof/config.py` lists every knob with its default.
+Each default reproduces the behavior from before the knobs existed, so a run
+with no `evidence` block renders byte-identical artifacts.
+
+- `evidence.video.fps` is the default for `--video-fps`; the flag wins when passed.
+- A `null` video knob means "omit that flag"; `fps_cap: null` keeps `agg`'s cap tied to the output fps.
+- `png.font_size` applies only when `png.font_path` is set — the bundled bitmap face has one fixed size.
+- Unknown keys under `evidence` are rejected at config load, so a misspelled knob fails loudly instead of silently doing nothing.
+- Evidence values are part of the `--skip-unchanged` cache key, so changing one re-renders cached runs.
 
 ## Packaging
 

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ with no `evidence` block renders byte-identical artifacts.
 - `evidence.video.fps` is the default for `--video-fps`; the flag wins when passed.
 - A `null` video knob means "omit that flag"; `fps_cap: null` keeps `agg`'s cap tied to the output fps.
 - `png.font_size` applies only when `png.font_path` is set — the bundled bitmap face has one fixed size.
-- Unknown keys under `evidence` are rejected at config load, so a misspelled knob fails loudly instead of silently doing nothing.
-- Evidence values are part of the `--skip-unchanged` cache key, so changing one re-renders cached runs.
+- Unknown keys under `evidence` are rejected at config load, so a misspelled knob fails loudly instead of silently doing nothing. So are a value of the wrong type, a section that is not a mapping, a non-positive size or frame rate, and a negative padding.
+- Evidence values are part of the `--skip-unchanged` cache key, so changing one re-renders cached runs. The `video` knobs only count towards it for a run that renders video, as `--video-fps` and the video backend already do.
 
 ## Packaging
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ with no `evidence` block renders byte-identical artifacts.
 - `evidence.video.fps` is the default for `--video-fps`; the flag wins when passed.
 - A `null` video knob means "omit that flag"; `fps_cap: null` keeps `agg`'s cap tied to the output fps.
 - `png.font_size` applies only when `png.font_path` is set — the bundled bitmap face has one fixed size.
+- `png.scale` multiplies the canvas, the padding and the line pitch, not the glyphs of that bitmap face, so it spreads the same text over a larger image unless `png.font_path` is set too.
 - Unknown keys under `evidence` are rejected at config load, so a misspelled knob fails loudly instead of silently doing nothing. So are a value of the wrong type, a section that is not a mapping, a non-positive size or frame rate, and a negative padding.
 - Evidence values are part of the `--skip-unchanged` cache key, so changing one re-renders cached runs. The `video` knobs only count towards it for a run that renders video, as `--video-fps` and the video backend already do.
 

--- a/docs/plugin-protocols.md
+++ b/docs/plugin-protocols.md
@@ -24,6 +24,9 @@ TermProof exposes stable plugin protocols from `termproof.protocols`.
 present TermProof calls it instead of the zero-argument constructor, so the
 plugin can read the `evidence` config block (see the Configuration section of
 the README). Plugins without it keep being constructed with no arguments.
+`EvidenceConfig`, and the narrower `SvgRenderConfig`, `PngRenderConfig`, and
+`VideoConfig` its sections hold, are exported from `termproof.protocols`
+alongside the protocols themselves.
 
 ## ExecutionMode runner surface
 

--- a/docs/plugin-protocols.md
+++ b/docs/plugin-protocols.md
@@ -19,6 +19,12 @@ TermProof exposes stable plugin protocols from `termproof.protocols`.
 
 `ScreenRenderer` plugins can optionally set `extension = "png"` (or another file extension) so evidence artifacts use that screenshot filename suffix.
 
+`ScreenRenderer` and `VideoBackend` plugins can optionally define a
+`from_config(cls, evidence: EvidenceConfig) -> Self` classmethod. When it is
+present TermProof calls it instead of the zero-argument constructor, so the
+plugin can read the `evidence` config block (see the Configuration section of
+the README). Plugins without it keep being constructed with no arguments.
+
 ## ExecutionMode runner surface
 
 An `ExecutionMode.execute` implementation receives a `VerificationRunner` and

--- a/termproof/__init__.py
+++ b/termproof/__init__.py
@@ -1,6 +1,13 @@
 """Evidence-first verification for terminal and TUI applications."""
 
-from .config import VerifierConfig, load_config
+from .config import (
+    EvidenceConfig,
+    PngRenderConfig,
+    SvgRenderConfig,
+    VerifierConfig,
+    VideoConfig,
+    load_config,
+)
 from .models import AssertionResult, Recipe, RunResult, StepResult, load_recipe
 from .protocols import (
     AgentRunner,
@@ -20,7 +27,9 @@ __all__ = [
     "AgentRunner",
     "AssertionResult",
     "AssertionType",
+    "EvidenceConfig",
     "ExecutionMode",
+    "PngRenderConfig",
     "Recipe",
     "Registry",
     "Reporter",
@@ -30,7 +39,9 @@ __all__ = [
     "SessionBackend",
     "StepAction",
     "StepResult",
+    "SvgRenderConfig",
     "VideoBackend",
+    "VideoConfig",
     "VerificationRunner",
     "VerifierConfig",
     "load_config",

--- a/termproof/builtin_renderers.py
+++ b/termproof/builtin_renderers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from PIL import Image, ImageDraw, ImageFont
 
+from .config import EvidenceConfig, PngRenderConfig, SvgRenderConfig
 from .protocols import ScreenRenderer as ScreenRenderer
 
 
@@ -14,6 +15,13 @@ class SvgRenderer:
     name = "svg"
     extension = "svg"
 
+    def __init__(self, config: SvgRenderConfig | None = None) -> None:
+        self.config = config or SvgRenderConfig()
+
+    @classmethod
+    def from_config(cls, evidence: EvidenceConfig) -> SvgRenderer:
+        return cls(evidence.svg)
+
     def render(
         self,
         text: str,
@@ -21,22 +29,20 @@ class SvgRenderer:
         cols: int,
         rows: int,
     ) -> None:
-        line_height = 20
-        char_width = 9
-        padding = 18
-        width = max(320, cols * char_width + padding * 2)
-        height = max(160, rows * line_height + padding * 2)
+        config = self.config
+        width = max(320, cols * config.char_width + config.padding * 2)
+        height = max(160, rows * config.line_height + config.padding * 2)
         visible_lines = text.splitlines()[:rows] or [""]
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         parts = [
             f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
-            '<rect width="100%" height="100%" fill="#101418"/>',
-            '<style>text{font:14px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;fill:#e6edf3;white-space:pre}</style>',
+            f'<rect width="100%" height="100%" fill="{config.bg}"/>',
+            f'<style>text{{font:{config.font_size}px {config.font_family};fill:{config.fg};white-space:pre}}</style>',
         ]
         for index, line in enumerate(visible_lines):
-            y = padding + line_height * (index + 1)
-            parts.append(f'<text x="{padding}" y="{y}">{html.escape(line)}</text>')
+            y = config.padding + config.line_height * (index + 1)
+            parts.append(f'<text x="{config.padding}" y="{y}">{html.escape(line)}</text>')
         parts.append("</svg>")
         output_path.write_text("\n".join(parts) + "\n", encoding="utf-8")
 
@@ -45,6 +51,21 @@ class PngRenderer:
     name = "png"
     extension = "png"
 
+    def __init__(self, config: PngRenderConfig | None = None) -> None:
+        self.config = config or PngRenderConfig()
+
+    @classmethod
+    def from_config(cls, evidence: EvidenceConfig) -> PngRenderer:
+        return cls(evidence.png)
+
+    def _font(self) -> ImageFont.ImageFont | ImageFont.FreeTypeFont:
+        if self.config.font_path is None:
+            return ImageFont.load_default()
+        return ImageFont.truetype(
+            self.config.font_path,
+            self.config.font_size * self.config.scale,
+        )
+
     def render(
         self,
         text: str,
@@ -52,19 +73,21 @@ class PngRenderer:
         cols: int,
         rows: int,
     ) -> None:
-        font = ImageFont.load_default()
+        config = self.config
+        scale = config.scale
+        font = self._font()
         bbox = font.getbbox("M")
-        char_width = max(9, bbox[2] - bbox[0])
-        line_height = max(18, bbox[3] - bbox[1] + 6)
-        padding = 18
-        width = max(320, cols * char_width + padding * 2)
-        height = max(160, rows * line_height + padding * 2)
-        image = Image.new("RGB", (int(width), int(height)), "#101418")
+        char_width = max(9 * scale, bbox[2] - bbox[0])
+        line_height = max(18 * scale, bbox[3] - bbox[1] + 6 * scale)
+        padding = config.padding * scale
+        width = max(320 * scale, cols * char_width + padding * 2)
+        height = max(160 * scale, rows * line_height + padding * 2)
+        image = Image.new("RGB", (int(width), int(height)), config.bg)
         draw = ImageDraw.Draw(image)
 
         for index, line in enumerate(text.splitlines()[:rows] or [""]):
             y = padding + line_height * index
-            draw.text((padding, y), line[:cols], font=font, fill="#e6edf3")
+            draw.text((padding, y), line[:cols], font=font, fill=config.fg)
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
         image.save(output_path, format="PNG")

--- a/termproof/builtin_video.py
+++ b/termproof/builtin_video.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from .config import EvidenceConfig, VideoConfig
 from .protocols import VideoBackend as VideoBackend
 
 
@@ -14,6 +15,13 @@ class AggFfmpegBackend:
     # (agg/ffmpeg), while custom plugin dispatch remains ungated.
     builtin = True
 
+    def __init__(self, config: VideoConfig | None = None) -> None:
+        self.config = config or VideoConfig()
+
+    @classmethod
+    def from_config(cls, evidence: EvidenceConfig) -> AggFfmpegBackend:
+        return cls(evidence.video)
+
     def render(
         self,
         cast_path: Path,
@@ -22,4 +30,4 @@ class AggFfmpegBackend:
     ) -> None:
         from .evidence import render_mp4
 
-        render_mp4(cast_path, output_path, fps)
+        render_mp4(cast_path, output_path, fps, self.config)

--- a/termproof/cli.py
+++ b/termproof/cli.py
@@ -295,6 +295,7 @@ def _run_item(
             video_backend=args.video_backend,
             render_video=render_video,
             video_fps=args.video_fps,
+            evidence=runner.config.evidence,
         )
         if cached is not None:
             return cached
@@ -320,5 +321,6 @@ def _run_item(
             video_backend=args.video_backend,
             render_video=render_video,
             video_fps=args.video_fps,
+            evidence=runner.config.evidence,
         )
     return result

--- a/termproof/cli.py
+++ b/termproof/cli.py
@@ -26,7 +26,8 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--out", type=Path, default=Path(".termproof/runs"))
     run_parser.add_argument("--video", action="store_true")
     run_parser.add_argument("--no-video", action="store_true")
-    run_parser.add_argument("--video-fps", type=int, default=60)
+    run_parser.add_argument("--video-fps", type=int, default=None,
+                            help="video frame rate; overrides evidence.video.fps (default: 60)")
     run_parser.add_argument("--priority")
     run_parser.add_argument("--recipe-name", action="append", dest="recipe_names")
     run_parser.add_argument("--parallel", type=int, default=1,
@@ -89,7 +90,8 @@ def main(argv: list[str] | None = None) -> int:
                              help="do not attempt to open generated report in browser")
     demo_parser.add_argument("--video", action="store_true",
                              help="render video evidence if video backend available")
-    demo_parser.add_argument("--video-fps", type=int, default=60)
+    demo_parser.add_argument("--video-fps", type=int, default=None,
+                             help="video frame rate; overrides evidence.video.fps (default: 60)")
     demo_parser.add_argument("--config", type=Path, default=None,
                              help="path to a termproof config YAML file")
     demo_parser.add_argument("--reporter", default="markdown",
@@ -110,6 +112,10 @@ def main(argv: list[str] | None = None) -> int:
             print("--skip-unchanged cannot be combined with --diff or --update-baselines")
             return 2
         config = _resolve_config(args)
+        # The flag is the last step of the same cascade: builtin, then user,
+        # project and explicit config files, then the command line.
+        if args.video_fps is None:
+            args.video_fps = config.evidence.video.fps
         recipes = select_recipes(
             load_recipes(args.recipes),
             priority=args.priority,

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -298,6 +298,7 @@ _EVIDENCE_MINIMUMS: dict[str, int] = {
     "evidence.png.padding": 0,
     "evidence.video.fps": 1,
     "evidence.video.fps_cap": 1,
+    "evidence.video.font_size": 1,
 }
 
 

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -284,13 +284,52 @@ def _check_field_type(label: str, name: str, hint: Any, value: Any) -> None:
     raise ValueError(f"{label}.{name} must be {names}, got {value!r}")
 
 
+# Smallest value each dimensional or rate knob can take. A zero or negative
+# size collapses the rendered geometry (or reaches ``ImageFont.truetype`` as a
+# negative size), and ``fps: 0`` reaches ffmpeg as ``-vf fps=0``, so these have
+# to be refused where the offending key can still be named.
+_EVIDENCE_MINIMUMS: dict[str, int] = {
+    "evidence.svg.char_width": 1,
+    "evidence.svg.line_height": 1,
+    "evidence.svg.font_size": 1,
+    "evidence.svg.padding": 0,
+    "evidence.png.scale": 1,
+    "evidence.png.font_size": 1,
+    "evidence.png.padding": 0,
+    "evidence.video.fps": 1,
+    "evidence.video.fps_cap": 1,
+}
+
+
+def _check_field_range(label: str, name: str, value: Any) -> None:
+    """Reject an out-of-range size or rate, naming the key as the type check does."""
+    minimum = _EVIDENCE_MINIMUMS.get(f"{label}.{name}")
+    if minimum is None or value is None or value >= minimum:
+        return
+    wording = "a positive integer" if minimum == 1 else "a nonnegative integer"
+    raise ValueError(f"{label}.{name} must be {wording}, got {value!r}")
+
+
+def _mapping(raw: Any, label: str) -> dict[str, Any]:
+    """Return a config section as a mapping, refusing a scalar or a sequence.
+
+    ``dict(raw)`` alone raises a ``TypeError`` that names neither the section
+    nor the key, and callers of ``load_config`` expect a ``ValueError``.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{label} must be a mapping, got {raw!r}")
+    return dict(raw)
+
+
 def _section(cls: type, raw: Any, label: str) -> Any:
     """Build a frozen config dataclass from a YAML mapping.
 
     Unknown keys are rejected rather than ignored: a misspelled rendering knob
     that silently does nothing is indistinguishable from one that had no effect.
     """
-    values = dict(raw or {})
+    values = _mapping(raw, label)
     hints = get_type_hints(cls)
     known = {field_.name for field_ in fields(cls)}
     unknown = sorted(set(values) - known)
@@ -300,11 +339,12 @@ def _section(cls: type, raw: Any, label: str) -> Any:
         )
     for name, value in values.items():
         _check_field_type(label, name, hints[name], value)
+        _check_field_range(label, name, value)
     return cls(**values)
 
 
 def _evidence_from_mapping(raw: Any) -> EvidenceConfig:
-    values = dict(raw or {})
+    values = _mapping(raw, "evidence")
     evidence = EvidenceConfig(
         svg=_section(SvgRenderConfig, values.pop("svg", {}), "evidence.svg"),
         png=_section(PngRenderConfig, values.pop("png", {}), "evidence.png"),

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
@@ -62,6 +62,42 @@ BUILTIN_DEFAULTS: dict[str, Any] = {
     "defaults": {
         "idle_cap_seconds": 3.0,
     },
+    # Evidence-rendering parameters. Every value here reproduces the behavior
+    # that was previously hardcoded in the renderers and the video pipeline, so
+    # an unconfigured run is byte-identical to one from before they were
+    # extracted.
+    "evidence": {
+        "svg": {
+            "char_width": 9,
+            "line_height": 20,
+            "padding": 18,
+            "font_size": 14,
+            "font_family": "ui-monospace,SFMono-Regular,Menlo,Consolas,monospace",
+            "fg": "#e6edf3",
+            "bg": "#101418",
+        },
+        "png": {
+            "scale": 1,
+            "padding": 18,
+            "font_size": 14,
+            "font_path": None,
+            "fg": "#e6edf3",
+            "bg": "#101418",
+        },
+        "video": {
+            "fps": 60,
+            "fps_cap": None,
+            "pix_fmt": "yuv420p",
+            "crf": None,
+            "preset": None,
+            "tune": None,
+            "idle_time_limit": None,
+            "last_frame_duration": None,
+            "theme": None,
+            "font_size": None,
+            "font_family": None,
+        },
+    },
 }
 
 
@@ -85,6 +121,54 @@ class DockerBackendConfig:
 
 
 @dataclass(frozen=True)
+class SvgRenderConfig:
+    char_width: int = 9
+    line_height: int = 20
+    padding: int = 18
+    font_size: int = 14
+    font_family: str = "ui-monospace,SFMono-Regular,Menlo,Consolas,monospace"
+    fg: str = "#e6edf3"
+    bg: str = "#101418"
+
+
+@dataclass(frozen=True)
+class PngRenderConfig:
+    # ``font_path`` of None keeps PIL's bundled proportional bitmap face.
+    # ``font_size`` is only consulted when a font path is given.
+    scale: int = 1
+    padding: int = 18
+    font_size: int = 14
+    font_path: str | None = None
+    fg: str = "#e6edf3"
+    bg: str = "#101418"
+
+
+@dataclass(frozen=True)
+class VideoConfig:
+    # None means "omit the flag", so the default command line is the one the
+    # pipeline built before these were configurable. ``fps_cap`` of None keeps
+    # agg's cap tied to the effective output fps, as it was.
+    fps: int = 60
+    fps_cap: int | None = None
+    pix_fmt: str = "yuv420p"
+    crf: int | None = None
+    preset: str | None = None
+    tune: str | None = None
+    idle_time_limit: float | None = None
+    last_frame_duration: float | None = None
+    theme: str | None = None
+    font_size: int | None = None
+    font_family: str | None = None
+
+
+@dataclass(frozen=True)
+class EvidenceConfig:
+    svg: SvgRenderConfig = SvgRenderConfig()
+    png: PngRenderConfig = PngRenderConfig()
+    video: VideoConfig = VideoConfig()
+
+
+@dataclass(frozen=True)
 class VerifierConfig:
     steps: dict[str, str]
     assertions: dict[str, str]
@@ -96,6 +180,7 @@ class VerifierConfig:
     session_backend: str
     docker: DockerBackendConfig
     defaults: GlobalDefaults
+    evidence: EvidenceConfig
 
     @classmethod
     def builtin(cls) -> VerifierConfig:
@@ -177,6 +262,34 @@ def _parse_idle_cap_seconds(value: Any) -> float | None:
     return parsed
 
 
+def _section(cls: type, raw: Any, label: str) -> Any:
+    """Build a frozen config dataclass from a YAML mapping.
+
+    Unknown keys are rejected rather than ignored: a misspelled rendering knob
+    that silently does nothing is indistinguishable from one that had no effect.
+    """
+    values = dict(raw or {})
+    known = {field_.name for field_ in fields(cls)}
+    unknown = sorted(set(values) - known)
+    if unknown:
+        raise ValueError(
+            f"unknown {label} option(s) {unknown}; known options: {sorted(known)}"
+        )
+    return cls(**values)
+
+
+def _evidence_from_mapping(raw: Any) -> EvidenceConfig:
+    values = dict(raw or {})
+    evidence = EvidenceConfig(
+        svg=_section(SvgRenderConfig, values.pop("svg", {}), "evidence.svg"),
+        png=_section(PngRenderConfig, values.pop("png", {}), "evidence.png"),
+        video=_section(VideoConfig, values.pop("video", {}), "evidence.video"),
+    )
+    if values:
+        raise ValueError(f"unknown evidence option(s) {sorted(values)}")
+    return evidence
+
+
 def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
     defaults_raw = data.get("defaults", {})
     docker_raw = data.get("docker", {})
@@ -204,6 +317,7 @@ def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
                 defaults_raw.get("idle_cap_seconds", 3.0)
             ),
         ),
+        evidence=_evidence_from_mapping(data.get("evidence", {})),
     )
 
 

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args, get_type_hints
 
 try:
     import yaml
@@ -135,6 +135,10 @@ class SvgRenderConfig:
 class PngRenderConfig:
     # ``font_path`` of None keeps PIL's bundled proportional bitmap face.
     # ``font_size`` is only consulted when a font path is given.
+    # ``scale`` multiplies the canvas, the padding and the line pitch, but not
+    # the glyphs of the default bitmap face, which has one fixed size. Scaling
+    # up therefore spreads the same text over a larger image unless
+    # ``font_path`` is also set, which is what yields a higher-DPI screenshot.
     scale: int = 1
     padding: int = 18
     font_size: int = 14
@@ -262,6 +266,24 @@ def _parse_idle_cap_seconds(value: Any) -> float | None:
     return parsed
 
 
+def _check_field_type(label: str, name: str, hint: Any, value: Any) -> None:
+    """Reject a value whose type its field cannot honor.
+
+    A quoted number or a stray mapping loads happily and then fails deep inside
+    a renderer, in an error that no longer names the option that was wrong.
+    """
+    declared = get_args(hint) or (hint,)
+    accepted = (*declared, int) if float in declared else declared
+    if isinstance(value, accepted) and not (
+        isinstance(value, bool) and bool not in declared
+    ):
+        return
+    names = " or ".join(
+        "null" if arg is type(None) else arg.__name__ for arg in declared
+    )
+    raise ValueError(f"{label}.{name} must be {names}, got {value!r}")
+
+
 def _section(cls: type, raw: Any, label: str) -> Any:
     """Build a frozen config dataclass from a YAML mapping.
 
@@ -269,12 +291,15 @@ def _section(cls: type, raw: Any, label: str) -> Any:
     that silently does nothing is indistinguishable from one that had no effect.
     """
     values = dict(raw or {})
+    hints = get_type_hints(cls)
     known = {field_.name for field_ in fields(cls)}
     unknown = sorted(set(values) - known)
     if unknown:
         raise ValueError(
             f"unknown {label} option(s) {unknown}; known options: {sorted(known)}"
         )
+    for name, value in values.items():
+        _check_field_type(label, name, hints[name], value)
     return cls(**values)
 
 

--- a/termproof/demo.py
+++ b/termproof/demo.py
@@ -112,7 +112,7 @@ def run_demo(
     out_dir: Path,
     no_open: bool,
     render_video: bool = False,
-    video_fps: int = 60,
+    video_fps: int | None = None,
     reporter_name: str = "markdown",
     screen_renderer_name: str = "svg",
     video_backend_name: str = "agg_ffmpeg",
@@ -128,6 +128,8 @@ def run_demo(
         # Default demo uses builtin config only — avoids ambient project/user
         # config contamination for a self-contained demo.
         config = VerifierConfig.builtin()
+    if video_fps is None:
+        video_fps = config.evidence.video.fps
 
     recipe = build_demo_recipe(out_dir=out_dir)
     runner = VerificationRunner(config=config)

--- a/termproof/evidence.py
+++ b/termproof/evidence.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from .agg_bundle import resolve_agg
+from .config import EvidenceConfig, SvgRenderConfig, VideoConfig
 from .models import RunResult, StepResult
 from .screen import render_svg, replay_cast
 
@@ -29,17 +30,18 @@ def render_artifacts(
     rows: int | None = None,
     screen_renderer: Any = None,
     video_backend: Any = None,
+    evidence_config: EvidenceConfig | None = None,
 ) -> dict[str, str]:
+    evidence_config = evidence_config or EvidenceConfig()
     cast_path = run_dir / "session.cast"
     final_text, cols, rows = replay_cast(cast_path)
     final_txt = run_dir / "final.txt"
     screenshot_ext = _screen_extension(screen_renderer)
     final_screenshot = run_dir / f"final.{screenshot_ext}"
     final_txt.write_text(final_text + "\n", encoding="utf-8")
-    if screen_renderer is not None:
-        screen_renderer.render(final_text, final_screenshot, cols, rows)
-    else:
-        render_svg(final_text, final_screenshot, cols, rows)
+    _render_screen(
+        final_text, final_screenshot, cols, rows, screen_renderer, evidence_config.svg
+    )
     artifacts = {
         "cast": str(cast_path),
         "screenshot": str(final_screenshot),
@@ -55,6 +57,7 @@ def render_artifacts(
         rows,
         screen_renderer,
         screenshot_ext,
+        evidence_config,
     )
     if step_dir is not None:
         artifacts["step_screenshots"] = str(step_dir)
@@ -82,7 +85,7 @@ def render_artifacts(
                 if video_backend is not None:
                     video_backend.render(cast_path, mp4_path, video_fps)
                 else:
-                    render_mp4(cast_path, mp4_path, video_fps)
+                    render_mp4(cast_path, mp4_path, video_fps, evidence_config.video)
                 artifacts["video"] = str(mp4_path)
     return artifacts
 
@@ -103,6 +106,20 @@ def _resolve_ffmpeg() -> str | None:
         return None
 
 
+def _render_screen(
+    text: str,
+    output_path: Path,
+    cols: int,
+    rows: int,
+    screen_renderer: Any,
+    svg_config: SvgRenderConfig,
+) -> None:
+    if screen_renderer is not None:
+        screen_renderer.render(text, output_path, cols, rows)
+    else:
+        render_svg(text, output_path, cols, rows, svg_config)
+
+
 def _render_step_screens(
     run_dir: Path,
     steps: list[StepResult],
@@ -110,9 +127,11 @@ def _render_step_screens(
     rows: int,
     screen_renderer: Any = None,
     screenshot_ext: str = "svg",
+    evidence_config: EvidenceConfig | None = None,
 ) -> Path | None:
     if not steps:
         return None
+    config = evidence_config or EvidenceConfig()
     step_dir = run_dir / "steps"
     step_dir.mkdir(parents=True, exist_ok=True)
     for index, step in enumerate(steps, start=1):
@@ -120,10 +139,9 @@ def _render_step_screens(
         path_base = step_dir / f"{index:02d}-{safe_name}"
         (path_base.with_suffix(".txt")).write_text(step.screen + "\n", encoding="utf-8")
         screenshot_path = path_base.with_suffix(f".{screenshot_ext}")
-        if screen_renderer is not None:
-            screen_renderer.render(step.screen, screenshot_path, cols, rows)
-        else:
-            render_svg(step.screen, screenshot_path, cols, rows)
+        _render_screen(
+            step.screen, screenshot_path, cols, rows, screen_renderer, config.svg
+        )
     return step_dir
 
 
@@ -134,18 +152,43 @@ def _screen_extension(screen_renderer: Any = None) -> str:
     return extension or "svg"
 
 
-def render_mp4(cast_path: Path, mp4_path: Path, fps: int = 60) -> None:
+def _optional_flags(pairs: tuple[tuple[str, Any], ...]) -> list[str]:
+    """Expand ``(flag, value)`` pairs, omitting any whose value is None."""
+    flags: list[str] = []
+    for flag, value in pairs:
+        if value is not None:
+            flags.extend([flag, str(value)])
+    return flags
+
+
+def render_mp4(
+    cast_path: Path,
+    mp4_path: Path,
+    fps: int = 60,
+    config: VideoConfig | None = None,
+) -> None:
+    config = config or VideoConfig()
     agg_path = resolve_agg()
     if agg_path is None:
         return
     gif_path = mp4_path.with_suffix(".agg.gif")
+    fps_cap = fps if config.fps_cap is None else config.fps_cap
     try:
         subprocess.run(
             [
                 agg_path,
                 "--quiet",
                 "--fps-cap",
-                str(fps),
+                str(fps_cap),
+                *_optional_flags(
+                    (
+                        ("--idle-time-limit", config.idle_time_limit),
+                        ("--last-frame-duration", config.last_frame_duration),
+                        ("--theme", config.theme),
+                        ("--font-size", config.font_size),
+                        ("--font-family", config.font_family),
+                    )
+                ),
                 str(cast_path),
                 str(gif_path),
             ],
@@ -163,7 +206,14 @@ def render_mp4(cast_path: Path, mp4_path: Path, fps: int = 60) -> None:
                 "-vf",
                 f"fps={fps},scale=trunc(iw/2)*2:trunc(ih/2)*2",
                 "-pix_fmt",
-                "yuv420p",
+                config.pix_fmt,
+                *_optional_flags(
+                    (
+                        ("-crf", config.crf),
+                        ("-preset", config.preset),
+                        ("-tune", config.tune),
+                    )
+                ),
                 "-movflags",
                 "+faststart",
                 str(mp4_path),

--- a/termproof/protocols.py
+++ b/termproof/protocols.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from .before_after import BeforeAfterResult
 from .build_info import BuildInfo
+from .config import EvidenceConfig, PngRenderConfig, SvgRenderConfig, VideoConfig
 from .models import AssertionResult, Recipe, RunResult, StepResult
 from .session import TerminalSession
 
@@ -109,10 +110,14 @@ class SessionBackend(Protocol):
 __all__ = [
     "AgentRunner",
     "AssertionType",
+    "EvidenceConfig",
     "ExecutionMode",
+    "PngRenderConfig",
     "Reporter",
     "ScreenRenderer",
     "SessionBackend",
     "StepAction",
+    "SvgRenderConfig",
     "VideoBackend",
+    "VideoConfig",
 ]

--- a/termproof/run_cache.py
+++ b/termproof/run_cache.py
@@ -112,6 +112,7 @@ def _cache_key(
         candidate = Path(ci_path)
         path = candidate if candidate.is_absolute() else recipe_path.parent / candidate
         _hash_path(digest, path)
+    evidence_config = evidence or EvidenceConfig()
     payload = {
         "renderer": renderer,
         "renderer_argv": renderer_argv,
@@ -120,10 +121,16 @@ def _cache_key(
         "render_video": render_video,
         "video_backend": video_backend if render_video else "",
         "video_fps": video_fps if render_video else 0,
-        # Serialize the whole evidence section rather than listing knobs: every
-        # value in it changes the rendered artifacts, so a knob added later has
-        # to invalidate cached runs without anyone remembering to add it here.
-        "evidence": asdict(evidence or EvidenceConfig()),
+        # Serialize each evidence sub-section wholesale rather than listing
+        # knobs: every value in one changes the artifacts that section renders,
+        # so a knob added later has to invalidate cached runs without anyone
+        # remembering to add it here. The video knobs drop out when no video is
+        # rendered, for the same reason video_backend and video_fps do.
+        "evidence": {
+            "svg": asdict(evidence_config.svg),
+            "png": asdict(evidence_config.png),
+            "video": asdict(evidence_config.video) if render_video else None,
+        },
     }
     digest.update(json.dumps(payload, sort_keys=True).encode("utf-8"))
     return digest.hexdigest()

--- a/termproof/run_cache.py
+++ b/termproof/run_cache.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import replace
+from dataclasses import asdict, replace
 from pathlib import Path
 from typing import Any
 
+from .config import EvidenceConfig
 from .models import Recipe, RunResult
 
 
@@ -20,6 +21,7 @@ def load_cached_result(
     video_backend: str,
     render_video: bool,
     video_fps: int,
+    evidence: EvidenceConfig | None = None,
 ) -> RunResult | None:
     key = _cache_key(
         recipe,
@@ -30,6 +32,7 @@ def load_cached_result(
         video_backend=video_backend,
         render_video=render_video,
         video_fps=video_fps,
+        evidence=evidence,
     )
     if key is None:
         return None
@@ -61,6 +64,7 @@ def store_cached_result(
     video_backend: str,
     render_video: bool,
     video_fps: int,
+    evidence: EvidenceConfig | None = None,
 ) -> None:
     if not result.passed:
         return
@@ -73,6 +77,7 @@ def store_cached_result(
         video_backend=video_backend,
         render_video=render_video,
         video_fps=video_fps,
+        evidence=evidence,
     )
     if key is None:
         return
@@ -94,6 +99,7 @@ def _cache_key(
     video_backend: str,
     render_video: bool,
     video_fps: int,
+    evidence: EvidenceConfig | None = None,
 ) -> str | None:
     if not recipe.source_path:
         return None
@@ -114,6 +120,10 @@ def _cache_key(
         "render_video": render_video,
         "video_backend": video_backend if render_video else "",
         "video_fps": video_fps if render_video else 0,
+        # Serialize the whole evidence section rather than listing knobs: every
+        # value in it changes the rendered artifacts, so a knob added later has
+        # to invalidate cached runs without anyone remembering to add it here.
+        "evidence": asdict(evidence or EvidenceConfig()),
     }
     digest.update(json.dumps(payload, sort_keys=True).encode("utf-8"))
     return digest.hexdigest()

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -162,13 +162,17 @@ class VerificationRunner:
         recipe: Recipe,
         out_dir: Path = Path(".termproof/runs"),
         render_video: bool = False,
-        video_fps: int = 60,
+        video_fps: int | None = None,
         renderer: str = "default",
         renderer_argv: list[str] | None = None,
         screen_renderer_name: str = "svg",
         video_backend_name: str = "agg_ffmpeg",
     ) -> RunResult:
         start = time.monotonic()
+        # An explicit argument wins; otherwise the configured fps is the last
+        # step of the same cascade the CLI entry points already follow.
+        if video_fps is None:
+            video_fps = self.config.evidence.video.fps
         runnable_recipe = _with_renderer_argv(recipe, renderer_argv or [])
         run_dir = new_run_dir(out_dir, recipe.name, renderer)
         run_dir.mkdir(parents=True, exist_ok=True)

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -9,6 +9,7 @@ from .agent_driven import AgentDrivenRunner, AgentRunner, CodexCliAgentRunner
 from .config import (
     CURRENT_PLUGIN_MODULE_PREFIX,
     LEGACY_PLUGIN_MODULE_PREFIX,
+    EvidenceConfig,
     VerifierConfig,
 )
 from .evidence import new_run_dir, render_artifacts, write_result_files
@@ -56,11 +57,22 @@ def _build_reporter_registry(config: VerifierConfig) -> Registry[Any]:
     return registry
 
 
+def _construct_evidence_plugin(cls: type, evidence: EvidenceConfig) -> Any:
+    """Instantiate a renderer or video backend, passing evidence config if wanted.
+
+    Plugins opt in by exposing ``from_config``. Ones that do not — including
+    every third-party plugin written against the existing protocols — keep being
+    constructed with no arguments.
+    """
+    factory = getattr(cls, "from_config", None)
+    return cls() if factory is None else factory(evidence)
+
+
 def _build_renderer_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.screen_renderers.items():
         cls = _import_class(qualname)
-        registry.register(name, lambda c=cls: c())
+        registry.register(name, lambda c=cls: _construct_evidence_plugin(c, config.evidence))
     return registry
 
 
@@ -84,7 +96,7 @@ def _build_video_backend_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.video_backends.items():
         cls = _import_class(qualname)
-        registry.register(name, lambda c=cls: c())
+        registry.register(name, lambda c=cls: _construct_evidence_plugin(c, config.evidence))
     return registry
 
 
@@ -176,6 +188,7 @@ class VerificationRunner:
             rows=recipe.rows,
             screen_renderer=screen_renderer,
             video_backend=video_backend,
+            evidence_config=self.config.evidence,
         )
         score = score_from_assertions(assertions)
         passed = all(step.passed for step in steps) and all(a.passed for a in assertions)

--- a/termproof/screen.py
+++ b/termproof/screen.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pyte
 
+from .config import SvgRenderConfig
+
 
 def replay_cast(cast_path: Path) -> tuple[str, int, int]:
     with cast_path.open(encoding="utf-8") as file:
@@ -28,22 +30,31 @@ def screen_text(screen: pyte.Screen) -> str:
     return "\n".join(lines)
 
 
-def render_svg(text: str, output_path: Path, cols: int, rows: int) -> None:
-    line_height = 20
-    char_width = 9
-    padding = 18
-    width = max(320, cols * char_width + padding * 2)
-    height = max(160, rows * line_height + padding * 2)
+def render_svg(
+    text: str,
+    output_path: Path,
+    cols: int,
+    rows: int,
+    config: SvgRenderConfig | None = None,
+) -> None:
+    """Render a screen to SVG.
+
+    Deliberately duplicates ``builtin_renderers.SvgRenderer``; the two must be
+    kept in step until the duplicate is removed in a separate structural change.
+    """
+    config = config or SvgRenderConfig()
+    width = max(320, cols * config.char_width + config.padding * 2)
+    height = max(160, rows * config.line_height + config.padding * 2)
     visible_lines = text.splitlines()[:rows] or [""]
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
-        '<rect width="100%" height="100%" fill="#101418"/>',
-        '<style>text{font:14px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;fill:#e6edf3;white-space:pre}</style>',
+        f'<rect width="100%" height="100%" fill="{config.bg}"/>',
+        f'<style>text{{font:{config.font_size}px {config.font_family};fill:{config.fg};white-space:pre}}</style>',
     ]
     for index, line in enumerate(visible_lines):
-        y = padding + line_height * (index + 1)
-        parts.append(f'<text x="{padding}" y="{y}">{html.escape(line)}</text>')
+        y = config.padding + config.line_height * (index + 1)
+        parts.append(f'<text x="{config.padding}" y="{y}">{html.escape(line)}</text>')
     parts.append("</svg>")
     output_path.write_text("\n".join(parts) + "\n", encoding="utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from termproof.cli import main
+from termproof.config import VerifierConfig
 from termproof.models import RunResult, load_recipe
 from termproof.run_cache import store_cached_result
 
@@ -305,6 +306,9 @@ class CliTest(unittest.TestCase):
 
             with patch("termproof.cli.VerificationRunner") as runner_class:
                 runner = runner_class.return_value
+                # The cache key covers the evidence config the runner renders
+                # with, so the stand-in needs the real one.
+                runner.config = VerifierConfig.builtin()
                 runner.run.side_effect = AssertionError("runner should be skipped")
                 runner.reporter_registry.get.return_value.generate.return_value = "report"
                 output = io.StringIO()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -226,6 +226,96 @@ docker:
         self.assertEqual({"PYTHONUNBUFFERED": "1"}, config.docker.env)
 
 
+class EvidenceConfigTest(unittest.TestCase):
+    def test_builtin_evidence_defaults_reproduce_the_previous_literals(self) -> None:
+        evidence = VerifierConfig.builtin().evidence
+        self.assertEqual(
+            (9, 20, 18, 14, "#e6edf3", "#101418"),
+            (
+                evidence.svg.char_width,
+                evidence.svg.line_height,
+                evidence.svg.padding,
+                evidence.svg.font_size,
+                evidence.svg.fg,
+                evidence.svg.bg,
+            ),
+        )
+        self.assertEqual(
+            "ui-monospace,SFMono-Regular,Menlo,Consolas,monospace",
+            evidence.svg.font_family,
+        )
+        self.assertEqual((1, 18, None), (evidence.png.scale, evidence.png.padding, evidence.png.font_path))
+        self.assertEqual((60, None, "yuv420p"), (evidence.video.fps, evidence.video.fps_cap, evidence.video.pix_fmt))
+        # None means "omit the flag", which is what the pipeline did before.
+        self.assertEqual(
+            [None] * 8,
+            [
+                evidence.video.crf,
+                evidence.video.preset,
+                evidence.video.tune,
+                evidence.video.idle_time_limit,
+                evidence.video.last_frame_duration,
+                evidence.video.theme,
+                evidence.video.font_size,
+                evidence.video.font_family,
+            ],
+        )
+
+    def test_evidence_values_load_from_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text(
+                "evidence:\n"
+                "  svg:\n    char_width: 8\n    fg: '#ffffff'\n"
+                "  png:\n    scale: 2\n    font_path: /fonts/mono.ttf\n"
+                "  video:\n    pix_fmt: yuv444p\n    crf: 20\n",
+                encoding="utf-8",
+            )
+            config = load_config(project_path=Path(tmp), user_path=user_yaml)
+        self.assertEqual(8, config.evidence.svg.char_width)
+        self.assertEqual("#ffffff", config.evidence.svg.fg)
+        self.assertEqual(20, config.evidence.svg.line_height)  # untouched key keeps its default
+        self.assertEqual(2, config.evidence.png.scale)
+        self.assertEqual("/fonts/mono.ttf", config.evidence.png.font_path)
+        self.assertEqual("yuv444p", config.evidence.video.pix_fmt)
+        self.assertEqual(20, config.evidence.video.crf)
+
+    def test_project_evidence_config_wins_over_user(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp) / "project"
+            (project_dir / ".termproof").mkdir(parents=True)
+            (project_dir / ".termproof" / "config.yaml").write_text(
+                "evidence:\n  video:\n    crf: 18\n",
+                encoding="utf-8",
+            )
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text(
+                "evidence:\n  video:\n    crf: 30\n    preset: slow\n",
+                encoding="utf-8",
+            )
+            config = load_config(project_path=project_dir, user_path=user_yaml)
+        self.assertEqual(18, config.evidence.video.crf)  # project wins
+        self.assertEqual("slow", config.evidence.video.preset)  # user supplies, project doesn't
+        self.assertEqual("yuv420p", config.evidence.video.pix_fmt)  # builtin survives
+
+    def test_unknown_evidence_option_is_rejected(self) -> None:
+        """A misspelled rendering knob that silently does nothing is worse than an error."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text(
+                "evidence:\n  svg:\n    charwidth: 8\n", encoding="utf-8"
+            )
+            with self.assertRaises(ValueError):
+                load_config(project_path=Path(tmp), user_path=user_yaml)
+
+    def test_unknown_evidence_section_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text("evidence:\n  gif:\n    scale: 2\n", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_config(project_path=Path(tmp), user_path=user_yaml)
+
+
 class RegistryTest(unittest.TestCase):
     def test_register_and_get(self) -> None:
         registry: Registry[str] = Registry()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from dataclasses import fields
 from pathlib import Path
 
 from termproof.config import (
+    BUILTIN_DEFAULTS,
     DockerBackendConfig,
+    EvidenceConfig,
     VerifierConfig,
     load_config,
 )
@@ -244,7 +247,17 @@ class EvidenceConfigTest(unittest.TestCase):
             "ui-monospace,SFMono-Regular,Menlo,Consolas,monospace",
             evidence.svg.font_family,
         )
-        self.assertEqual((1, 18, None), (evidence.png.scale, evidence.png.padding, evidence.png.font_path))
+        self.assertEqual(
+            (1, 18, 14, None, "#e6edf3", "#101418"),
+            (
+                evidence.png.scale,
+                evidence.png.padding,
+                evidence.png.font_size,
+                evidence.png.font_path,
+                evidence.png.fg,
+                evidence.png.bg,
+            ),
+        )
         self.assertEqual((60, None, "yuv420p"), (evidence.video.fps, evidence.video.fps_cap, evidence.video.pix_fmt))
         # None means "omit the flag", which is what the pipeline did before.
         self.assertEqual(
@@ -260,6 +273,25 @@ class EvidenceConfigTest(unittest.TestCase):
                 evidence.video.font_family,
             ],
         )
+
+    def test_builtin_evidence_defaults_match_the_dataclass_defaults(self) -> None:
+        """The two are consumed independently, so drift between them is invisible.
+
+        A config-loaded run reads ``BUILTIN_DEFAULTS``; every ``EvidenceConfig()``
+        fallback in the renderers, the video pipeline and the run cache reads the
+        dataclass defaults. Comparing whole dataclasses covers each knob without
+        an assertion per field, and comparing the key sets catches a knob that
+        was added to only one of the two.
+        """
+        self.assertEqual(EvidenceConfig(), VerifierConfig.builtin().evidence)
+        builtin = BUILTIN_DEFAULTS["evidence"]
+        self.assertEqual({f.name for f in fields(EvidenceConfig)}, set(builtin))
+        for section in fields(EvidenceConfig):
+            with self.subTest(section=section.name):
+                declared = {
+                    f.name for f in fields(getattr(EvidenceConfig(), section.name))
+                }
+                self.assertEqual(declared, set(builtin[section.name]))
 
     def test_evidence_values_load_from_yaml(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -356,6 +388,58 @@ class EvidenceConfigTest(unittest.TestCase):
             user_yaml.write_text("evidence:\n  gif:\n    scale: 2\n", encoding="utf-8")
             with self.assertRaises(ValueError):
                 load_config(project_path=Path(tmp), user_path=user_yaml)
+
+    def test_out_of_range_size_or_rate_is_rejected_naming_the_offending_key(self) -> None:
+        """A zero fps dies inside ffmpeg, and a zero scale silently collapses the canvas."""
+        cases = {
+            "  video:\n    fps: 0\n": "evidence.video.fps",
+            "  video:\n    fps_cap: 0\n": "evidence.video.fps_cap",
+            "  png:\n    scale: 0\n": "evidence.png.scale",
+            "  png:\n    font_size: -1\n": "evidence.png.font_size",
+            "  png:\n    padding: -1\n": "evidence.png.padding",
+            "  svg:\n    char_width: 0\n": "evidence.svg.char_width",
+            "  svg:\n    line_height: 0\n": "evidence.svg.line_height",
+            "  svg:\n    font_size: 0\n": "evidence.svg.font_size",
+            "  svg:\n    padding: -1\n": "evidence.svg.padding",
+        }
+        for body, key in cases.items():
+            with self.subTest(key=key), tempfile.TemporaryDirectory() as tmp:
+                user_yaml = Path(tmp) / "user.yaml"
+                user_yaml.write_text(f"evidence:\n{body}", encoding="utf-8")
+                with self.assertRaises(ValueError) as caught:
+                    load_config(project_path=Path(tmp), user_path=user_yaml)
+                self.assertIn(key, str(caught.exception))
+
+    def test_zero_padding_and_null_optionals_still_load(self) -> None:
+        """Zero padding is a coherent choice, and an unset optional stays unset."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text(
+                "evidence:\n"
+                "  svg:\n    padding: 0\n"
+                "  png:\n    padding: 0\n"
+                "  video:\n    fps_cap: null\n",
+                encoding="utf-8",
+            )
+            config = load_config(project_path=Path(tmp), user_path=user_yaml)
+        self.assertEqual(0, config.evidence.svg.padding)
+        self.assertEqual(0, config.evidence.png.padding)
+        self.assertIsNone(config.evidence.video.fps_cap)
+
+    def test_non_mapping_evidence_section_is_rejected_naming_the_section(self) -> None:
+        """``dict()`` alone raises a TypeError that names neither the section nor the key."""
+        cases = {
+            "evidence:\n  svg: 8\n": "evidence.svg",
+            "evidence:\n  video: [fps]\n": "evidence.video",
+            "evidence:\n  - svg\n  - png\n": "evidence",
+        }
+        for body, label in cases.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                user_yaml = Path(tmp) / "user.yaml"
+                user_yaml.write_text(body, encoding="utf-8")
+                with self.assertRaises(ValueError) as caught:
+                    load_config(project_path=Path(tmp), user_path=user_yaml)
+                self.assertIn(f"{label} must be a mapping", str(caught.exception))
 
 
 class RegistryTest(unittest.TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -394,6 +394,8 @@ class EvidenceConfigTest(unittest.TestCase):
         cases = {
             "  video:\n    fps: 0\n": "evidence.video.fps",
             "  video:\n    fps_cap: 0\n": "evidence.video.fps_cap",
+            "  video:\n    font_size: 0\n": "evidence.video.font_size",
+            "  video:\n    font_size: -1\n": "evidence.video.font_size",
             "  png:\n    scale: 0\n": "evidence.png.scale",
             "  png:\n    font_size: -1\n": "evidence.png.font_size",
             "  png:\n    padding: -1\n": "evidence.png.padding",
@@ -418,13 +420,14 @@ class EvidenceConfigTest(unittest.TestCase):
                 "evidence:\n"
                 "  svg:\n    padding: 0\n"
                 "  png:\n    padding: 0\n"
-                "  video:\n    fps_cap: null\n",
+                "  video:\n    fps_cap: null\n    font_size: null\n",
                 encoding="utf-8",
             )
             config = load_config(project_path=Path(tmp), user_path=user_yaml)
         self.assertEqual(0, config.evidence.svg.padding)
         self.assertEqual(0, config.evidence.png.padding)
         self.assertIsNone(config.evidence.video.fps_cap)
+        self.assertIsNone(config.evidence.video.font_size)
 
     def test_non_mapping_evidence_section_is_rejected_naming_the_section(self) -> None:
         """``dict()`` alone raises a TypeError that names neither the section nor the key."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -308,6 +308,48 @@ class EvidenceConfigTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 load_config(project_path=Path(tmp), user_path=user_yaml)
 
+    def test_quoted_number_is_rejected_naming_the_offending_key(self) -> None:
+        """A YAML scalar of the wrong type must fail here, not inside a renderer."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text(
+                "evidence:\n  svg:\n    padding: '18'\n", encoding="utf-8"
+            )
+            with self.assertRaises(ValueError) as caught:
+                load_config(project_path=Path(tmp), user_path=user_yaml)
+        self.assertIn("evidence.svg.padding", str(caught.exception))
+        self.assertIn("int", str(caught.exception))
+
+    def test_wrong_type_is_rejected_for_each_evidence_section(self) -> None:
+        cases = {
+            "  png:\n    font_path: 3\n": "evidence.png.font_path",
+            "  video:\n    crf: fast\n": "evidence.video.crf",
+            "  svg:\n    font_family: 12\n": "evidence.svg.font_family",
+        }
+        for body, key in cases.items():
+            with self.subTest(key=key), tempfile.TemporaryDirectory() as tmp:
+                user_yaml = Path(tmp) / "user.yaml"
+                user_yaml.write_text(f"evidence:\n{body}", encoding="utf-8")
+                with self.assertRaises(ValueError) as caught:
+                    load_config(project_path=Path(tmp), user_path=user_yaml)
+                self.assertIn(key, str(caught.exception))
+
+    def test_optional_and_widening_values_still_load(self) -> None:
+        """Validation must not reject values that loaded fine before it existed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            user_yaml = Path(tmp) / "user.yaml"
+            user_yaml.write_text(
+                "evidence:\n"
+                "  png:\n    font_path: null\n"
+                # A float field written as a YAML integer is still a valid float.
+                "  video:\n    idle_time_limit: 2\n    theme: asciinema\n",
+                encoding="utf-8",
+            )
+            config = load_config(project_path=Path(tmp), user_path=user_yaml)
+        self.assertIsNone(config.evidence.png.font_path)
+        self.assertEqual(2, config.evidence.video.idle_time_limit)
+        self.assertEqual("asciinema", config.evidence.video.theme)
+
     def test_unknown_evidence_section_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             user_yaml = Path(tmp) / "user.yaml"

--- a/tests/test_evidence_config.py
+++ b/tests/test_evidence_config.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from PIL import Image, ImageDraw, ImageFont
+
+from termproof import evidence
+from termproof.builtin_renderers import PngRenderer, SvgRenderer
+from termproof.builtin_video import AggFfmpegBackend
+from termproof.config import (
+    EvidenceConfig,
+    PngRenderConfig,
+    SvgRenderConfig,
+    VerifierConfig,
+    VideoConfig,
+)
+from termproof.models import StepResult
+from termproof.screen import render_svg, replay_cast
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS = ROOT / "examples" / "artifacts"
+
+
+def _builtin_evidence() -> EvidenceConfig:
+    return VerifierConfig.builtin().evidence
+
+
+class CorpusByteIdentityTest(unittest.TestCase):
+    """The acceptance gate for making the rendering parameters configurable.
+
+    Every screenshot checked in under ``examples/artifacts/`` was produced by
+    the pre-configuration renderers. Replaying each recorded cast and
+    re-rendering it with no configuration present must reproduce those files
+    byte for byte, or the extracted defaults have drifted from the literals
+    they replaced and the checked-in corpus would need regenerating.
+    """
+
+    def _rendered_pairs(self) -> list[tuple[str, int, int, Path]]:
+        pairs: list[tuple[str, int, int, Path]] = []
+        for cast_path in sorted(ARTIFACTS.rglob("session.cast")):
+            run_dir = cast_path.parent
+            final_svg = run_dir / "final.svg"
+            if not final_svg.exists():
+                continue
+            text, cols, rows = replay_cast(cast_path)
+            pairs.append((text, cols, rows, final_svg))
+            for step_txt in sorted((run_dir / "steps").glob("*.txt")):
+                step_svg = step_txt.with_suffix(".svg")
+                if step_svg.exists():
+                    screen = step_txt.read_text(encoding="utf-8").removesuffix("\n")
+                    pairs.append((screen, cols, rows, step_svg))
+        return pairs
+
+    def test_corpus_is_present(self) -> None:
+        """Guard the guard: an empty corpus would make the gate vacuous."""
+        self.assertGreater(len(self._rendered_pairs()), 100)
+
+    def test_default_svg_renderer_reproduces_example_corpus_byte_for_byte(self) -> None:
+        renderer = SvgRenderer.from_config(_builtin_evidence())
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "candidate.svg"
+            for text, cols, rows, expected in self._rendered_pairs():
+                renderer.render(text, output, cols, rows)
+                self.assertEqual(
+                    expected.read_bytes(),
+                    output.read_bytes(),
+                    f"default config no longer reproduces {expected.relative_to(ROOT)}",
+                )
+
+    def test_screen_render_svg_matches_the_renderer_it_duplicates(self) -> None:
+        """``screen.render_svg`` is a duplicate; the two must not diverge."""
+        renderer = SvgRenderer.from_config(_builtin_evidence())
+        with tempfile.TemporaryDirectory() as tmp:
+            from_function = Path(tmp) / "function.svg"
+            from_renderer = Path(tmp) / "renderer.svg"
+            for text, cols, rows, _ in self._rendered_pairs()[:20]:
+                render_svg(text, from_function, cols, rows)
+                renderer.render(text, from_renderer, cols, rows)
+                self.assertEqual(from_function.read_bytes(), from_renderer.read_bytes())
+
+
+class PngDefaultsTest(unittest.TestCase):
+    def _legacy_png(self, text: str, output_path: Path, cols: int, rows: int) -> None:
+        """The PNG renderer exactly as it was before the parameters moved to config."""
+        font = ImageFont.load_default()
+        bbox = font.getbbox("M")
+        char_width = max(9, bbox[2] - bbox[0])
+        line_height = max(18, bbox[3] - bbox[1] + 6)
+        padding = 18
+        width = max(320, cols * char_width + padding * 2)
+        height = max(160, rows * line_height + padding * 2)
+        image = Image.new("RGB", (int(width), int(height)), "#101418")
+        draw = ImageDraw.Draw(image)
+        for index, line in enumerate(text.splitlines()[:rows] or [""]):
+            y = padding + line_height * index
+            draw.text((padding, y), line[:cols], font=font, fill="#e6edf3")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        image.save(output_path, format="PNG")
+
+    def test_default_png_renderer_is_byte_identical_to_the_previous_literals(self) -> None:
+        text = "hello png\nsecond line with a much longer body of text\n\ttab"
+        with tempfile.TemporaryDirectory() as tmp:
+            legacy = Path(tmp) / "legacy.png"
+            current = Path(tmp) / "current.png"
+            self._legacy_png(text, legacy, 80, 24)
+            PngRenderer.from_config(_builtin_evidence()).render(text, current, 80, 24)
+            self.assertEqual(legacy.read_bytes(), current.read_bytes())
+
+    def test_font_path_loads_a_truetype_face_at_the_scaled_size(self) -> None:
+        config = PngRenderConfig(font_path="/fonts/mono.ttf", font_size=10, scale=2)
+        with mock.patch.object(
+            ImageFont, "truetype", return_value=ImageFont.load_default()
+        ) as truetype:
+            with tempfile.TemporaryDirectory() as tmp:
+                output = Path(tmp) / "ttf.png"
+                PngRenderer(config).render("hello", output, 80, 24)
+                self.assertTrue(output.exists())
+        truetype.assert_called_once_with("/fonts/mono.ttf", 20)
+
+    def test_missing_font_path_surfaces_instead_of_silently_falling_back(self) -> None:
+        config = PngRenderConfig(font_path="/no/such/font.ttf")
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(OSError):
+                PngRenderer(config).render("hello", Path(tmp) / "x.png", 80, 24)
+
+    def test_scale_enlarges_the_canvas(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            single = Path(tmp) / "1x.png"
+            double = Path(tmp) / "2x.png"
+            PngRenderer().render("hello", single, 80, 24)
+            PngRenderer(PngRenderConfig(scale=2)).render("hello", double, 80, 24)
+            with Image.open(single) as small, Image.open(double) as large:
+                self.assertEqual(
+                    (small.width * 2, small.height * 2), large.size
+                )
+
+    def test_colours_reach_the_image(self) -> None:
+        config = PngRenderConfig(bg="#ff0000")
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "red.png"
+            PngRenderer(config).render("", output, 80, 24)
+            with Image.open(output) as image:
+                self.assertEqual((255, 0, 0), image.convert("RGB").getpixel((0, 0)))
+
+
+class VideoCommandTest(unittest.TestCase):
+    def _commands(self, config: VideoConfig | None, fps: int = 60) -> list[list[str]]:
+        with mock.patch.object(evidence, "resolve_agg", return_value="/bin/agg"), \
+             mock.patch.object(evidence, "find_ffmpeg", return_value="/bin/ffmpeg"), \
+             mock.patch.object(evidence.subprocess, "run") as run:
+            evidence.render_mp4(Path("in.cast"), Path("out.mp4"), fps, config)
+        return [call.args[0] for call in run.call_args_list]
+
+    def test_default_config_builds_the_previous_command_lines(self) -> None:
+        agg_cmd, ffmpeg_cmd = self._commands(_builtin_evidence().video)
+        self.assertEqual(
+            ["/bin/agg", "--quiet", "--fps-cap", "60", "in.cast", "out.agg.gif"],
+            agg_cmd,
+        )
+        self.assertEqual(
+            [
+                "/bin/ffmpeg", "-y", "-loglevel", "error", "-i", "out.agg.gif",
+                "-vf", "fps=60,scale=trunc(iw/2)*2:trunc(ih/2)*2",
+                "-pix_fmt", "yuv420p", "-movflags", "+faststart", "out.mp4",
+            ],
+            ffmpeg_cmd,
+        )
+
+    def test_fps_cap_defaults_to_the_effective_fps(self) -> None:
+        agg_cmd, _ = self._commands(VideoConfig(), fps=24)
+        self.assertEqual(["--fps-cap", "24"], agg_cmd[2:4])
+
+    def test_configured_flags_are_appended_in_order(self) -> None:
+        config = VideoConfig(
+            fps_cap=24,
+            pix_fmt="yuv444p",
+            crf=20,
+            preset="slow",
+            tune="stillimage",
+            idle_time_limit=0.5,
+            last_frame_duration=1.5,
+            theme="asciinema",
+            font_size=16,
+            font_family="DejaVu Sans Mono",
+        )
+        agg_cmd, ffmpeg_cmd = self._commands(config)
+        self.assertEqual(
+            [
+                "/bin/agg", "--quiet", "--fps-cap", "24",
+                "--idle-time-limit", "0.5", "--last-frame-duration", "1.5",
+                "--theme", "asciinema", "--font-size", "16",
+                "--font-family", "DejaVu Sans Mono",
+                "in.cast", "out.agg.gif",
+            ],
+            agg_cmd,
+        )
+        self.assertEqual(
+            ["-pix_fmt", "yuv444p", "-crf", "20", "-preset", "slow", "-tune", "stillimage"],
+            ffmpeg_cmd[8:16],
+        )
+
+    def test_backend_forwards_its_configured_video_settings(self) -> None:
+        backend = AggFfmpegBackend.from_config(
+            EvidenceConfig(video=VideoConfig(pix_fmt="yuv444p"))
+        )
+        with mock.patch.object(evidence, "render_mp4") as render_mp4:
+            backend.render(Path("in.cast"), Path("out.mp4"), 30)
+        render_mp4.assert_called_once_with(
+            Path("in.cast"), Path("out.mp4"), 30, backend.config
+        )
+
+
+class StepScreenScopeTest(unittest.TestCase):
+    """The step-screen path must honour the same configuration as the final one."""
+
+    STEPS = [
+        StepResult("wait for prompt", True, "", "screen one"),
+        StepResult("apply change", True, "", "screen two"),
+    ]
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_step_screens_use_the_configured_svg_settings(self) -> None:
+        run_dir = Path(self._tmp.name)
+        config = EvidenceConfig(svg=SvgRenderConfig(bg="#ff0000"))
+        evidence._render_step_screens(run_dir, self.STEPS, 80, 24, None, "svg", config)
+        written = sorted((run_dir / "steps").glob("*.svg"))
+        self.assertEqual(2, len(written))
+        for path in written:
+            self.assertIn("#ff0000", path.read_text(encoding="utf-8"))
+
+    def test_render_artifacts_threads_config_to_final_and_step_screens(self) -> None:
+        run_dir = Path(self._tmp.name) / "run"
+        run_dir.mkdir()
+        (run_dir / "session.cast").write_text(
+            json.dumps({"version": 2, "width": 80, "height": 24}) + "\n",
+            encoding="utf-8",
+        )
+        evidence.render_artifacts(
+            run_dir,
+            render_video=False,
+            steps=list(self.STEPS),
+            evidence_config=EvidenceConfig(svg=SvgRenderConfig(bg="#ff0000")),
+        )
+        rendered = [run_dir / "final.svg", *sorted((run_dir / "steps").glob("*.svg"))]
+        self.assertEqual(3, len(rendered))
+        for path in rendered:
+            self.assertIn("#ff0000", path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -13,12 +13,16 @@ class ProtocolApiTests(unittest.TestCase):
             [
                 "AgentRunner",
                 "AssertionType",
+                "EvidenceConfig",
                 "ExecutionMode",
+                "PngRenderConfig",
                 "Reporter",
                 "ScreenRenderer",
                 "SessionBackend",
                 "StepAction",
+                "SvgRenderConfig",
                 "VideoBackend",
+                "VideoConfig",
             ],
             protocols.__all__,
         )

--- a/tests/test_run_cache.py
+++ b/tests/test_run_cache.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from termproof.config import EvidenceConfig, SvgRenderConfig, VideoConfig
 from termproof.models import RunResult, load_recipe
 from termproof.run_cache import load_cached_result, store_cached_result
 
@@ -128,6 +129,76 @@ class RunCacheTest(unittest.TestCase):
             )
 
             self.assertIsNone(cached)
+
+
+class EvidenceConfigCacheKeyTest(unittest.TestCase):
+    """A rendering knob changes the artifacts, so it must invalidate the cache.
+
+    Otherwise ``--skip-unchanged`` replays a stored pass whose screenshots were
+    rendered with the old settings, and the new configuration silently does
+    nothing.
+    """
+
+    def _roundtrip(
+        self,
+        stored: EvidenceConfig,
+        loaded: EvidenceConfig,
+        *,
+        render_video: bool = False,
+    ) -> RunResult | None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            recipe = load_recipe(_write_recipe(root, "cached"))
+            screenshot = root / "run" / "final.svg"
+            screenshot.parent.mkdir()
+            screenshot.write_text("<svg/>\n", encoding="utf-8")
+
+            common = dict(
+                out_dir=root / "runs",
+                screen_renderer="svg",
+                video_backend="agg_ffmpeg",
+                render_video=render_video,
+                video_fps=60,
+            )
+            store_cached_result(
+                root / "cache",
+                recipe,
+                "default",
+                [],
+                _result("cached", screenshot),
+                evidence=stored,
+                **common,
+            )
+            return load_cached_result(
+                root / "cache",
+                recipe,
+                "default",
+                [],
+                evidence=loaded,
+                **common,
+            )
+
+    def test_unchanged_evidence_config_still_hits_the_cache(self) -> None:
+        self.assertIsNotNone(
+            self._roundtrip(EvidenceConfig(), EvidenceConfig())
+        )
+
+    def test_changed_screenshot_colour_invalidates_the_cache(self) -> None:
+        self.assertIsNone(
+            self._roundtrip(
+                EvidenceConfig(),
+                EvidenceConfig(svg=SvgRenderConfig(fg="#ff0000")),
+            )
+        )
+
+    def test_changed_video_setting_invalidates_the_cache(self) -> None:
+        self.assertIsNone(
+            self._roundtrip(
+                EvidenceConfig(),
+                EvidenceConfig(video=VideoConfig(crf=20)),
+                render_video=True,
+            )
+        )
 
 
 def _write_recipe(root: Path, name: str, ci_paths: list[str] | None = None) -> Path:

--- a/tests/test_run_cache.py
+++ b/tests/test_run_cache.py
@@ -4,7 +4,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from termproof.config import EvidenceConfig, SvgRenderConfig, VideoConfig
+from termproof.config import (
+    EvidenceConfig,
+    PngRenderConfig,
+    SvgRenderConfig,
+    VideoConfig,
+)
 from termproof.models import RunResult, load_recipe
 from termproof.run_cache import load_cached_result, store_cached_result
 
@@ -184,12 +189,26 @@ class EvidenceConfigCacheKeyTest(unittest.TestCase):
         )
 
     def test_changed_screenshot_colour_invalidates_the_cache(self) -> None:
-        self.assertIsNone(
-            self._roundtrip(
-                EvidenceConfig(),
-                EvidenceConfig(svg=SvgRenderConfig(fg="#ff0000")),
-            )
-        )
+        for render_video in (False, True):
+            with self.subTest(render_video=render_video):
+                self.assertIsNone(
+                    self._roundtrip(
+                        EvidenceConfig(),
+                        EvidenceConfig(svg=SvgRenderConfig(fg="#ff0000")),
+                        render_video=render_video,
+                    )
+                )
+
+    def test_changed_screenshot_scale_invalidates_the_cache(self) -> None:
+        for render_video in (False, True):
+            with self.subTest(render_video=render_video):
+                self.assertIsNone(
+                    self._roundtrip(
+                        EvidenceConfig(),
+                        EvidenceConfig(png=PngRenderConfig(scale=2)),
+                        render_video=render_video,
+                    )
+                )
 
     def test_changed_video_setting_invalidates_the_cache(self) -> None:
         self.assertIsNone(
@@ -197,6 +216,21 @@ class EvidenceConfigCacheKeyTest(unittest.TestCase):
                 EvidenceConfig(),
                 EvidenceConfig(video=VideoConfig(crf=20)),
                 render_video=True,
+            )
+        )
+
+    def test_changed_video_setting_still_hits_the_cache_without_video(self) -> None:
+        """A run that renders no video cannot produce a different artifact for it.
+
+        ``video_backend`` and ``video_fps`` are already excluded from the key for
+        exactly this reason, so the video knobs must drop out with them rather
+        than busting every screenshot-only cache entry.
+        """
+        self.assertIsNotNone(
+            self._roundtrip(
+                EvidenceConfig(),
+                EvidenceConfig(video=VideoConfig(crf=20, fps=30)),
+                render_video=False,
             )
         )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import sys
 import tempfile
+import types
 import unittest
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
+from PIL import Image
+
+from termproof import evidence as evidence_module
 from termproof import runner as runner_module
-from termproof.config import VerifierConfig, load_config
+from termproof.config import EvidenceConfig, VerifierConfig, load_config
 from termproof.models import CommandSpec, Recipe
 from termproof.runner import VerificationRunner
 
@@ -514,3 +518,131 @@ class QuiescenceBehaviorTest(unittest.TestCase):
                 self.assertTrue(session.wait_for_idle(0.3, 2.0))
         finally:
             session.close()
+
+
+class ConfigAwareRenderer:
+    """A plugin that opts into the evidence config via ``from_config``."""
+
+    name = "config_aware"
+    extension = "svg"
+
+    def __init__(self, evidence: EvidenceConfig) -> None:
+        self.evidence = evidence
+
+    @classmethod
+    def from_config(cls, evidence: EvidenceConfig) -> ConfigAwareRenderer:
+        return cls(evidence)
+
+    def render(self, text: str, output_path: Path, cols: int, rows: int) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(self.evidence.svg.bg, encoding="utf-8")
+
+
+class BareRenderer:
+    """A third-party plugin written against the bare protocol, with no hook."""
+
+    name = "bare"
+    extension = "svg"
+
+    def render(self, text: str, output_path: Path, cols: int, rows: int) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(text, encoding="utf-8")
+
+
+class EvidencePluginConstructionTest(unittest.TestCase):
+    """The registries are the only path by which ``evidence`` reaches a plugin.
+
+    A renderer or video backend a run actually uses comes from
+    ``runner.screen_renderer_registry`` / ``runner.video_backend_registry``, so
+    a configured knob that never reaches those instances is a knob that does
+    nothing. The opt-in hook has two halves worth pinning: a plugin exposing
+    ``from_config`` receives the loaded configuration, and one written against
+    the bare protocol is still constructed with no arguments.
+    """
+
+    @staticmethod
+    def _with_evidence(**sections: object) -> VerifierConfig:
+        config = VerifierConfig.builtin()
+        return replace(config, evidence=replace(config.evidence, **sections))
+
+    def _install_plugin_module(self, **members: type) -> str:
+        module = types.ModuleType("termproof_evidence_plugin_fixture")
+        for name, member in members.items():
+            setattr(module, name, member)
+        sys.modules[module.__name__] = module
+        self.addCleanup(sys.modules.pop, module.__name__, None)
+        return module.__name__
+
+    def test_configured_svg_colour_reaches_the_renderer_a_run_uses(self) -> None:
+        config = VerifierConfig.builtin()
+        runner = VerificationRunner(
+            config=self._with_evidence(svg=replace(config.evidence.svg, bg="#ff0000"))
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "final.svg"
+            runner.screen_renderer_registry.get("svg").render("hello", output, 80, 24)
+            svg = output.read_text(encoding="utf-8")
+        self.assertIn('fill="#ff0000"', svg)
+        self.assertNotIn("#101418", svg)
+
+    def test_configured_png_colour_reaches_the_renderer_a_run_uses(self) -> None:
+        config = VerifierConfig.builtin()
+        runner = VerificationRunner(
+            config=self._with_evidence(png=replace(config.evidence.png, bg="#00ff00"))
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "final.png"
+            runner.screen_renderer_registry.get("png").render("hello", output, 20, 4)
+            with Image.open(output) as image:
+                corner = image.convert("RGB").getpixel((0, 0))
+        self.assertEqual((0, 255, 0), corner)
+
+    def test_configured_video_setting_reaches_the_backend_a_run_uses(self) -> None:
+        config = VerifierConfig.builtin()
+        runner = VerificationRunner(
+            config=self._with_evidence(
+                video=replace(config.evidence.video, pix_fmt="yuv444p")
+            )
+        )
+        backend = runner.video_backend_registry.get("agg_ffmpeg")
+        with tempfile.TemporaryDirectory() as tmp, \
+                patch.object(evidence_module, "resolve_agg", return_value="/bin/agg"), \
+                patch.object(evidence_module, "find_ffmpeg", return_value="/bin/ffmpeg"), \
+                patch.object(evidence_module.subprocess, "run") as run:
+            backend.render(Path(tmp) / "in.cast", Path(tmp) / "out.mp4", 60)
+        ffmpeg_cmd = run.call_args_list[-1].args[0]
+        self.assertEqual("yuv444p", ffmpeg_cmd[ffmpeg_cmd.index("-pix_fmt") + 1])
+
+    def test_plugin_with_from_config_receives_the_loaded_evidence_config(self) -> None:
+        module = self._install_plugin_module(ConfigAwareRenderer=ConfigAwareRenderer)
+        config = VerifierConfig.builtin()
+        config = self._with_evidence(svg=replace(config.evidence.svg, bg="#123456"))
+        config = replace(
+            config,
+            screen_renderers={
+                **config.screen_renderers,
+                "config_aware": f"{module}:ConfigAwareRenderer",
+            },
+        )
+        renderer = VerificationRunner(config=config).screen_renderer_registry.get(
+            "config_aware"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "plugin.svg"
+            renderer.render("hello", output, 80, 24)
+            self.assertEqual("#123456", output.read_text(encoding="utf-8"))
+
+    def test_plugin_without_from_config_is_still_constructed_with_no_arguments(self) -> None:
+        """The opt-in hook is what keeps plugins written against the bare protocol working."""
+        module = self._install_plugin_module(BareRenderer=BareRenderer)
+        config = VerifierConfig.builtin()
+        config = replace(
+            config,
+            screen_renderers={**config.screen_renderers, "bare": f"{module}:BareRenderer"},
+        )
+        renderer = VerificationRunner(config=config).screen_renderer_registry.get("bare")
+        self.assertIsInstance(renderer, BareRenderer)
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "plugin.svg"
+            renderer.render("hello", output, 80, 24)
+            self.assertEqual("hello", output.read_text(encoding="utf-8"))

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
+from termproof import runner as runner_module
 from termproof.config import VerifierConfig, load_config
 from termproof.models import CommandSpec, Recipe
 from termproof.runner import VerificationRunner
@@ -208,6 +210,55 @@ class RunnerTest(unittest.TestCase):
             message = str(caught.warning)
             self.assertIn("agg", message)
             self.assertIn("--video", message)
+
+
+class VideoFpsWiringTest(unittest.TestCase):
+    """``evidence.video.fps`` must be honoured on the library path too.
+
+    The CLI entry points resolve it themselves; a caller going straight through
+    ``VerificationRunner.run`` used to get the literal 60 regardless.
+    """
+
+    RECIPE = Recipe(
+        name="fps",
+        command=CommandSpec(argv=[sys.executable, "-c", "print('ok')"], pty=False),
+        steps=[{"action": "wait_for_text", "text": "ok"}],
+    )
+
+    def _rendered_fps(self, config: VerifierConfig, **run_kwargs: object) -> int:
+        seen: list[int] = []
+        real = runner_module.render_artifacts
+
+        def spy(run_dir, render_video, video_fps, **kwargs):  # type: ignore[no-untyped-def]
+            seen.append(video_fps)
+            return real(run_dir, render_video, video_fps, **kwargs)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(runner_module, "render_artifacts", spy):
+                VerificationRunner(config=config).run(
+                    self.RECIPE, Path(tmp), render_video=False, **run_kwargs
+                )
+        self.assertEqual(1, len(seen))
+        return seen[0]
+
+    @staticmethod
+    def _with_fps(fps: int) -> VerifierConfig:
+        config = VerifierConfig.builtin()
+        return replace(
+            config,
+            evidence=replace(
+                config.evidence, video=replace(config.evidence.video, fps=fps)
+            ),
+        )
+
+    def test_unconfigured_run_still_renders_at_sixty(self) -> None:
+        self.assertEqual(60, self._rendered_fps(VerifierConfig.builtin()))
+
+    def test_configured_fps_reaches_the_renderer(self) -> None:
+        self.assertEqual(24, self._rendered_fps(self._with_fps(24)))
+
+    def test_explicit_argument_beats_the_configured_fps(self) -> None:
+        self.assertEqual(30, self._rendered_fps(self._with_fps(24), video_fps=30))
 
 
 class IdleCapWiringTest(unittest.TestCase):


### PR DESCRIPTION
## Intent

Make TermProof's evidence-rendering parameters configurable, with no observable behaviour change. Every screenshot and video knob was a literal buried in the renderers (SVG cell metrics/colours in two places, PNG padding/colours in a third, the ffmpeg pix_fmt and agg flags in a fourth), so the question of whether the defaults are any good was not even expressible. This change moves them into the project's existing cascading YAML config under a new 'evidence:' section (evidence.svg / evidence.png / evidence.video), deliberately reusing that mechanism rather than inventing a second one.

IMPORTANT CONTEXT ON THIS BRANCH: this exact content already passed a full local no-mistakes run (01KZM08W1FTRNJRP398QREV733, outcome passed) with push/pr/ci skipped, because the user was holding the push until a prerequisite PR merged. That prerequisite (#156, the colour-stress fixture) has merged, and the branch was rebased onto the updated default branch with no conflicts. The rebase left the earlier run's gate ref on the old branch name diverged and unpushable, so on the user's explicit instruction this identical content now lives on the fresh branch fm/evidence-config-k2b. Nothing was ever published from the old branch: no remote branch, no PR. The two later commits here are the earlier run's own gate-fix commits, rebased, and must be preserved. Full suite is green (412 tests) and ruff is clean on this base. Re-review is welcome, but the findings below were already raised, decided by the user, and fixed.

Deliberate decisions the user made and that should NOT be flagged as mistakes:
- No default changes at all. The acceptance criterion is that with no configuration present the full example corpus produces byte-identical artifacts. tests/test_evidence_config.py proves it by replaying every session.cast under examples/artifacts/ and comparing re-rendered SVGs byte-for-byte against the checked-in ones (146 artifacts). The checked-in corpus is the contract; it must NOT be regenerated.
- BUILTIN_DEFAULTS intentionally mirrors the dataclass defaults even though that is duplication. A self-documenting list of every knob in one place was judged worth its ~37 lines. Do not propose collapsing it.
- termproof/screen.py:render_svg is a known, deliberate duplicate of builtin_renderers.SvgRenderer, so the parameterisation is applied TWICE on purpose. render_svg is public API imported by tests/test_screen.py, so deleting it is an API removal and a structural change that does not belong in a diff claiming no behaviour change; removing it is scheduled as a separate change. A test pins the two byte-for-byte meanwhile. Do not propose deleting or unifying them here.
- Config reaches plugin instances through an optional from_config(cls, evidence) classmethod honoured by runner._construct_evidence_plugin, rather than changing the renderer/video-backend protocols. Registries construct plugins with zero-arg factories, and this opt-in hook keeps third-party plugins written against the bare protocols working untouched.
- Unknown keys under evidence: raise rather than being ignored, on purpose: a misspelled rendering knob that silently does nothing is indistinguishable from one that had no effect. Per-field type coercion was added for the same reason, so a bad value fails at config-load naming the key instead of as a TypeError inside max() during rendering.
- PngRenderConfig.scale multiplies the canvas, padding and line pitch but not the glyphs of PIL's default bitmap face. The user decided this is documented, not changed: there is a comment on the field saying it only yields a higher-DPI screenshot when font_path is also set. Making scale upscale bitmap glyphs would alter PNG output and is explicitly forbidden in this diff. test_scale_enlarges_the_canvas pins the intended canvas-only behaviour and must stay.
- PngRenderConfig.font_size is the one knob beyond the originally required list. ImageFont.truetype needs a size and it is inert unless font_path is set. Reviewed and approved.
- fps_cap defaults to None meaning 'follow the effective fps' to preserve today's coupling when --video-fps is passed; crf/preset/tune default to None meaning 'omit the flag' so the default command line is exactly the pre-change one. VerificationRunner.run resolves video_fps from config when the caller passes none, so the knob is honoured on the library path and not only at the CLI entry points; an explicit --video-fps still wins.
- The --skip-unchanged run-cache fingerprint now includes the evidence section, so changing a rendering knob invalidates cached runs.

Explicitly OUT OF SCOPE, do not add or request:
- The real underlying defect is that screen.py flattens pyte's buffer to plain text, discarding all colour and attributes before any renderer runs. Fixing that needs an additive renderer-interface change and is a separate change. Do not implement the attributed-grid path here, and do not add knobs today's code cannot honour.
- Step-screenshot deduplication, steps-manifest.json, docs/evidence-quality.md and the evidence contact sheets are the next change in this series. This change deliberately does not contain them.

Known pre-existing issues in this environment, not caused by this diff: mypy fails on a numpy stub syntax error; SdistRustIsolationTest.setUpClass can fail because cargo test --workspace exits 101 when cli_baseline is SIGKILLed by the sandbox; and tests/test_runner.py::QuiescenceBehaviorTest::test_wait_for_idle_times_out_when_output_never_stable is timing-sensitive and flaked once under parallel load in the prior run, passing 4/4 in isolation. All reproduce on the base commit.

## What Changed

- Added an `evidence:` section (`svg` / `png` / `video`) to the cascading YAML config, backed by new frozen `EvidenceConfig`, `SvgRenderConfig`, `PngRenderConfig`, and `VideoConfig` dataclasses exported from `termproof` and `termproof.protocols`. Loading validates per-field types, ranges, and section shape, and rejects unknown keys with a `ValueError` naming the offending option. Every default reproduces the previously hardcoded value, so an unconfigured run renders byte-identical artifacts.
- Replaced the literals in `SvgRenderer`, `PngRenderer`, `screen.render_svg`, and the agg/ffmpeg pipeline with these config values; `render_mp4` now takes a `VideoConfig` and omits `--idle-time-limit`, `--last-frame-duration`, `--theme`, `--font-size`, `--font-family`, `-crf`, `-preset`, and `-tune` when their values are `None`, keeping the default command line unchanged.
- Wired config through the runner: renderer and video-backend registries construct plugins via an optional `from_config` classmethod (plugins without it are still built with no arguments), `VerificationRunner.run` and `--video-fps` fall back to `evidence.video.fps`, and the `--skip-unchanged` cache key now includes the evidence sections (video knobs only when video is rendered). README and `docs/plugin-protocols.md` document the block and the hook; new tests cover config parsing/validation, plugin construction, the cache key, and byte-for-byte re-rendering of the checked-in example artifacts.

## Risk Assessment

✅ Low: Purely additive, default-preserving configuration extraction whose no-behaviour-change claim is pinned by a 146-artifact byte-identity corpus test, a legacy-PNG characterization test, exact agg/ffmpeg command-line assertions, and reflective builtin-vs-dataclass default parity; all three fix-round commits were independently verified correct against the current code, and the only remaining note is a non-reachable layering nit.

## Testing

Ran the targeted unit modules for this change (evidence config, config loading, protocol exports, run cache, runner, CLI, screen) — all pass; the only failure encountered was an environment one, the bundled asciinema not being on PATH, which I fixed by prepending .venv/bin before re-running. On top of that I exercised the real `termproof run` CLI in nine configurations and captured reviewer-visible artifacts: rasterized SVG screenshots, real PNG screenshots, extracted MP4 frames and ffmpeg stream probes showing default-vs-configured output side by side, plus transcripts proving byte-identical artifacts with no config (146/146 corpus screenshots and every artifact of a live run), --video-fps precedence over evidence.video.fps, --skip-unchanged cache invalidation when a single rendering knob changes, and key-naming config-load errors for misspelled/mistyped/out-of-range values. No product defects surfaced and the worktree was left clean.

- Evidence: SVG renderer: no config vs configured evidence.svg (rendered side by side) (local file: <code>/var/folders/00/dn1zh_wx3ys5gq4f1dtgpp8h0000gn/T/no-mistakes-evidence/01KZM33Z6BGQRGTGGD76ETZEYF/screenshots/compare-svg-default-vs-configured.png</code>)
- Evidence: PNG renderer: no config (936x468) vs evidence.png scale 2 + TrueType + colours (2820x1008) (local file: <code>/var/folders/00/dn1zh_wx3ys5gq4f1dtgpp8h0000gn/T/no-mistakes-evidence/01KZM33Z6BGQRGTGGD76ETZEYF/screenshots/compare-png-default-vs-configured.png</code>)
- Evidence: session.mp4 frames: default vs evidence.video theme/font_size/fps/pix_fmt (local file: <code>/var/folders/00/dn1zh_wx3ys5gq4f1dtgpp8h0000gn/T/no-mistakes-evidence/01KZM33Z6BGQRGTGGD76ETZEYF/screenshots/compare-video-default-vs-tuned.png</code>)
<details>
<summary>Evidence: ffmpeg stream probe of the three rendered videos</summary>

<code>## 1. no evidence config (expected: unchanged pre-change output - yuv420p, 60 fps)&#10;Stream #0:0: Video: h264 (High), yuv420p(progressive), 982x560, 60 fps&#10;&#10;## 2. evidence.video: fps 24, pix_fmt yuv444p, crf 40, preset ultrafast, tune zerolatency, theme solarized-light, font_size 20, idle_time_limit 0.5&#10;Stream #0:0: Video: h264 (High 4:4:4 Predictive), yuv444p(progressive), 1228x700, 24 fps&#10;&#10;## 3. same config plus an explicit --video-fps 12 (expected: the flag wins over evidence.video.fps)&#10;Stream #0:0: Video: h264 (High 4:4:4 Predictive), yuv444p(progressive), 1228x700, 12 fps</code>

```text
# termproof run ... --video, three configurations, real agg+ffmpeg pipeline

## 1. no evidence config  (expected: unchanged pre-change output — yuv420p, 60 fps)
  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 982x560, 66 kb/s, 60 fps, 60 tbr, 15360 tbn (default)

## 2. evidence.video: fps 24, pix_fmt yuv444p, crf 40, preset ultrafast, tune zerolatency, theme solarized-light, font_size 20, idle_time_limit 0.5
  Stream #0:0[0x1](und): Video: h264 (High 4:4:4 Predictive) (avc1 / 0x31637661), yuv444p(progressive), 1228x700, 69 kb/s, 24 fps, 24 tbr, 12288 tbn (default)
   (H.264 profile switches to High 4:4:4 Predictive, canvas grows with agg --font-size 20)

## 3. same config plus an explicit --video-fps 12  (expected: the flag wins over evidence.video.fps)
  Stream #0:0[0x1](und): Video: h264 (High 4:4:4 Predictive) (avc1 / 0x31637661), yuv444p(progressive), 1228x700, 59 kb/s, 12 fps, 12 tbr, 12288 tbn (default)
```
</details>
<details>
<summary>Evidence: Byte-identity of a live CLI run with no config vs one restating the defaults</summary>

<code>$ shasum -a256 A/final.svg B/final.svg C/final.svg&#10;096d26f7... A/final.svg (no --config)&#10;096d26f7... B/final.svg (evidence.svg restating every default)&#10;4d923653... C/final.svg (evidence.svg retuned)&#10;&#10;per-step screenshots: 01..09 A==B: yes (all) A==C: no (all)</code>

```text
# Same recipe, three runs of the real CLI.
# A: no --config at all           B: evidence.svg restating every default           C: evidence.svg retuned

$ shasum -a256 A/final.svg B/final.svg C/final.svg
096d26f78b21fcda66f892f5d2a25cd08710b4338ca10020555eacb53c16c311  A/final.svg
096d26f78b21fcda66f892f5d2a25cd08710b4338ca10020555eacb53c16c311  B/final.svg
4d9236530eef124ab847ff3c076f32510a52964d7261255ea6dc38ee686da95a  C/final.svg

$ diff -r --brief A B   # every artifact, final + per-step screenshots
  (no screenshot differences reported above => A and B are byte-identical)

$ head -3 A/final.svg
<svg xmlns="http://www.w3.org/2000/svg" width="936" height="516" viewBox="0 0 936 516">
<rect width="100%" height="100%" fill="#101418"/>
<style>text{font:14px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;fill:#e6edf3;white-space:pre}</style>

$ head -3 C/final.svg
<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="656" viewBox="0 0 1180 656">
<rect width="100%" height="100%" fill="#fdf6e3"/>
<style>text{font:17px Courier New,monospace;fill:#073642;white-space:pre}</style>

$ ls A/steps | head -4
01-wait-for-prompt.svg
01-wait-for-prompt.txt
02-open-dashboard.svg
02-open-dashboard.txt

$ for each step screenshot: sha256 A == sha256 B ?
  01-wait-for-prompt.svg             A==B:yes  A==C:no
  02-open-dashboard.svg              A==B:yes  A==C:no
  03-wait-for-dashboard.svg          A==B:yes  A==C:no
  04-filter-errors.svg               A==B:yes  A==C:no
  05-wait-for-filter.svg             A==B:yes  A==C:no
  06-export-report.svg               A==B:yes  A==C:no
  07-wait-for-export.svg             A==B:yes  A==C:no
  08-close-session.svg               A==B:yes  A==C:no
  09-wait-for-close.svg              A==B:yes  A==C:no
```
</details>
<details>
<summary>Evidence: Corpus byte-identity: every checked-in example screenshot re-rendered with the extracted defaults</summary>

<code># Re-rendering every checked-in example screenshot with the extracted defaults&#10;# (no config present) and comparing byte-for-byte against the committed file.&#10;&#10;identical: 146&#10;different: 0</code>

```text
# Re-rendering every checked-in example screenshot with the extracted defaults
# (no config present) and comparing byte-for-byte against the committed file.

identical: 146
different: 0
```
</details>
<details>
<summary>Evidence: --skip-unchanged cache invalidated by a single evidence knob change</summary>

<code># 1 cold cache -&gt; run directories now: 1&#10;# 2 unchanged config -&gt; run directories now: 1 &lt;- served from cache&#10;# 3 evidence.svg.fg #ff0000 -&gt; run directories now: 2 &lt;- cache invalidated, re-rendered&#10;# 4 unchanged again -&gt; run directories now: 2 &lt;- served from cache at the new key&#10;&#10;final.svg fills: run1 fill:#e6edf3 run2 fill:#ff0000</code>

```text
# --skip-unchanged: a cache hit re-uses the recorded result and creates no new run directory.
# config: /var/folders/00/dn1zh_wx3ys5gq4f1dtgpp8h0000gn/T/no-mistakes-evidence/01KZM33Z6BGQRGTGGD76ETZEYF/configs/cache-demo.yaml (evidence.svg = the built-in defaults)

$ termproof run ... --skip-unchanged   # 1: cold cache
PASS generic-tui-workflow [default] video: -
  run directories now: 1

$ termproof run ... --skip-unchanged   # 2: unchanged config
PASS generic-tui-workflow [default] video: -
  run directories now: 1   <- unchanged, result served from cache

$ sed -i 's/#e6edf3/#ff0000/' cache-demo.yaml   # change evidence.svg.fg only
$ termproof run ... --skip-unchanged   # 3: one rendering knob changed
PASS generic-tui-workflow [default] video: -
  run directories now: 2   <- cache invalidated, recipe re-ran and re-rendered

$ termproof run ... --skip-unchanged   # 4: unchanged again at the new key
PASS generic-tui-workflow [default] video: -
  run directories now: 2   <- served from cache again

$ ls cache dir
generic-tui-workflow

$ grep fill= final.svg of each run directory
  20260809-143441-750974-generic-tui-workflow-default: fill:#e6edf3
  20260809-143447-508816-generic-tui-workflow-default: fill:#ff0000
```
</details>
<details>
<summary>Evidence: Config-load errors name the offending evidence key</summary>

<code>ValueError: unknown evidence.svg option(s) [&#39;fnt_family&#39;]; known options: [&#39;bg&#39;, &#39;char_width&#39;, &#39;fg&#39;, &#39;font_family&#39;, &#39;font_size&#39;, &#39;line_height&#39;, &#39;padding&#39;]&#10;ValueError: evidence.png.scale must be a positive integer, got 0&#10;ValueError: evidence.svg.char_width must be int, got &#39;9&#39;&#10;ValueError: unknown evidence option(s) [&#39;vidoe&#39;]&#10;&#10;(for comparison, the pre-existing validator behaves the same way:)&#10;ValueError: idle_cap_seconds must be a finite nonnegative number, got -1</code>

```text
$ cat typo.yaml
evidence:
  svg:
    font_size: 14
    fnt_family: "Courier New"

$ termproof run examples/generic/generic_tui.recipe.json --config typo.yaml
        f"unknown {label} option(s) {unknown}; known options: {sorted(known)}"
    )
ValueError: unknown evidence.svg option(s) ['fnt_family']; known options: ['bg', 'char_width', 'fg', 'font_family', 'font_size', 'line_height', 'padding']
exit=0

$ cat badvalue.yaml
evidence:
  png:
    scale: 0

$ termproof run examples/generic/generic_tui.recipe.json --config badvalue.yaml
  File "/Users/mengwei/.no-mistakes/worktrees/32a742fa334a/01KZM33Z6BGQRGTGGD76ETZEYF/termproof/config.py", line 311, in _check_field_range
    raise ValueError(f"{label}.{name} must be {wording}, got {value!r}")
ValueError: evidence.png.scale must be a positive integer, got 0

$ cat badtype.yaml
evidence:
  svg:
    char_width: "9"

$ termproof validate examples/generic/generic_tui.recipe.json --config badtype.yaml
  File "/Users/mengwei/.no-mistakes/worktrees/32a742fa334a/01KZM33Z6BGQRGTGGD76ETZEYF/termproof/config.py", line 284, in _check_field_type
    raise ValueError(f"{label}.{name} must be {names}, got {value!r}")
ValueError: evidence.svg.char_width must be int, got '9'

$ cat badsection.yaml
evidence:
  vidoe:
    fps: 30

$ termproof validate examples/generic/generic_tui.recipe.json --config badsection.yaml
  File "/Users/mengwei/.no-mistakes/worktrees/32a742fa334a/01KZM33Z6BGQRGTGGD76ETZEYF/termproof/config.py", line 355, in _evidence_from_mapping
    raise ValueError(f"unknown evidence option(s) {sorted(values)}")
ValueError: unknown evidence option(s) ['vidoe']
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (25m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `termproof/config.py:293` - `_section` and `_evidence_from_mapping` both start with `dict(raw or {})`, which only produces a keyed error for mappings. A scalar or list where a mapping is expected escapes the deliberate &#34;fail at config-load naming the key&#34; contract that motivated `_check_field_type`: `evidence:\n  svg: 8` raises `TypeError: &#39;int&#39; object is not iterable` and `evidence: [a, b]` raises `TypeError: cannot convert dictionary update sequence element #0 to a sequence` — neither mentions `evidence` or `svg`, and `TypeError` is not what `load_config` callers catch alongside the `ValueError`s raised for every other bad evidence value. Add an `isinstance(raw, dict)` guard in both helpers that raises `ValueError(f&#34;{label} must be a mapping, got {raw!r}&#34;)`.
- ⚠️ `termproof/config.py:269` - Validation is type-only, so out-of-range dimensional and rate knobs still load and then fail (or silently degrade) far from the config that caused it — the exact failure mode `_check_field_type` was added to eliminate, and the one `_parse_idle_cap_seconds` already guards against for `defaults.idle_cap_seconds`. Concretely: `evidence.video.fps: 0` loads, becomes the `--video-fps` default, and dies mid-run as an unhandled `CalledProcessError` from `ffmpeg -vf fps=0` at termproof/evidence.py:198 (`check=True`, no except); `evidence.png.scale: 0` loads and produces a screenshot with zero padding and a collapsed line pitch with no error at all; `evidence.png.scale: -1` with `font_path` set reaches `ImageFont.truetype(path, -10)`. Reject non-positive values for the size/rate fields (`svg.char_width`, `svg.line_height`, `svg.font_size`, `png.scale`, `png.font_size`, `video.fps`, `video.fps_cap`) and negative values for `svg.padding`/`png.padding` at load time, naming the key as the type check already does.
- ℹ️ `termproof/run_cache.py:126` - Serializing the whole evidence section unconditionally defeats an existing deliberate exclusion two lines above it: `video_fps` and `video_backend` are zeroed/blanked when `render_video` is False precisely so video settings do not invalidate screenshot-only cached runs. Now editing `evidence.video.crf` (or any video knob) busts every `--skip-unchanged` cache entry even for runs invoked without `--video`, forcing full re-runs that cannot produce a different artifact. The stated goal (a knob added later invalidates without anyone remembering) is preserved by keying on `asdict(evidence.svg)`/`asdict(evidence.png)` always and `asdict(evidence.video)` only when `render_video` — but this touches the author&#39;s explicit &#34;the fingerprint now includes the evidence section&#34; decision, so it is a call for the user rather than a silent change.
- ℹ️ `tests/test_config.py:230` - `BUILTIN_DEFAULTS[&#34;evidence&#34;]` and the dataclass defaults are two independently-consumed sources of the same values — config-loaded runs use the former, while `EvidenceConfig()` fallbacks in evidence.render_artifacts, evidence._render_step_screens, evidence.render_mp4, screen.render_svg and run_cache._cache_key use the latter — yet nothing asserts they agree. `test_builtin_evidence_defaults_reproduce_the_previous_literals` spot-checks most fields but omits `png.font_size`, `png.fg` and `png.bg`, so changing e.g. `PngRenderConfig.bg` without touching `BUILTIN_DEFAULTS` would leave `PngRenderer()` and the registry-constructed `PngRenderer.from_config(...)` rendering different colours with a green suite. Given the duplication is an accepted tradeoff, one `assertEqual(EvidenceConfig(), VerifierConfig.builtin().evidence)` makes it a safe one.
- ℹ️ `termproof/__init__.py:19` - docs/plugin-protocols.md now documents `from_config(cls, evidence: EvidenceConfig) -&gt; Self` as a plugin hook, in a file that opens with &#34;TermProof exposes stable plugin protocols from `termproof.protocols`&#34; — but `EvidenceConfig` is in neither `termproof.protocols.__all__` nor `termproof.__all__`, so a third-party plugin implementing the documented hook has to import from `termproof.config`, which the package&#39;s public surface does not advertise as stable. Re-export `EvidenceConfig` (and, for renderers that want the narrower type, `SvgRenderConfig`/`PngRenderConfig`/`VideoConfig`) from `termproof/__init__.py` alongside `VerifierConfig`, which is already exported.

🔧 Fix: validate evidence ranges and sections, narrow cache key, export config types
2 issues (1 warning, 1 info) still open:
- ⚠️ `termproof/runner.py:60` - `_construct_evidence_plugin` is the only path by which `evidence.svg`/`evidence.png` reach a real run, and nothing in the suite exercises it. Replace its body with `return cls()` and all 412 tests still pass: `tests/test_evidence_config.py` only calls `SvgRenderer.from_config(...)`/`PngRenderer.from_config(...)` directly; `StepScreenScopeTest` and `test_render_artifacts_threads_config_to_final_and_step_screens` pass `screen_renderer=None`, exercising the `render_svg(..., svg_config)` fallback that the runner never takes (`screen_renderer_registry.get()` always returns an instance); and `tests/test_runner.py::test_video_backend_roundtrip` only asserts the backend is not None. A real `termproof run` with `evidence.svg.bg: &#34;#ff0000&#34;` would silently render the default colour with a green suite. The zero-arg fallback the intent guarantees for third-party plugins written against the bare protocols is likewise untested. Fix: one test that builds a `VerificationRunner` from a config with a non-default `evidence.svg.bg`, pulls `runner.screen_renderer_registry.get(&#34;svg&#34;)`, renders, and asserts the colour is present; plus one registering a renderer class without `from_config` and asserting it still constructs.
- ℹ️ `termproof/cli.py:29` - The new positive-integer validation guards `evidence.video.fps` at config load but not the `--video-fps` flag that overrides it. `termproof run r.recipe.json --video --video-fps 0` skips `_check_field_range` entirely (the flag is only replaced by the config value when it is None, cli.py:117-118) and reaches `render_mp4`, where `agg --fps-cap 0` exits non-zero under `check=True` at termproof/evidence.py:177 — an uncaught `CalledProcessError` after the session has already run. This is pre-existing at base commit e87e0e7 and outside the bounded scope the author explicitly approved for this change (config knobs only), so it belongs in a separate change; noted only because README.md now advertises &#34;a non-positive size or frame rate&#34; as rejected, which a reader may take to cover the flag too.

🔧 Fix: test evidence plugin construction through runner registries
2 infos still open:
- ℹ️ `termproof/config.py:291` - `_EVIDENCE_MINIMUMS` covers `svg.font_size` and `png.font_size` but not `evidence.video.font_size`, which is the same class of knob with the same concrete failure. Verified against this worktree: `evidence:\n  video:\n    font_size: -1` loads cleanly (`_check_field_type` accepts it for `int | None`, no minimum entry matches), and `render_mp4` then builds `[&#39;/bin/agg&#39;, &#39;--quiet&#39;, &#39;--fps-cap&#39;, &#39;60&#39;, &#39;--font-size&#39;, &#39;-1&#39;, ...]`. agg&#39;s clap parser treats `-1` as an unexpected flag, so `subprocess.run(..., check=True)` at termproof/evidence.py:193 raises an uncaught `CalledProcessError` after the session has already run — exactly the fail-late mode the range check was added to eliminate, and the reason README.md:260 now advertises &#34;a non-positive size or frame rate&#34; as rejected. The other agg passthroughs (`idle_time_limit`, `last_frame_duration`) have the same shape. This is outside the field list the user explicitly bounded in round 1, so it is a scope question rather than a defect to fix silently: either add `evidence.video.font_size: 1` to the dict or accept that the agg passthroughs stay unvalidated.
- ℹ️ `termproof/builtin_renderers.py:40` - `bg`, `fg` and `font_family` are now interpolated straight into the generated SVG markup at builtin_renderers.py:40-41 and the deliberate duplicate at screen.py:53-54, where they used to be literals. A value containing `&#34;` or `&lt;` (e.g. `bg: &#39;\&#34;/&gt;&lt;script&gt;&#39;`) produces malformed or markup-injected SVG with no error naming the key. Noting the tradeoff rather than recommending action: the config file already resolves arbitrary `module:Class` plugin references through `runner._import_class`, so anyone who can write `.termproof/config.yaml` already has code execution and gains nothing from SVG injection. Escaping would also not make a bad colour fail loudly, only keep the markup well-formed, and the user explicitly declined any value policy for colour and font-family strings. No change needed.

🔧 Fix: reject non-positive evidence.video.font_size at config load
1 info still open:
- ℹ️ `termproof/evidence.py:167` - `render_mp4` and `render_artifacts` now receive a `VideoConfig`/`EvidenceConfig` that carries `fps`, but neither consults it — `fps` stays a separate positional with its own literal default of 60. So `render_mp4(cast, out, config=VideoConfig(fps=24))` renders `-vf fps=60` and `--fps-cap 60`, silently ignoring the configured rate, and `render_artifacts(run_dir, render_video=True, evidence_config=cfg.evidence)` does the same. This is not reachable in product: every in-repo caller resolves fps first (cli.py:117-118, runner.py:174-175, demo.py:131-132), and `AggFfmpegBackend.render` is only ever handed the already-resolved value, which is exactly the layering the intent describes (&#34;VerificationRunner.run resolves video_fps from config when the caller passes none&#34;). Noting it as a trap in newly-widened surface — `config` is a new parameter on a module-level function whose `fps` field is inert — rather than recommending a change, since altering it would move fps resolution below the boundary the author deliberately chose. No action needed.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/test_protocols.py:14` - tests/test_protocols.py::ProtocolApiTests::test_public_protocol_exports_are_stable failed on HEAD: commit 3b2afcc added EvidenceConfig, PngRenderConfig, SvgRenderConfig and VideoConfig to termproof/protocols.py __all__, but the test still pinned the pre-change 8-name list (it passes on base commit e87e0e78). Since exporting the config types is deliberate, I updated the expected list in the test to include the four new names; the module now passes.
- <code>`python -m unittest tests.test_evidence_config tests.test_config tests.test_run_cache tests.test_protocols tests.test_screen tests.test_png_renderer tests.test_runner.VideoFpsWiringTest tests.test_runner.EvidencePluginConstructionTest` (68 tests, all pass after the test fix)</code>
- `python -m unittest tests.test_cli tests.test_bundled_video tests.test_demo tests.test_docs_pages tests.test_plugin_directory tests.test_termproof_rename`
- <code>`termproof run examples/generic/generic_tui.recipe.json --out &lt;evidence&gt;/run-default` then compared final.svg and all 9 steps/*.svg byte-for-byte against the same casts re-rendered by the base-commit (pre-change) `screen.py:render_svg`</code>
- <code>`termproof run examples/generic/generic_tui.recipe.json --config evidence-config.yaml` — SVG geometry/colour/font changed as configured (936x516/#101418/14px mono to 1180x704/#fffbe6/18px Georgia)</code>
- <code>`termproof run ... --screen-renderer png` with and without the config — 936x468 dark screenshot vs 1920x984 scale-2 navy/green screenshot</code>
- <code>`termproof run ... --video` with and without the config, then `ffmpeg -i session.mp4` — yuv420p/60fps vs yuv444p/24fps/crf 30 (bitrate 82 kb/s to 28 kb/s)</code>
- <code>`termproof run ... --video --video-fps 12 --config evidence-config.yaml` — flag wins over configured fps 24 (stream reports 12 fps)</code>
- <code>`termproof run ... --config &lt;bad&gt;.yaml` for a misspelled key, a quoted int, `video.fps: 0`, and an unknown `evidence.gif` section — each rejected at config load naming the offending key</code>
- <code>`termproof run ... --skip-unchanged --cache-dir ...` four times, counting created run directories: cache hit when nothing changed, re-run after an evidence knob changed</code>

🔧 Fix: update protocols __all__ test for exported evidence config types
✅ Re-checked - no issues remain.
- <code>`.venv/bin/python -m unittest tests.test_evidence_config tests.test_config tests.test_protocols tests.test_run_cache` (55 tests, OK)</code>
- <code>`PATH=.venv/bin:$PATH .venv/bin/python -m unittest tests.test_runner tests.test_cli tests.test_screen` (43 tests, OK — initial asciinema-not-found errors were a PATH setup issue, fixed by putting .venv/bin on PATH)</code>
- <code>`termproof run examples/generic/generic_tui.recipe.json --out &lt;evidence&gt;/runs/a-no-config` (no --config) vs `--config defaults-restated.yaml` — sha256 of final.svg and all 9 step SVGs identical</code>
- <code>`termproof run ... --config solarized.yaml` — SVG char_width/line_height/padding/font_size/font_family/fg/bg all applied; SVG rasterized to PNG for visual comparison</code>
- <code>`termproof run ... --screen-renderer png` default vs `--config png-hidpi.yaml` (scale 2, padding 30, font_size 22, Courier New TTF, solarized colours): 936x468 -&gt; 2820x1008 with real TrueType glyphs</code>
- <code>`termproof run ... --video` with no config vs `--config video-tuned.yaml`, probed with ffmpeg: yuv420p/60fps/982x560 -&gt; yuv444p (High 4:4:4)/24fps/1228x700 with solarized-light theme and font_size 20</code>
- <code>`termproof run ... --video --video-fps 12 --config video-tuned.yaml` — explicit flag wins over evidence.video.fps: 24 (output is 12 fps)</code>
- <code>`termproof run ... --skip-unchanged --cache-dir ...` four times: cache hit on unchanged config, cache miss after changing only evidence.svg.fg (new run dir, final.svg fill:#ff0000), hit again at the new key</code>
- <code>`termproof run/validate --config` with a misspelled key, unknown section, wrong-typed value and scale: 0 — each fails at config load with a ValueError naming evidence.&lt;section&gt;.&lt;key&gt;</code>
- `Re-rendered every checked-in screenshot under examples/artifacts with SvgRenderer.from_config(VerifierConfig.builtin().evidence): 146 identical, 0 different`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
