### PR TITLE
feat(protocols): let assertions read the screen captured after each step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           uv pip install --python plugin-template/.pkg-test/bin/python --no-deps plugin-template/dist/*.whl
           plugin-template/.pkg-test/bin/python -c "
           import termproof_my_plugin
-          expected = {'JsonSummaryReporter', 'ScreenCount', 'WaitForRegex', 'MyStore'}
+          expected = {'JsonSummaryReporter', 'MyStore', 'ScreenCount', 'StepScreenMatches', 'WaitForRegex'}
           actual = set(termproof_my_plugin.__all__)
           assert actual == expected, f'__all__ mismatch: {actual} != {expected}'
           print('__all__ verified:', termproof_my_plugin.__all__)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `from_target` classmethod, mirroring `from_config` for renderers, so
   credentials stay out of the checked-in config file. See
   `docs/plugin-protocols.md`.
+- **Assertions can read the screen captured after each step.** Until now an
+  assertion saw only the final screen, which makes anything about a state the
+  run passes through and then leaves — a dialog that was dismissed, a mid-flow
+  confirmation — inexpressible. The data already existed: `StepResult` carries a
+  per-step `screen`, and the scripted execution modes simply did not pass it on.
+  They now do, via a new `steps` argument on `VerificationRunner.evaluate_assertions`
+  and on assertion evaluation, plus a `StepAwareAssertionType` protocol exported
+  from `termproof.protocols` alongside the existing nine. The new built-in
+  `step_screen_contains` assertion takes a `step` name and a `value` substring
+  and reads that step's screen.
+
+  The change is additive: TermProof passes `steps` only to an `evaluate` that
+  declares a parameter of that name, so an assertion written against
+  `AssertionType` is still called with the original five arguments and keeps
+  working without source changes. A bare `**kwargs` deliberately does not count
+  as opting in, so an assertion that forwards unrecognised arguments to another
+  one written against the older signature cannot break either. `steps` is
+  keyword-only with a default of `None`, which also lets a step-aware assertion
+  run unchanged on a TermProof that never passes it — `None` means the execution
+  mode supplied no per-step screens, which is not the same as a run in which no
+  step ran. See `docs/plugin-protocols.md` and the `StepScreenMatches` example in
+  `plugin-template/`.
 - **An `evidence:` block in `.termproof/config.yaml`.** The SVG and PNG
   renderers and the video pipeline no longer hardcode their rendering
   parameters: `evidence.svg` (character width, line height, padding, font size

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Each run writes under `.termproof/runs/<run-id>/` (or the `--out` you provide):
 ```
 
 Step actions: `wait_for_text`, `wait_for_idle`, `send_text`, `send_line`, `press`, `sleep`, `wait_for_count`
-Assertions: `output_contains`, `output_not_contains`, `screen_contains`, `screen_not_contains`, `exit_code`, `file_exists`, `file_contains`
+Assertions: `output_contains`, `output_not_contains`, `screen_contains`, `screen_not_contains`, `step_screen_contains`, `exit_code`, `file_exists`, `file_contains`
 
 See [`docs/recipe-packs.md`](docs/recipe-packs.md) for layout and [`examples/generic/generic_tui.recipe.json`](examples/generic/generic_tui.recipe.json) for a minimal working recipe.
 

--- a/docs-site/api/index.md
+++ b/docs-site/api/index.md
@@ -18,6 +18,7 @@ Stable protocols cover:
 
 - `StepAction`
 - `AssertionType`
+- `StepAwareAssertionType`
 - `ExecutionMode`
 - `Reporter`
 - `ScreenRenderer`

--- a/docs/plugin-protocols.md
+++ b/docs/plugin-protocols.md
@@ -8,6 +8,7 @@ TermProof exposes stable plugin protocols from `termproof.protocols`.
 | --- | --- |
 | `StepAction` | `execute(session, step, index) -> StepResult` |
 | `AssertionType` | `evaluate(recipe, assertion, screen, raw_output, exit_code) -> AssertionResult` |
+| `StepAwareAssertionType` | `evaluate(recipe, assertion, screen, raw_output, exit_code, *, steps=None) -> AssertionResult` |
 | `ExecutionMode` | `execute(runner, recipe, run_dir) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]` |
 | `Reporter` | `generate(results, build_info=None, before_after=None) -> str` |
 | `ScreenRenderer` | `render(text, output_path, cols, rows) -> None` |
@@ -16,7 +17,7 @@ TermProof exposes stable plugin protocols from `termproof.protocols`.
 | `SessionBackend` | `create_session(argv, cast_path, cwd, env, cols, rows) -> TerminalSession` |
 | `ArtifactPublisher` | `publish(source, key) -> PublishedArtifact` |
 
-`StepAction`, `AssertionType`, `ExecutionMode`, `Reporter`, `ScreenRenderer`, `VideoBackend`, and `ArtifactPublisher` also require a `name: str` class attribute. `AgentRunner` and `SessionBackend` are selected by config keys and do not require a `name`.
+`StepAction`, `AssertionType`, `StepAwareAssertionType`, `ExecutionMode`, `Reporter`, `ScreenRenderer`, `VideoBackend`, and `ArtifactPublisher` also require a `name: str` class attribute. `AgentRunner` and `SessionBackend` are selected by config keys and do not require a `name`.
 
 `ScreenRenderer` plugins can optionally set `extension = "png"` (or another file extension) so evidence artifacts use that screenshot filename suffix.
 
@@ -62,6 +63,36 @@ the README). Plugins without it keep being constructed with no arguments.
 `EvidenceConfig`, and the narrower `SvgRenderConfig`, `PngRenderConfig`, and
 `VideoConfig` its sections hold, are exported from `termproof.protocols`
 alongside the protocols themselves.
+
+## Assertions and per-step screens
+
+`AssertionType` sees the final screen only, which makes an assertion about a
+state the run passes through and then leaves inexpressible. `StepAwareAssertionType`
+extends it with `steps`: the `StepResult` list for the steps that ran, in order,
+each carrying the screen captured after that step.
+
+`StepResult.screen` is plain text — pyte's already-flattened `display` — not an
+`AttributedScreen`. Colour, bold and reverse video are gone by the time an
+assertion sees a per-step screen, so a step-aware assertion can match glyphs and
+layout but not styling. The `render_attributed` grid described above is built
+for the final screen and the video, not for these; see
+[`docs/evidence-quality.md`](evidence-quality.md) for why per-step screens are
+still flat.
+
+The two protocols are one opt-in apart. TermProof passes `steps` only to an
+`evaluate` that declares a parameter of that name, so an assertion written
+against `AssertionType` is called with the original five arguments and needs no
+source change. A bare `**kwargs` does not count as declaring it — an assertion
+that forwards unrecognised arguments to another assertion would otherwise pass
+`steps` into one that cannot accept it. Keeping `steps` keyword-only with a
+default of `None`, as the protocol declares it, also lets a step-aware assertion
+run unchanged on a TermProof that never passes it.
+
+`steps` is `None` when the execution mode supplied no per-step screens, which is
+distinct from a run in which no step ran. Both built-in scripted modes supply
+them; the agent-driven mode derives its assertions from the agent's own report
+and does not go through the assertion registry. The built-in
+`step_screen_contains` assertion is the reference implementation.
 
 ## ArtifactPublisher
 
@@ -133,7 +164,7 @@ internals:
 | `run_pty(recipe, run_dir) -> tuple[list[StepResult], str, int | None, str]` | Run scripted steps interactively over a PTY session. |
 | `run_process(recipe, run_dir) -> tuple[list[StepResult], str, int | None, str]` | Run the command to completion, then replay the cast. |
 | `run_agent_driven(recipe, run_dir) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]` | Delegate execution to the configured agent runner. |
-| `evaluate_assertions(recipe, screen, raw_output, exit_code) -> list[AssertionResult]` | Evaluate a recipe's assertions against captured output. |
+| `evaluate_assertions(recipe, screen, raw_output, exit_code, *, steps=None) -> list[AssertionResult]` | Evaluate a recipe's assertions against captured output. Pass `steps` so step-aware assertions can read per-step screens. |
 
 The former private methods (`_run_pty`, `_run_process`, `_run_agent_driven`,
 `_evaluate_assertions`) remain as deprecated aliases that delegate to the public

--- a/docs/recipe-format-v1.md
+++ b/docs/recipe-format-v1.md
@@ -58,6 +58,32 @@ The formal JSON Schema is published at [`recipe-schema-v1.json`](recipe-schema-v
 
 Recipes that verify JSON-producing CLIs can use the built-in `json_schema` assertion. Set `schema` to either an inline JSON Schema object or a recipe-relative schema file path.
 
+## Asserting on an intermediate screen
+
+`screen_contains` reads the last screen of the run. To assert on a state the
+target passes through and then leaves, name the step whose screen to read:
+
+```json
+{
+  "steps": [
+    { "name": "open the palette", "action": "wait_for_text", "text": "Command palette" },
+    { "name": "dismiss", "action": "press", "key": "escape" }
+  ],
+  "assertions": [
+    { "type": "step_screen_contains", "step": "open the palette", "value": "Command palette" },
+    { "type": "screen_not_contains", "value": "Command palette" }
+  ]
+}
+```
+
+`step` matches the step's `name`. A step without one is named `"<index>:<action>"`,
+so naming the steps you assert on is worth doing.
+
+Recipes are not required to give their steps distinct names, and `step` reads the
+screen of the **first** step whose name matches. Two steps sharing a name is
+therefore a silently confusing assertion rather than an error — keep the name of
+any step you assert on unique within the recipe.
+
 ## Migrating v0.x recipes
 
 Existing recipes usually need only one edit:

--- a/examples/generic/generic_tui.recipe.json
+++ b/examples/generic/generic_tui.recipe.json
@@ -74,6 +74,12 @@
   ],
   "assertions": [
     {
+      "type": "step_screen_contains",
+      "name": "dashboard was on screen mid-run",
+      "step": "wait for dashboard",
+      "value": "DASHBOARD READY"
+    },
+    {
       "type": "output_contains",
       "value": "DASHBOARD READY"
     },

--- a/plugin-template/.github/workflows/ci.yml
+++ b/plugin-template/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           .pkg-test/bin/pip install dist/*.whl
           .pkg-test/bin/python -c "
           import termproof_my_plugin
-          expected = {'JsonSummaryReporter', 'ScreenCount', 'WaitForRegex', 'MyStore'}
+          expected = {'JsonSummaryReporter', 'MyStore', 'ScreenCount', 'StepScreenMatches', 'WaitForRegex'}
           actual = set(termproof_my_plugin.__all__)
           assert actual == expected, f'__all__ mismatch: {actual} != {expected}'
           print('__all__ verified:', termproof_my_plugin.__all__)

--- a/plugin-template/README.md
+++ b/plugin-template/README.md
@@ -11,6 +11,7 @@ Copy this repository to start your own plugin. It contains:
 
 - **Example step** (`WaitForRegex`) — regex-aware terminal wait with `ignore_case`/`multiline`/`dotall` flags (`src/termproof_my_plugin/steps.py`)
 - **Example assertion** (`ScreenCount`) — occurrence counting with optional min/max bounds (`src/termproof_my_plugin/assertions.py`)
+- **Example step-aware assertion** (`StepScreenMatches`) — regex against the screen captured after a named step, not the final one (`src/termproof_my_plugin/step_assertions.py`)
 - **Example reporter** (`JsonSummaryReporter`) — machine-readable JSON summary with build provenance (`src/termproof_my_plugin/reporters.py`)
 - Packaging metadata (`pyproject.toml`) with dev extras
 - Tests (`tests/`) including config-wiring verification
@@ -52,6 +53,7 @@ steps:
 
 assertions:
   screen_count: termproof_my_plugin.assertions:ScreenCount
+  step_screen_matches: termproof_my_plugin.step_assertions:StepScreenMatches
 
 reporters:
   json_summary: termproof_my_plugin.reporters:JsonSummaryReporter
@@ -65,7 +67,8 @@ Then reference by name in recipe JSON:
     { "action": "wait_for_regex", "pattern": "Dashboard .* \\\\d+/\\\\d+" }
   ],
   "assertions": [
-    { "type": "screen_count", "pattern": "TODO", "max": 0 }
+    { "type": "screen_count", "pattern": "TODO", "max": 0 },
+    { "type": "step_screen_matches", "step": "open dashboard", "pattern": "Dashboard .* \\\\d+/\\\\d+" }
   ]
 }
 ```

--- a/plugin-template/docs/protocol.md
+++ b/plugin-template/docs/protocol.md
@@ -20,6 +20,7 @@ Most protocols require a `name` class attribute and a single method:
 
 - Step: execute(session, step, index) -> StepResult
 - Assertion: evaluate(recipe, assertion, screen, raw_output, exit_code) -> AssertionResult
+- Step-aware assertion: evaluate(recipe, assertion, screen, raw_output, exit_code, *, steps=None) -> AssertionResult
 - Reporter: generate(results, build_info, before_after) -> str
 - ScreenRenderer: render(text, output_path, cols, rows) -> None
 - VideoBackend: render(cast_path, output_path, fps) -> None
@@ -57,8 +58,18 @@ ship one.
 
 ## Context availability for assertions
 
-Assertions receive only the final state of the run. The following are **NOT**
-available at assertion evaluation time and must not be relied upon:
+Available at assertion evaluation time:
+
+- **Final screen** and **final raw output** — the `screen` and `raw_output`
+  arguments
+- **Exit code** — `None` when the target had not exited
+- **The recipe** — including `command.cwd`, which is what the file assertions
+  resolve their relative paths against
+- **Per-step screens** — the `steps` argument, one `StepResult` per step that
+  ran, in order, each carrying the screen captured after that step, as plain
+  text. Opt in by declaring the parameter (see below).
+
+The following are **NOT** available and must not be relied upon:
 
 - **Run directory** — no filesystem path to the current run's artifacts
 - **Elapsed time / duration** — `RunResult.duration_seconds` is computed after
@@ -67,11 +78,50 @@ available at assertion evaluation time and must not be relied upon:
   stale prior runs at best, nothing at worst
 - **Accumulated raw output** — assertion receives the final raw output, not
   the incremental stream
+- **Screen attributes** — every screen an assertion sees, final or per-step, is
+  flattened text. Colour, bold and reverse video are available to renderers via
+  `render_attributed`, not to assertions
 
 Plugin authors should not attempt filesystem-based workarounds. To enforce
 timing constraints, use TermProof core features (e.g. recipe-level
-`timeout_seconds`). For counting and content checks, the `screen` and
-`raw_output` strings are the correct inputs.
+`timeout_seconds`).
+
+### Opting into per-step screens
+
+An assertion whose subject is a state the target passes through and then leaves
+— a dialog that was dismissed, a screen that was shown mid-flow — cannot read it
+off the final screen. Declare a `steps` parameter and TermProof passes the
+per-step screens:
+
+```python
+def evaluate(
+    self, recipe, assertion, screen, raw_output, exit_code, *, steps=None
+) -> AssertionResult:
+    match = next((s for s in steps or [] if s.name == assertion["step"]), None)
+```
+
+Rules worth knowing:
+
+- **Declaring `steps` is the whole opt-in.** An assertion that does not declare
+  it is called with the original five arguments, exactly as before, and needs no
+  source change.
+- **`**kwargs` alone does not opt in.** An assertion that forwards unrecognised
+  arguments to another assertion would otherwise pass `steps` into one that
+  cannot accept it.
+- **Give `steps` a default of `None`.** Then the same assertion also runs on a
+  TermProof that predates the argument.
+- **`None` is not the same as `[]`.** `None` means the execution mode supplied
+  no per-step screens — report that rather than treating it as a run with no
+  steps. The built-in scripted modes always supply them; the agent-driven mode
+  produces its assertions from the agent's own report and does not go through
+  the assertion registry at all.
+- **`StepResult.name` is what `step` matches**: the recipe step's `name` when it
+  sets one, and `"<index>:<action>"` when it does not.
+- Steps after a failing step do not run, so they are absent from the list.
+
+`StepScreenMatches` in `src/termproof_my_plugin/step_assertions.py` is a worked
+example; `ScreenCount` in `src/termproof_my_plugin/assertions.py` is deliberately
+left on the original signature to show the two coexisting in one plugin.
 
 ## Version and deprecation policy
 

--- a/plugin-template/examples/.termproof/config.yaml
+++ b/plugin-template/examples/.termproof/config.yaml
@@ -2,6 +2,7 @@ steps:
   wait_for_regex: termproof_my_plugin.steps:WaitForRegex
 assertions:
   screen_count: termproof_my_plugin.assertions:ScreenCount
+  step_screen_matches: termproof_my_plugin.step_assertions:StepScreenMatches
 reporters:
   json_summary: termproof_my_plugin.reporters:JsonSummaryReporter
 artifact_publishers:

--- a/plugin-template/scripts/check_config_wiring.py
+++ b/plugin-template/scripts/check_config_wiring.py
@@ -14,6 +14,7 @@ with tempfile.TemporaryDirectory() as tmp:
           wait_for_regex: termproof_my_plugin.steps:WaitForRegex
         assertions:
           screen_count: termproof_my_plugin.assertions:ScreenCount
+          step_screen_matches: termproof_my_plugin.step_assertions:StepScreenMatches
         reporters:
           json_summary: termproof_my_plugin.reporters:JsonSummaryReporter
         """),
@@ -22,11 +23,13 @@ with tempfile.TemporaryDirectory() as tmp:
     cfg = load_config(project_path=proj)
     assert "wait_for_regex" in cfg.steps
     assert "screen_count" in cfg.assertions
+    assert "step_screen_matches" in cfg.assertions
     assert "json_summary" in cfg.reporters
     from termproof.runner import VerificationRunner
 
     runner = VerificationRunner(config=cfg)
     assert "wait_for_regex" in runner.step_registry.names()
     assert "screen_count" in runner.assertion_registry.names()
+    assert "step_screen_matches" in runner.assertion_registry.names()
     assert "json_summary" in runner.reporter_registry.names()
     print("Config wiring verified")

--- a/plugin-template/src/termproof_my_plugin/__init__.py
+++ b/plugin-template/src/termproof_my_plugin/__init__.py
@@ -3,11 +3,13 @@
 from .assertions import ScreenCount
 from .publishers import MyStore
 from .reporters import JsonSummaryReporter
+from .step_assertions import StepScreenMatches
 from .steps import WaitForRegex
 
 __all__ = [
     "JsonSummaryReporter",
     "MyStore",
     "ScreenCount",
+    "StepScreenMatches",
     "WaitForRegex",
 ]

--- a/plugin-template/src/termproof_my_plugin/assertions.py
+++ b/plugin-template/src/termproof_my_plugin/assertions.py
@@ -13,10 +13,12 @@ Protocol compatibility:
 - ``name`` class attribute must match the config ``assertions`` mapping
 - ``evaluate(recipe, assertion, screen, raw_output, exit_code) -> AssertionResult``
 
-Note: The assertion protocol only receives the final screen/raw_output/exit_code.
-Timing data and run artifacts are NOT available, so duration-based assertions
-must be implemented in TermProof core and cannot be written in a plugin.
-See ``docs/protocol.md`` for the full availability matrix.
+Note: this signature receives the final screen/raw_output/exit_code only, which
+is all ``screen_count`` needs. An assertion about an *intermediate* state opts
+into the per-step screens by declaring a ``steps`` parameter — see
+``step_assertions.py``. Timing data and run artifacts are still NOT available,
+so duration-based assertions must be implemented in TermProof core and cannot be
+written in a plugin. See ``docs/protocol.md`` for the full availability matrix.
 """
 
 from __future__ import annotations

--- a/plugin-template/src/termproof_my_plugin/step_assertions.py
+++ b/plugin-template/src/termproof_my_plugin/step_assertions.py
@@ -1,0 +1,95 @@
+"""Example step-aware assertion for TermProof.
+
+Implements ``step_screen_matches`` — asserts a regex matches the screen
+captured after a named step, rather than the final screen. Register it in
+config:
+
+.. code-block:: yaml
+
+   assertions:
+     step_screen_matches: termproof_my_plugin.step_assertions:StepScreenMatches
+
+Protocol compatibility:
+- Requires a TermProof that supplies per-step screens to assertions
+- Loads and runs on older TermProof too: ``steps`` is keyword-only with a
+  default, so a runner that does not know about it calls this unchanged and the
+  assertion reports that the screens were unavailable
+- ``evaluate(recipe, assertion, screen, raw_output, exit_code, *, steps=None)
+  -> AssertionResult``
+
+An assertion opts into per-step screens purely by declaring a ``steps``
+parameter — see ``ScreenCount`` in ``assertions.py`` for one that does not and
+is called with the original five arguments. ``**kwargs`` alone does not opt in,
+so a wrapper that forwards unrecognised arguments to another assertion stays
+safe. See ``docs/protocol.md`` for the full availability matrix.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from termproof.models import AssertionResult, Recipe, StepResult
+
+
+class StepScreenMatches:
+    """Assert a regex matches the screen captured after a named step.
+
+    Recipe usage::
+
+        {
+          "type": "step_screen_matches",
+          "step": "open dashboard",
+          "pattern": "Dashboard .* \\d+/\\d+"
+        }
+
+    ``step`` matches ``StepResult.name``: the recipe step's ``name`` when it
+    sets one, and ``"<index>:<action>"`` when it does not.
+    """
+
+    name = "step_screen_matches"
+
+    def evaluate(
+        self,
+        recipe: Recipe,
+        assertion: dict[str, Any],
+        screen: str,
+        raw_output: str,
+        exit_code: int | None,
+        *,
+        steps: list[StepResult] | None = None,
+    ) -> AssertionResult:
+        display = str(assertion.get("name", self.name))
+
+        step_name = assertion.get("step")
+        if not isinstance(step_name, str) or not step_name:
+            return AssertionResult(display, False, "missing required field 'step'")
+
+        pattern = assertion.get("pattern")
+        if not isinstance(pattern, str) or not pattern:
+            return AssertionResult(display, False, "missing required field 'pattern'")
+        try:
+            compiled = re.compile(pattern)
+        except re.error as exc:
+            return AssertionResult(display, False, f"invalid regex {pattern!r}: {exc}")
+
+        if steps is None:
+            return AssertionResult(
+                display,
+                False,
+                "per-step screens are unavailable: this TermProof, or this "
+                "execution mode, does not supply them",
+            )
+
+        match = next((step for step in steps if step.name == step_name), None)
+        if match is None:
+            ran = ", ".join(repr(step.name) for step in steps) or "no steps ran"
+            return AssertionResult(display, False, f"no step named {step_name!r}: {ran}")
+
+        found = compiled.search(match.screen) is not None
+        return AssertionResult(
+            display,
+            found,
+            f"{pattern!r} {'matches' if found else 'does not match'} "
+            f"the screen after {step_name!r}",
+        )

--- a/plugin-template/tests/test_step_assertions.py
+++ b/plugin-template/tests/test_step_assertions.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import unittest
+
+from termproof_my_plugin.assertions import ScreenCount
+from termproof_my_plugin.step_assertions import StepScreenMatches
+
+from termproof.models import CommandSpec, Recipe, StepResult
+
+
+def _recipe(name: str = "r") -> Recipe:
+    return Recipe(name=name, command=CommandSpec(argv=["echo", "hi"]))
+
+
+def _steps() -> list[StepResult]:
+    return [
+        StepResult("open dashboard", True, "", "Dashboard READY 3/3"),
+        StepResult("quit", True, "", "bye"),
+    ]
+
+
+class StepScreenMatchesTest(unittest.TestCase):
+    # --- happy path --------------------------------------------------------------
+    def test_matches_the_named_step_screen(self):
+        r = StepScreenMatches().evaluate(
+            _recipe(),
+            {"step": "open dashboard", "pattern": r"Dashboard .* \d+/\d+"},
+            "bye",
+            "",
+            0,
+            steps=_steps(),
+        )
+        self.assertTrue(r.passed)
+
+    def test_final_screen_is_not_what_is_read(self):
+        r = StepScreenMatches().evaluate(
+            _recipe(),
+            {"step": "quit", "pattern": "Dashboard"},
+            "Dashboard READY 3/3",
+            "",
+            0,
+            steps=_steps(),
+        )
+        self.assertFalse(r.passed)
+
+    # --- missing fields ----------------------------------------------------------
+    def test_missing_step(self):
+        r = StepScreenMatches().evaluate(
+            _recipe(), {"pattern": "OK"}, "", "", 0, steps=_steps()
+        )
+        self.assertFalse(r.passed)
+        self.assertIn("'step'", r.detail)
+
+    def test_missing_pattern(self):
+        r = StepScreenMatches().evaluate(
+            _recipe(), {"step": "quit"}, "", "", 0, steps=_steps()
+        )
+        self.assertFalse(r.passed)
+        self.assertIn("'pattern'", r.detail)
+
+    def test_invalid_regex(self):
+        r = StepScreenMatches().evaluate(
+            _recipe(), {"step": "quit", "pattern": "[bad"}, "", "", 0, steps=_steps()
+        )
+        self.assertFalse(r.passed)
+        self.assertIn("invalid regex", r.detail)
+
+    # --- unknown step ------------------------------------------------------------
+    def test_unknown_step_reports_the_steps_that_ran(self):
+        r = StepScreenMatches().evaluate(
+            _recipe(), {"step": "typo", "pattern": "OK"}, "", "", 0, steps=_steps()
+        )
+        self.assertFalse(r.passed)
+        self.assertIn("'open dashboard'", r.detail)
+
+    # --- older TermProof ---------------------------------------------------------
+    def test_runs_when_the_caller_does_not_pass_steps(self):
+        """A TermProof without per-step screens calls with five arguments."""
+        r = StepScreenMatches().evaluate(
+            _recipe(), {"step": "quit", "pattern": "OK"}, "bye", "", 0
+        )
+        self.assertFalse(r.passed)
+        self.assertIn("unavailable", r.detail)
+
+
+class OptInIsExplicitTest(unittest.TestCase):
+    """An assertion opts in by declaring ``steps``; the other one still works.
+
+    ``ScreenCount`` is written against the original assertion signature and is
+    deliberately left that way, so this pins that both styles coexist in one
+    plugin.
+    """
+
+    def test_screen_count_takes_no_steps(self):
+        import inspect
+
+        self.assertNotIn(
+            "steps", inspect.signature(ScreenCount.evaluate).parameters
+        )
+        r = ScreenCount().evaluate(_recipe(), {"pattern": "OK", "min": 1}, "OK", "", 0)
+        self.assertTrue(r.passed)
+
+    def test_step_screen_matches_declares_steps_as_optional(self):
+        import inspect
+
+        steps = inspect.signature(StepScreenMatches.evaluate).parameters["steps"]
+        self.assertIs(inspect.Parameter.KEYWORD_ONLY, steps.kind)
+        self.assertIsNone(steps.default)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/termproof/__init__.py
+++ b/termproof/__init__.py
@@ -35,6 +35,7 @@ from .protocols import (
     ScreenRenderer,
     SessionBackend,
     StepAction,
+    StepAwareAssertionType,
     VideoBackend,
 )
 from .registry import Registry
@@ -62,6 +63,7 @@ __all__ = [
     "ScreenRenderer",
     "SessionBackend",
     "StepAction",
+    "StepAwareAssertionType",
     "StepResult",
     "SvgRenderConfig",
     "SvgStyle",

--- a/termproof/builtin_assertions.py
+++ b/termproof/builtin_assertions.py
@@ -6,8 +6,9 @@ from typing import Any
 
 import jsonschema
 
-from .models import AssertionResult, Recipe
+from .models import AssertionResult, Recipe, StepResult
 from .protocols import AssertionType as AssertionType
+from .protocols import StepAwareAssertionType as StepAwareAssertionType
 
 
 def _contains(
@@ -137,6 +138,54 @@ class ScreenNotContains:
             False,
             assertion.get("detail"),
         )
+
+
+class StepScreenContains:
+    """Assert a substring is on the screen captured after a named step.
+
+    ``screen_contains`` can only see the last screen of the run, so a state the
+    target passes through and then leaves is not expressible with it. This
+    assertion names the step whose screen to read::
+
+        {
+          "type": "step_screen_contains",
+          "step": "open the palette",
+          "value": "Command palette"
+        }
+
+    ``step`` matches ``StepResult.name``, which is the recipe step's ``name``
+    when it sets one and ``"<index>:<action>"`` when it does not.
+    """
+
+    name = "step_screen_contains"
+
+    def evaluate(
+        self,
+        recipe: Recipe,
+        assertion: dict[str, Any],
+        screen: str,
+        raw_output: str,
+        exit_code: int | None,
+        *,
+        steps: list[StepResult] | None = None,
+    ) -> AssertionResult:
+        name = assertion.get("name", self.name)
+        step_name = str(assertion["step"])
+        if steps is None:
+            return AssertionResult(
+                name,
+                False,
+                "per-step screens were not supplied by the execution mode",
+            )
+        match = next((step for step in steps if step.name == step_name), None)
+        if match is None:
+            ran = ", ".join(repr(step.name) for step in steps) or "no steps ran"
+            return AssertionResult(name, False, f"no step named {step_name!r}: {ran}")
+        value = assertion["value"]
+        detail = assertion.get("detail") or (
+            f"screen after {step_name!r} contains {value!r}"
+        )
+        return AssertionResult(name, value in match.screen, detail)
 
 
 class ExitCode:

--- a/termproof/builtin_modes.py
+++ b/termproof/builtin_modes.py
@@ -19,7 +19,9 @@ class ScriptedPtyMode:
         run_dir: Path,
     ) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]:
         steps, raw_output, exit_code, screen = runner.run_pty(recipe, run_dir)
-        assertions = runner.evaluate_assertions(recipe, screen, raw_output, exit_code)
+        assertions = runner.evaluate_assertions(
+            recipe, screen, raw_output, exit_code, steps=steps
+        )
         return steps, assertions, raw_output, exit_code, screen
 
 
@@ -35,7 +37,9 @@ class ScriptedProcessMode:
         run_dir: Path,
     ) -> tuple[list[StepResult], list[AssertionResult], str, int | None, str]:
         steps, raw_output, exit_code, screen = runner.run_process(recipe, run_dir)
-        assertions = runner.evaluate_assertions(recipe, screen, raw_output, exit_code)
+        assertions = runner.evaluate_assertions(
+            recipe, screen, raw_output, exit_code, steps=steps
+        )
         return steps, assertions, raw_output, exit_code, screen
 
 

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -30,6 +30,7 @@ BUILTIN_DEFAULTS: dict[str, Any] = {
         "output_not_contains": "termproof.builtin_assertions:OutputNotContains",
         "screen_contains": "termproof.builtin_assertions:ScreenContains",
         "screen_not_contains": "termproof.builtin_assertions:ScreenNotContains",
+        "step_screen_contains": "termproof.builtin_assertions:StepScreenContains",
         "exit_code": "termproof.builtin_assertions:ExitCode",
         "file_exists": "termproof.builtin_assertions:FileExists",
         "file_contains": "termproof.builtin_assertions:FileContains",

--- a/termproof/protocols.py
+++ b/termproof/protocols.py
@@ -40,6 +40,35 @@ class AssertionType(Protocol):
         ...
 
 
+class StepAwareAssertionType(Protocol):
+    """An assertion that also sees the screen captured after each step.
+
+    Implementations satisfy ``AssertionType`` as well: ``steps`` is keyword-only
+    and defaults to ``None``, so a caller that predates it invokes them exactly
+    as before. TermProof passes ``steps`` only to evaluators that declare the
+    parameter, which is why an assertion written against ``AssertionType`` keeps
+    working without source changes.
+
+    ``steps`` is ``None`` when the execution mode did not supply per-step
+    screens — an assertion that needs them should report that rather than
+    assume an empty run.
+    """
+
+    name: str
+
+    def evaluate(
+        self,
+        recipe: Recipe,
+        assertion: dict[str, Any],
+        screen: str,
+        raw_output: str,
+        exit_code: int | None,
+        *,
+        steps: list[StepResult] | None = None,
+    ) -> AssertionResult:
+        ...
+
+
 class ExecutionMode(Protocol):
     name: str
 
@@ -140,6 +169,7 @@ __all__ = [
     "ScreenRenderer",
     "SessionBackend",
     "StepAction",
+    "StepAwareAssertionType",
     "SvgRenderConfig",
     "VideoBackend",
     "VideoConfig",

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import inspect
 import time
 from dataclasses import replace
+from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +49,24 @@ def _build_assertion_registry(config: VerifierConfig) -> Registry[Any]:
         cls = import_class(qualname)
         registry.register(name, lambda c=cls: c())
     return registry
+
+
+@cache
+def _evaluate_wants_steps(evaluate: Any) -> bool:
+    """Whether an assertion's ``evaluate`` opts into the per-step screens.
+
+    Opting in means declaring a parameter named ``steps``, the same shape of
+    opt-in as ``from_config`` on evidence plugins. A bare ``**kwargs`` does not
+    count: an assertion that forwards unrecognised arguments to another
+    assertion written against the older signature would break if we passed
+    ``steps`` into it.
+    """
+    try:
+        parameters = inspect.signature(evaluate).parameters
+    except (TypeError, ValueError):
+        return False
+    parameter = parameters.get("steps")
+    return parameter is not None and parameter.kind is not inspect.Parameter.POSITIONAL_ONLY
 
 
 def _build_reporter_registry(config: VerifierConfig) -> Registry[Any]:
@@ -305,12 +325,16 @@ class VerificationRunner:
         screen: str,
         raw_output: str,
         exit_code: int | None,
+        *,
+        steps: list[StepResult] | None = None,
     ) -> list[AssertionResult]:
         assertions = list(recipe.assertions)
         if recipe.expect_exit_code is not None:
             assertions.append({"type": "exit_code", "value": recipe.expect_exit_code})
         return [
-            self._evaluate_assertion(recipe, assertion, screen, raw_output, exit_code)
+            self._evaluate_assertion(
+                recipe, assertion, screen, raw_output, exit_code, steps=steps
+            )
             for assertion in assertions
         ]
 
@@ -346,8 +370,12 @@ class VerificationRunner:
         screen: str,
         raw_output: str,
         exit_code: int | None,
+        *,
+        steps: list[StepResult] | None = None,
     ) -> list[AssertionResult]:
-        return self.evaluate_assertions(recipe, screen, raw_output, exit_code)
+        return self.evaluate_assertions(
+            recipe, screen, raw_output, exit_code, steps=steps
+        )
 
     def _evaluate_assertion(
         self,
@@ -356,13 +384,18 @@ class VerificationRunner:
         screen: str,
         raw_output: str,
         exit_code: int | None,
+        *,
+        steps: list[StepResult] | None = None,
     ) -> AssertionResult:
         kind = assertion["type"]
         try:
             evaluator = self.assertion_registry.get(kind)
         except KeyError as err:
             raise ValueError(f"unknown assertion type: {kind}") from err
-        return evaluator.evaluate(recipe, assertion, screen, raw_output, exit_code)
+        evaluate = evaluator.evaluate
+        if _evaluate_wants_steps(getattr(evaluate, "__func__", evaluate)):
+            return evaluate(recipe, assertion, screen, raw_output, exit_code, steps=steps)
+        return evaluate(recipe, assertion, screen, raw_output, exit_code)
 
 
 def _with_renderer_argv(recipe: Recipe, renderer_argv: list[str]) -> Recipe:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -22,6 +22,7 @@ class ProtocolApiTests(unittest.TestCase):
                 "ScreenRenderer",
                 "SessionBackend",
                 "StepAction",
+                "StepAwareAssertionType",
                 "SvgRenderConfig",
                 "VideoBackend",
                 "VideoConfig",
@@ -39,6 +40,18 @@ class ProtocolApiTests(unittest.TestCase):
             ),
             protocols.AssertionType.evaluate: (
                 ["self", "recipe", "assertion", "screen", "raw_output", "exit_code"],
+                "AssertionResult",
+            ),
+            protocols.StepAwareAssertionType.evaluate: (
+                [
+                    "self",
+                    "recipe",
+                    "assertion",
+                    "screen",
+                    "raw_output",
+                    "exit_code",
+                    "steps",
+                ],
                 "AssertionResult",
             ),
             protocols.ExecutionMode.execute: (
@@ -74,6 +87,23 @@ class ProtocolApiTests(unittest.TestCase):
             signature = inspect.signature(method)
             self.assertEqual(parameters, list(signature.parameters))
             self.assertEqual(return_annotation, signature.return_annotation)
+
+    def test_step_aware_assertions_extend_the_assertion_protocol_additively(self) -> None:
+        """``steps`` must be optional, and only on the extended protocol.
+
+        An assertion implementing ``StepAwareAssertionType`` also satisfies
+        ``AssertionType``, so it keeps working on a TermProof that never passes
+        ``steps``; and ``AssertionType`` itself is untouched, so an assertion
+        written against it needs no source change.
+        """
+        steps = inspect.signature(protocols.StepAwareAssertionType.evaluate).parameters[
+            "steps"
+        ]
+        self.assertIs(inspect.Parameter.KEYWORD_ONLY, steps.kind)
+        self.assertIsNone(steps.default)
+        self.assertNotIn(
+            "steps", inspect.signature(protocols.AssertionType.evaluate).parameters
+        )
 
     def test_legacy_protocol_import_locations_reexport_public_protocols(self) -> None:
         from termproof.agent_driven import AgentRunner

--- a/tests/test_step_screen_assertions.py
+++ b/tests/test_step_screen_assertions.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import textwrap
+import types
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from termproof.builtin_assertions import StepScreenContains
+from termproof.config import VerifierConfig
+from termproof.models import AssertionResult, CommandSpec, Recipe, StepResult
+from termproof.runner import VerificationRunner
+
+
+def _recipe(**overrides: Any) -> Recipe:
+    defaults: dict[str, Any] = {
+        "name": "r",
+        "command": CommandSpec(argv=["echo", "hi"]),
+    }
+    return Recipe(**{**defaults, **overrides})
+
+
+def _steps(*pairs: tuple[str, str]) -> list[StepResult]:
+    return [StepResult(name, True, "", screen) for name, screen in pairs]
+
+
+class LegacyAssertion:
+    """An assertion written against the 0.2.1 signature, verbatim.
+
+    The point of this fixture is that it is never updated. Every test that
+    exercises it is a test that a plugin published before per-step screens
+    existed still runs, unmodified, on the current runner.
+    """
+
+    name = "legacy_probe"
+
+    def evaluate(
+        self,
+        recipe: Recipe,
+        assertion: dict[str, Any],
+        screen: str,
+        raw_output: str,
+        exit_code: int | None,
+    ) -> AssertionResult:
+        return AssertionResult(
+            assertion.get("name", self.name), True, f"saw final screen {screen!r}"
+        )
+
+
+class ForwardingAssertion:
+    """A wrapper that forwards whatever it is handed to a legacy assertion.
+
+    ``**kwargs`` is deliberately not treated as opting in: if the runner passed
+    ``steps`` here, the forwarded call to ``LegacyAssertion.evaluate`` would
+    raise ``TypeError``.
+    """
+
+    name = "forwarding_probe"
+
+    def __init__(self) -> None:
+        self.inner = LegacyAssertion()
+
+    def evaluate(self, *args: Any, **kwargs: Any) -> AssertionResult:
+        return self.inner.evaluate(*args, **kwargs)
+
+
+class StepAwareAssertion:
+    """An assertion that opts into per-step screens by declaring ``steps``."""
+
+    name = "step_aware_probe"
+
+    def evaluate(
+        self,
+        recipe: Recipe,
+        assertion: dict[str, Any],
+        screen: str,
+        raw_output: str,
+        exit_code: int | None,
+        *,
+        steps: list[StepResult] | None = None,
+    ) -> AssertionResult:
+        names = "none" if steps is None else ",".join(step.name for step in steps)
+        return AssertionResult(assertion.get("name", self.name), True, names)
+
+
+def _config_with(**assertions: type) -> tuple[VerifierConfig, str]:
+    module = types.ModuleType("termproof_step_screen_fixture")
+    for attribute, member in assertions.items():
+        setattr(module, attribute, member)
+    sys.modules[module.__name__] = module
+    config = VerifierConfig.builtin()
+    mapping = dict(config.assertions)
+    for attribute, member in assertions.items():
+        mapping[member.name] = f"{module.__name__}:{attribute}"
+    return replace(config, assertions=mapping), module.__name__
+
+
+class StepScreenContainsTest(unittest.TestCase):
+    def test_reads_the_screen_of_the_named_step(self) -> None:
+        result = StepScreenContains().evaluate(
+            _recipe(),
+            {"type": "step_screen_contains", "step": "open", "value": "palette"},
+            "final screen",
+            "",
+            0,
+            steps=_steps(("open", "the palette is open"), ("close", "final screen")),
+        )
+        self.assertTrue(result.passed)
+
+    def test_fails_when_the_named_step_screen_lacks_the_value(self) -> None:
+        result = StepScreenContains().evaluate(
+            _recipe(),
+            {"type": "step_screen_contains", "step": "close", "value": "palette"},
+            "final screen",
+            "",
+            0,
+            steps=_steps(("open", "the palette is open"), ("close", "final screen")),
+        )
+        self.assertFalse(result.passed)
+        self.assertEqual("screen after 'close' contains 'palette'", result.detail)
+
+    def test_matches_the_first_step_sharing_a_name(self) -> None:
+        """Duplicate step names resolve to the first, as the recipe format says."""
+        steps = _steps(("retry", "first attempt"), ("retry", "second attempt"))
+        first = StepScreenContains().evaluate(
+            _recipe(),
+            {"type": "step_screen_contains", "step": "retry", "value": "first"},
+            "final screen",
+            "",
+            0,
+            steps=steps,
+        )
+        last = StepScreenContains().evaluate(
+            _recipe(),
+            {"type": "step_screen_contains", "step": "retry", "value": "second"},
+            "final screen",
+            "",
+            0,
+            steps=steps,
+        )
+        self.assertTrue(first.passed)
+        self.assertFalse(last.passed)
+
+    def test_reports_the_steps_that_ran_when_the_name_does_not_match(self) -> None:
+        result = StepScreenContains().evaluate(
+            _recipe(),
+            {"type": "step_screen_contains", "step": "typo", "value": "palette"},
+            "final screen",
+            "",
+            0,
+            steps=_steps(("open", "the palette is open")),
+        )
+        self.assertFalse(result.passed)
+        self.assertIn("no step named 'typo'", result.detail)
+        self.assertIn("'open'", result.detail)
+
+    def test_reports_when_per_step_screens_were_not_supplied(self) -> None:
+        result = StepScreenContains().evaluate(
+            _recipe(),
+            {"type": "step_screen_contains", "step": "open", "value": "palette"},
+            "final screen",
+            "",
+            0,
+        )
+        self.assertFalse(result.passed)
+        self.assertIn("not supplied", result.detail)
+
+    def test_custom_name_is_used_for_the_result(self) -> None:
+        result = StepScreenContains().evaluate(
+            _recipe(),
+            {
+                "type": "step_screen_contains",
+                "name": "palette opened",
+                "step": "open",
+                "value": "palette",
+            },
+            "",
+            "",
+            0,
+            steps=_steps(("open", "the palette is open")),
+        )
+        self.assertEqual("palette opened", result.name)
+
+    def test_registered_as_a_builtin(self) -> None:
+        runner = VerificationRunner()
+        self.assertIn("step_screen_contains", runner.assertion_registry.names())
+
+
+class EvaluateAssertionsDispatchTest(unittest.TestCase):
+    """Which assertions the runner hands ``steps`` to, and which it does not."""
+
+    def _runner(self, **assertions: type) -> VerificationRunner:
+        config, module_name = _config_with(**assertions)
+        self.addCleanup(sys.modules.pop, module_name, None)
+        return VerificationRunner(config=config)
+
+    def test_legacy_assertion_is_called_with_the_original_signature(self) -> None:
+        runner = self._runner(LegacyAssertion=LegacyAssertion)
+        results = runner.evaluate_assertions(
+            _recipe(assertions=[{"type": "legacy_probe"}], expect_exit_code=None),
+            "final",
+            "",
+            0,
+            steps=_steps(("open", "mid")),
+        )
+        self.assertEqual(["saw final screen 'final'"], [r.detail for r in results])
+
+    def test_forwarding_assertion_does_not_receive_steps(self) -> None:
+        runner = self._runner(ForwardingAssertion=ForwardingAssertion)
+        results = runner.evaluate_assertions(
+            _recipe(assertions=[{"type": "forwarding_probe"}], expect_exit_code=None),
+            "final",
+            "",
+            0,
+            steps=_steps(("open", "mid")),
+        )
+        self.assertEqual(["saw final screen 'final'"], [r.detail for r in results])
+
+    def test_step_aware_assertion_receives_steps(self) -> None:
+        runner = self._runner(StepAwareAssertion=StepAwareAssertion)
+        results = runner.evaluate_assertions(
+            _recipe(assertions=[{"type": "step_aware_probe"}], expect_exit_code=None),
+            "final",
+            "",
+            0,
+            steps=_steps(("open", "mid"), ("close", "final")),
+        )
+        self.assertEqual(["open,close"], [r.detail for r in results])
+
+    def test_caller_that_omits_steps_yields_none(self) -> None:
+        """An execution mode written against 0.2.1 calls with four arguments."""
+        runner = self._runner(StepAwareAssertion=StepAwareAssertion)
+        results = runner.evaluate_assertions(
+            _recipe(assertions=[{"type": "step_aware_probe"}], expect_exit_code=None),
+            "final",
+            "",
+            0,
+        )
+        self.assertEqual(["none"], [r.detail for r in results])
+
+    def test_deprecated_private_alias_threads_steps(self) -> None:
+        runner = self._runner(StepAwareAssertion=StepAwareAssertion)
+        results = runner._evaluate_assertions(
+            _recipe(assertions=[{"type": "step_aware_probe"}], expect_exit_code=None),
+            "final",
+            "",
+            0,
+            steps=_steps(("open", "mid")),
+        )
+        self.assertEqual(["open"], [r.detail for r in results])
+
+
+# A target that shows one screen, then clears it and shows another, so the
+# intermediate state is genuinely absent from the final screen.
+_TWO_SCREENS = textwrap.dedent(
+    """
+    import sys, time
+    sys.stdout.write("PALETTE OPEN\\n")
+    sys.stdout.flush()
+    time.sleep(0.4)
+    sys.stdout.write("\\x1b[2J\\x1b[HSAVED\\n")
+    sys.stdout.flush()
+    time.sleep(0.4)
+    """
+)
+
+
+class StepScreenEndToEndTest(unittest.TestCase):
+    """The wiring, exercised through a real run rather than a direct call."""
+
+    def _recipe(self, assertions: list[dict[str, Any]]) -> Recipe:
+        return Recipe(
+            name="two-screens",
+            command=CommandSpec(argv=[sys.executable, "-c", _TWO_SCREENS]),
+            steps=[
+                {
+                    "name": "open palette",
+                    "action": "wait_for_text",
+                    "text": "PALETTE OPEN",
+                    "timeout_seconds": 5,
+                },
+                {
+                    "name": "save",
+                    "action": "wait_for_text",
+                    "text": "SAVED",
+                    "timeout_seconds": 5,
+                },
+            ],
+            assertions=assertions,
+            expect_exit_code=None,
+        )
+
+    def _run(self, assertions: list[dict[str, Any]]) -> dict[str, bool]:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = VerificationRunner().run(
+                self._recipe(assertions), Path(tmp), render_video=False
+            )
+        return {assertion.name: assertion.passed for assertion in result.assertions}
+
+    def test_intermediate_screen_is_assertable_and_the_final_one_is_not(self) -> None:
+        outcome = self._run(
+            [
+                {
+                    "type": "step_screen_contains",
+                    "name": "palette was open",
+                    "step": "open palette",
+                    "value": "PALETTE OPEN",
+                },
+                {
+                    "type": "screen_contains",
+                    "name": "final screen still shows the palette",
+                    "value": "PALETTE OPEN",
+                },
+                {
+                    "type": "screen_contains",
+                    "name": "final screen shows the save",
+                    "value": "SAVED",
+                },
+            ]
+        )
+        self.assertTrue(outcome["palette was open"])
+        self.assertFalse(outcome["final screen still shows the palette"])
+        self.assertTrue(outcome["final screen shows the save"])
+
+    def test_process_mode_also_supplies_step_screens(self) -> None:
+        recipe = replace(
+            self._recipe(
+                [
+                    {
+                        "type": "step_screen_contains",
+                        "name": "palette was open",
+                        "step": "open palette",
+                        "value": "PALETTE OPEN",
+                    }
+                ]
+            ),
+            command=CommandSpec(argv=[sys.executable, "-c", _TWO_SCREENS], pty=False),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result = VerificationRunner().run(recipe, Path(tmp), render_video=False)
+        outcome = {a.name: a.passed for a in result.assertions}
+        self.assertTrue(outcome["palette was open"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

`AssertionType.evaluate()` only ever received the **final** screen, so a whole class of
assertion was inexpressible: anything about a state the run passes through and then
leaves. "The palette was dismissed" needs the screen right after Escape, not the last one.

The data already existed and was already in scope — `StepResult` carries a per-step
`screen`, and the scripted execution modes destructured `steps` and then simply did not
pass it on. This threads it through.

## What changed

- **`StepAwareAssertionType`**, a ninth protocol in `termproof/protocols.py`, sitting
  beside `AssertionType` rather than replacing it. `AssertionType` is byte-identical.
- **`steps` threaded** through `VerificationRunner.evaluate_assertions` and assertion
  evaluation, keyword-only with a default of `None`.
- **`step_screen_contains`** built-in — takes a `step` name and a `value` substring and
  reads that step's screen.
- **`StepScreenMatches`** worked example (regex against a named step's screen) in
  `plugin-template/`, plus a rewrite of `plugin-template/docs/protocol.md`, which
  previously stated per-step screens were unavailable.
- Docs: `docs/plugin-protocols.md`, `docs/recipe-format-v1.md`, `README.md`, `CHANGELOG.md`.
- The shipped `examples/generic` recipe asserts on an intermediate screen, so the
  end-to-end smoke exercises the new path on every run.

No version bump — this sits under `[Unreleased]`, matching how 0.2.1 was cut.

## Backwards compatibility is the point

**A plugin written against 0.2.1 keeps working untouched** — not with a deprecation
warning, untouched. The mechanism:

- TermProof passes `steps` only to an `evaluate` that **declares a parameter of that
  name**, the same shape of opt-in as `from_config` on evidence plugins. An assertion
  written against `AssertionType` is still called with the original five arguments.
- **A bare `**kwargs` deliberately does not count as opting in.** An assertion that
  forwards unrecognised arguments to another one written against the older signature
  would break if we passed `steps` into it, so declaring the parameter is the whole
  opt-in and nothing else is.
- `steps` is keyword-only with a default of `None`, so a step-aware assertion also runs
  unchanged on a TermProof that never passes it.
- `None` means the execution mode supplied no per-step screens, which is **not** the same
  as a run in which no step ran. `step_screen_contains` reports that rather than
  pretending the screen was empty.

`AgentDrivenMode` is deliberately untouched: it builds its assertions outside the
assertion registry and never reaches this dispatch.

## What review already found and fixed

An automated review round on an earlier revision of this branch raised three findings.
Two were accepted and are already folded into this commit:

1. **A failing `step_screen_contains` did not name the step it read** — it emitted a bare
   `contains 'X'`, which is the feature falling short of its own value. The detail now
   reads `screen after 'wait for dashboard' contains 'DASHBOARD READY'`. The `detail`
   override and both error-path details are unchanged.
2. **Duplicate step names were undocumented** — `step` resolves to the first match.
   `docs/recipe-format-v1.md` now says so and advises keeping asserted-on step names
   unique. Docs only; no behaviour change.

The third finding was pre-existing drift that the finding itself scoped out of this
change, and belongs in a separate PR.

The validation pipeline could not run to completion on this branch for environment
reasons unrelated to the code, so the checks below were run by hand.

## Verified by hand

| Check | Result |
|---|---|
| `python -m unittest discover -s tests` | 469 passed |
| plugin-template suite (`PYTHONPATH=plugin-template/src`) | 56 passed |
| `ruff check .` | clean |
| `mypy termproof` | clean, 35 source files |
| `plugin-template/scripts/check_config_wiring.py` | config wiring verified |
| `termproof run examples/generic --video` | 1/1 passed, video rendered |

The end-to-end run is the one that matters here — unit tests would not catch a protocol
change that breaks the actual runner wiring. Its `result.json` shows the new assertion
passing against a mid-run screen:

```
True | dashboard was on screen mid-run | screen after 'wait for dashboard' contains 'DASHBOARD READY'
```

Both new tests were **mutation-checked**, not just observed green: a `reversed(steps)`
implementation fails the first-match test, and stripping the step name out of the detail
fails the failure-detail assertion.

The acceptance test for the whole change lives in `tests/test_step_screen_assertions.py`:
a `LegacyAssertion` written against the verbatim 0.2.1 five-argument signature and never
updated, a `ForwardingAssertion` that wraps it with `*args, **kwargs` (proving `**kwargs`
must not opt in), and a `StepAwareAssertion`, all evaluated through the real runner in the
same run.

## Coordination

An independent change adding an `ArtifactPublisher` protocol touches
`termproof/protocols.py` and `plugin-template/docs/protocol.md` as well. Both are
additive and land in different parts of those files; this one avoids restructuring
either.
