### PR TITLE
feat(protocols): add an ArtifactPublisher plugin protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           uv pip install --python plugin-template/.pkg-test/bin/python --no-deps plugin-template/dist/*.whl
           plugin-template/.pkg-test/bin/python -c "
           import termproof_my_plugin
-          expected = {'JsonSummaryReporter', 'ScreenCount', 'WaitForRegex'}
+          expected = {'JsonSummaryReporter', 'ScreenCount', 'WaitForRegex', 'MyStore'}
           actual = set(termproof_my_plugin.__all__)
           assert actual == expected, f'__all__ mismatch: {actual} != {expected}'
           print('__all__ verified:', termproof_my_plugin.__all__)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   binary that exists — previously any commit at all was enough, including the
   working tree's, which says nothing about what was tested.
 - **`asciinema` is now an optional extra, `termproof[record]`.** See Changed.
+- **An `ArtifactPublisher` plugin protocol.** Where evidence goes is now an
+  extension point like every other part of the pipeline, registered under the
+  `artifact_publishers` config key and selected by name. A publisher implements
+  `publish(source, key) -> PublishedArtifact`: the caller decides the key layout,
+  because that is the shape of the evidence rather than a property of any store,
+  and the publisher maps the key onto its own namespace and onto a public URL.
+  The result is a record rather than a bare URL because publishing is not the
+  last step — reports link evidence by local path, so rewriting those links
+  needs the source and the URL together, which `url_map_from_published` builds.
+  A publisher reports `published=False` when it did not transfer the bytes and
+  an empty `url` when it did but cannot address them, so neither has to be an
+  exception. The existing S3/R2 path is the first implementation
+  (`termproof.evidence_publish:S3ArtifactPublisher`, registered as `s3`) rather
+  than a parallel special case, and `publish-videos` gained `--publisher` to
+  select another one. Publishing behaviour is unchanged: same keys, same URLs,
+  same report rewriting, same failure when neither the AWS CLI nor boto3 is
+  installed. Deployment settings reach a publisher through an optional
+  `from_target` classmethod, mirroring `from_config` for renderers, so
+  credentials stay out of the checked-in config file. See
+  `docs/plugin-protocols.md`.
 - **An `evidence:` block in `.termproof/config.yaml`.** The SVG and PNG
   renderers and the video pipeline no longer hardcode their rendering
   parameters: `evidence.svg` (character width, line height, padding, font size

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,12 +83,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   needs the source and the URL together, which `url_map_from_published` builds.
   A publisher reports `published=False` when it did not transfer the bytes and
   an empty `url` when it did but cannot address them, so neither has to be an
-  exception. The existing S3/R2 path is the first implementation
+  exception. Neither is treated as a success either: only an artifact that is
+  both published and addressable is rewritten into a report, `publish-videos`
+  reports each declined artifact with its `detail`, records only what was stored
+  in `video-manifest.json`, and exits non-zero when a batch was offered and
+  nothing was stored. The existing S3/R2 path is the first implementation
   (`termproof.evidence_publish:S3ArtifactPublisher`, registered as `s3`) rather
   than a parallel special case, and `publish-videos` gained `--publisher` to
-  select another one. Publishing behaviour is unchanged: same keys, same URLs,
-  same report rewriting, same failure when neither the AWS CLI nor boto3 is
-  installed. Deployment settings reach a publisher through an optional
+  select another one; `--bucket` is a precondition of that publisher rather than
+  of publishing, so another one may run without it. Publishing behaviour is
+  unchanged: same keys, same URLs, same report rewriting, same failure when
+  neither the AWS CLI nor boto3 is installed. A configured publisher is imported
+  when it is asked for rather than when a runner is built, so a store that
+  nothing publishes to cannot break an ordinary run. Deployment settings reach a
+  publisher through an optional
   `from_target` classmethod, mirroring `from_config` for renderers, so
   credentials stay out of the checked-in config file. See
   `docs/plugin-protocols.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exception. Neither is treated as a success either: only an artifact that is
   both published and addressable is rewritten into a report, `publish-videos`
   reports each declined artifact with its `detail`, records only what was stored
-  in `video-manifest.json`, and exits non-zero when a batch was offered and
-  nothing was stored. The existing S3/R2 path is the first implementation
+  in `video-manifest.json`, and exits non-zero if anything was declined — a
+  batch that stored most of its evidence and quietly dropped the rest is the
+  same false success as one that stored none. Report links are rewritten to the
+  URLs the selected publisher reported rather than to a predicted S3 layout, so
+  no store's address scheme can speak for another, and `--dry-run` is refused by
+  a publisher that takes no target, since it would never see the flag and would
+  publish for real. The existing S3/R2 path is the first implementation
   (`termproof.evidence_publish:S3ArtifactPublisher`, registered as `s3`) rather
   than a parallel special case, and `publish-videos` gained `--publisher` to
   select another one; `--bucket` is a precondition of that publisher rather than

--- a/docs-site/api/index.md
+++ b/docs-site/api/index.md
@@ -24,5 +24,6 @@ Stable protocols cover:
 - `VideoBackend`
 - `AgentRunner`
 - `SessionBackend`
+- `ArtifactPublisher`
 
 See `docs/plugin-protocols.md` for signatures and compatibility policy.

--- a/docs/plugin-protocols.md
+++ b/docs/plugin-protocols.md
@@ -102,6 +102,14 @@ The two failure shapes are distinct and both are reportable without raising:
 - `url=""` — the bytes were transferred but the publisher cannot name a public
   address for them, so a report link should keep pointing at the local file.
 
+Only an artifact that is both published and addressable is rewritten into a
+report, so neither failure shape can replace a working local path with a link
+that does not resolve. `publish-videos` reports every declined artifact with its
+`detail`, records only what was stored in `video-manifest.json`, and exits
+non-zero when a batch was offered and nothing was stored — a store that declines
+without raising must not read as a successful publish. A dry run is not a
+decline: it names URLs without moving bytes and still succeeds.
+
 A publisher may define a `from_target(cls, target: PublishTarget) -> Self`
 classmethod to receive the bucket, endpoint, public base URL and dry-run flag
 supplied at publish time — the same opt-in pattern `from_config` uses for

--- a/docs/plugin-protocols.md
+++ b/docs/plugin-protocols.md
@@ -14,8 +14,9 @@ TermProof exposes stable plugin protocols from `termproof.protocols`.
 | `VideoBackend` | `render(cast_path, output_path, fps) -> None` |
 | `AgentRunner` | `run(recipe, prompt, run_dir) -> AgentOutcome` |
 | `SessionBackend` | `create_session(argv, cast_path, cwd, env, cols, rows) -> TerminalSession` |
+| `ArtifactPublisher` | `publish(source, key) -> PublishedArtifact` |
 
-`StepAction`, `AssertionType`, `ExecutionMode`, `Reporter`, `ScreenRenderer`, and `VideoBackend` also require a `name: str` class attribute. `AgentRunner` and `SessionBackend` are selected by config keys and do not require a `name`.
+`StepAction`, `AssertionType`, `ExecutionMode`, `Reporter`, `ScreenRenderer`, `VideoBackend`, and `ArtifactPublisher` also require a `name: str` class attribute. `AgentRunner` and `SessionBackend` are selected by config keys and do not require a `name`.
 
 `ScreenRenderer` plugins can optionally set `extension = "png"` (or another file extension) so evidence artifacts use that screenshot filename suffix.
 
@@ -61,6 +62,57 @@ the README). Plugins without it keep being constructed with no arguments.
 `EvidenceConfig`, and the narrower `SvgRenderConfig`, `PngRenderConfig`, and
 `VideoConfig` its sections hold, are exported from `termproof.protocols`
 alongside the protocols themselves.
+
+## ArtifactPublisher
+
+An `ArtifactPublisher` decides where evidence goes once a run has produced it.
+It is registered under the `artifact_publishers` config key and selected by
+name; `s3` (`termproof.evidence_publish:S3ArtifactPublisher`) ships as the
+built-in implementation and publishes to any S3-compatible bucket.
+
+```python
+from pathlib import Path
+
+from termproof.protocols import ArtifactPublisher, PublishedArtifact
+
+
+class MyPublisher:
+    name = "my_store"
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        url = upload_somehow(source, key)
+        return PublishedArtifact(source=source, key=key, url=url)
+```
+
+`key` is the destination-relative identifier the caller has chosen. The layout
+of published evidence is the caller's policy, so a publisher should map a key
+onto its own namespace rather than invent one.
+
+`PublishedArtifact` carries `source`, `key`, `url`, `published` and `detail`.
+The result is a record rather than a bare URL string because publishing is not
+the last step: reports reference evidence by local path, so rewriting those
+links needs `source` and `url` together. `termproof.evidence_publish` exposes
+`url_map_from_published(published)` to turn a batch of results into the
+local-path-to-URL map that `rewrite_report_video_links` consumes.
+
+The two failure shapes are distinct and both are reportable without raising:
+
+- `published=False` — the bytes were not transferred (a dry run, an artifact
+  the store does not accept). `detail` says why.
+- `url=""` — the bytes were transferred but the publisher cannot name a public
+  address for them, so a report link should keep pointing at the local file.
+
+A publisher may define a `from_target(cls, target: PublishTarget) -> Self`
+classmethod to receive the bucket, endpoint, public base URL and dry-run flag
+supplied at publish time — the same opt-in pattern `from_config` uses for
+renderers. Deployment credentials are passed this way rather than read from
+`.termproof/config.yaml`, which is checked in. Publishers without it are
+constructed with no arguments.
+
+Because a publisher is an ordinary object returning ordinary results, publishers
+compose: a wrapper that tries one publisher, falls back to a second, and records
+the degradation in `detail` is a plain implementation of the same protocol.
+TermProof does not ship one.
 
 ## ExecutionMode runner surface
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Community plugins
 
-TermProof is extensible via a plugin registry: steps, assertions, session backends, video backends, reporters, execution modes, and agent runners. This directory lists community-provided plugins.
+TermProof is extensible via a plugin registry: steps, assertions, session backends, video backends, reporters, execution modes, agent runners, and artifact publishers. This directory lists community-provided plugins.
 
 ## What counts as a plugin?
 
@@ -15,6 +15,8 @@ assertions:
 session_backend: my_org.termproof_session:DockerSessionBackend
 reporters:
   junit_xml: my_org.termproof_reporters:JunitReporter
+artifact_publishers:
+  my_store: my_org.termproof_publishers:MyStorePublisher
 ```
 
 See [`plugin-protocols.md`](plugin-protocols.md) for the stable protocol contract and `termproof/config.py` for built-ins.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -138,7 +138,11 @@ The upload itself goes through the `ArtifactPublisher` protocol. `s3` is the
 default and is what the table above configures; `--publisher <name>` (or
 `TERM_PROOF_ARTIFACT_PUBLISHER`) selects any other publisher registered under
 `artifact_publishers` in `.termproof/config.yaml`, which is how evidence is sent
-to a store that is not S3-compatible. See `docs/plugin-protocols.md`.
+to a store that is not S3-compatible. `--bucket` is a precondition of the `s3`
+publisher rather than of publishing, so another publisher is free to run without
+it. Whichever publisher runs, the manifest and the count record what was
+actually stored, and a batch where nothing was stored exits non-zero. See
+`docs/plugin-protocols.md`.
 
 The PR comment (`termproof.ci_evidence comment`) accepts `--video-base-url` and
 rewrites video links the same way it rewrites screenshot links. When

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -141,7 +141,13 @@ default and is what the table above configures; `--publisher <name>` (or
 to a store that is not S3-compatible. `--bucket` is a precondition of the `s3`
 publisher rather than of publishing, so another publisher is free to run without
 it. Whichever publisher runs, the manifest and the count record what was
-actually stored, and a batch where nothing was stored exits non-zero. See
+actually stored, any declined artifact is reported with its `detail`, and the
+command exits non-zero if anything was declined — a partial publish is a failed
+publish, not a smaller success. Report links are rewritten to the URLs the
+publisher itself reported, so a store that maps keys into its own namespace, or
+that stores bytes it cannot address, is never credited with a link it would not
+serve. `--dry-run` is refused by a publisher that takes no target, because such
+a publisher never sees the flag and would publish for real. See
 `docs/plugin-protocols.md`.
 
 The PR comment (`termproof.ci_evidence comment`) accepts `--video-base-url` and

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -134,6 +134,12 @@ What happens when publishing:
 3. When `--video-base-url` is set, `report.md` / `latest-report.md` links for
    `session.mp4` are rewritten to `{base_url}/pr/{pr}/{run}/{scope}/...`.
 
+The upload itself goes through the `ArtifactPublisher` protocol. `s3` is the
+default and is what the table above configures; `--publisher <name>` (or
+`TERM_PROOF_ARTIFACT_PUBLISHER`) selects any other publisher registered under
+`artifact_publishers` in `.termproof/config.yaml`, which is how evidence is sent
+to a store that is not S3-compatible. See `docs/plugin-protocols.md`.
+
 The PR comment (`termproof.ci_evidence comment`) accepts `--video-base-url` and
 rewrites video links the same way it rewrites screenshot links. When
 `TERM_PROOF_VIDEO_BASE_URL` is set in CI, the existing screenshot flow needs no

--- a/plugin-template/.github/workflows/ci.yml
+++ b/plugin-template/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           .pkg-test/bin/pip install dist/*.whl
           .pkg-test/bin/python -c "
           import termproof_my_plugin
-          expected = {'JsonSummaryReporter', 'ScreenCount', 'WaitForRegex'}
+          expected = {'JsonSummaryReporter', 'ScreenCount', 'WaitForRegex', 'MyStore'}
           actual = set(termproof_my_plugin.__all__)
           assert actual == expected, f'__all__ mismatch: {actual} != {expected}'
           print('__all__ verified:', termproof_my_plugin.__all__)

--- a/plugin-template/docs/protocol.md
+++ b/plugin-template/docs/protocol.md
@@ -46,7 +46,9 @@ did but cannot name a public address for them; neither has to raise.
 Deployment settings (bucket, endpoint, public base URL, dry-run) arrive through
 an optional `from_target(cls, target)` classmethod rather than from
 `.termproof/config.yaml`, since that file is checked in. Publishers without it
-are constructed with no arguments.
+are constructed with no arguments. A publisher that takes a target has to honour
+`dry_run`: name the URL the artifact would get, report `published=False`, and
+move nothing.
 
 Publishers compose, because a publisher is just an object returning results: a
 wrapper that tries one store, falls back to another and records the degradation

--- a/plugin-template/docs/protocol.md
+++ b/plugin-template/docs/protocol.md
@@ -12,6 +12,7 @@
 | Session backend | session_backend | my_plugin.session:DockerBackend |
 | Execution mode | execution_modes | my_plugin.modes:MyMode |
 | Agent runner | agent_runners | my_plugin.agents:MyRunner |
+| Artifact publisher | artifact_publishers | my_plugin.publishers:MyStore |
 
 Import protocols from `termproof.protocols`. Older module locations still re-export the same protocol objects for compatibility.
 
@@ -25,8 +26,32 @@ Most protocols require a `name` class attribute and a single method:
 - SessionBackend: create_session(argv, cast_path, cwd, env, cols, rows) -> TerminalSession
 - ExecutionMode: execute(runner, recipe, run_dir) -> (steps, assertions, raw_output, exit_code, screen)
 - AgentRunner: run(recipe, prompt, run_dir) -> AgentOutcome
+- ArtifactPublisher: publish(source, key) -> PublishedArtifact
 
 AgentRunner and SessionBackend are selected by config keys and do not require a `name`.
+
+## Publishing evidence
+
+An ArtifactPublisher decides where evidence goes after a run. `key` is the
+destination-relative identifier the caller has chosen, so a publisher maps that
+key onto its own namespace instead of inventing a layout.
+
+`PublishedArtifact(source, key, url="", published=True, detail="")` is a record
+rather than a bare URL because reports link evidence by local path: rewriting
+those links needs `source` and `url` together, which is what
+`termproof.evidence_publish.url_map_from_published` builds. A publisher reports
+`published=False` when it did not transfer the bytes, and an empty `url` when it
+did but cannot name a public address for them; neither has to raise.
+
+Deployment settings (bucket, endpoint, public base URL, dry-run) arrive through
+an optional `from_target(cls, target)` classmethod rather than from
+`.termproof/config.yaml`, since that file is checked in. Publishers without it
+are constructed with no arguments.
+
+Publishers compose, because a publisher is just an object returning results: a
+wrapper that tries one store, falls back to another and records the degradation
+in `detail` is a plain implementation of the same protocol. TermProof does not
+ship one.
 
 ## Context availability for assertions
 

--- a/plugin-template/examples/.termproof/config.yaml
+++ b/plugin-template/examples/.termproof/config.yaml
@@ -4,3 +4,5 @@ assertions:
   screen_count: termproof_my_plugin.assertions:ScreenCount
 reporters:
   json_summary: termproof_my_plugin.reporters:JsonSummaryReporter
+artifact_publishers:
+  my_store: termproof_my_plugin.publishers:MyStore

--- a/plugin-template/src/termproof_my_plugin/__init__.py
+++ b/plugin-template/src/termproof_my_plugin/__init__.py
@@ -1,11 +1,13 @@
-"""Example TermProof plugin providing custom step, assertion, and reporter."""
+"""Example TermProof plugin providing custom step, assertion, reporter, and publisher."""
 
 from .assertions import ScreenCount
+from .publishers import MyStore
 from .reporters import JsonSummaryReporter
 from .steps import WaitForRegex
 
 __all__ = [
     "JsonSummaryReporter",
+    "MyStore",
     "ScreenCount",
     "WaitForRegex",
 ]

--- a/plugin-template/src/termproof_my_plugin/publishers.py
+++ b/plugin-template/src/termproof_my_plugin/publishers.py
@@ -1,0 +1,66 @@
+"""Example custom artifact publisher for TermProof.
+
+Implements a publisher that copies evidence into a local directory tree and
+serves it under a base URL. Register it in config:
+
+.. code-block:: yaml
+
+   artifact_publishers:
+     my_store: termproof_my_plugin.publishers:MyStore
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from termproof.evidence_publish import PublishTarget
+from termproof.models import PublishedArtifact
+
+
+class MyStore:
+    """Copy evidence into a directory that is served over HTTP.
+
+    CLI usage::
+
+        python -m termproof.evidence_publish publish-videos \\
+            --base-dir .termproof/pr-base --head-dir .termproof/ci \\
+            --publisher my_store --video-base-url https://evidence.example
+
+    Protocol compatibility:
+    - Requires a TermProof with the ``artifact_publishers`` config key
+    - ``name`` attribute must match config ``artifact_publishers`` key
+    - ``publish(source, key) -> PublishedArtifact`` required
+    - ``from_target(target)`` is optional; without it the publisher is
+      constructed with no arguments
+    """
+
+    name = "my_store"
+
+    def __init__(self, root: Path = Path("published"), base_url: str = "") -> None:
+        self.root = root
+        self.base_url = base_url.rstrip("/")
+
+    @classmethod
+    def from_target(cls, target: PublishTarget) -> MyStore:
+        # ``bucket`` names the destination; this store reads it as a directory.
+        return cls(
+            root=Path(target.bucket or "published"),
+            base_url=target.base_url,
+        )
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        if not source.is_file():
+            return PublishedArtifact(
+                source=source,
+                key=key,
+                published=False,
+                detail=f"no such file: {source}",
+            )
+        destination = self.root / key
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        # An empty base URL means the bytes are stored but not addressable, so
+        # reports keep pointing at the local file rather than a broken link.
+        url = f"{self.base_url}/{key}" if self.base_url else ""
+        return PublishedArtifact(source=source, key=key, url=url)

--- a/plugin-template/src/termproof_my_plugin/publishers.py
+++ b/plugin-template/src/termproof_my_plugin/publishers.py
@@ -37,9 +37,10 @@ class MyStore:
 
     name = "my_store"
 
-    def __init__(self, root: Path = Path("published"), base_url: str = "") -> None:
+    def __init__(self, root: Path = Path("published"), base_url: str = "", dry_run: bool = False) -> None:
         self.root = root
         self.base_url = base_url.rstrip("/")
+        self.dry_run = dry_run
 
     @classmethod
     def from_target(cls, target: PublishTarget) -> MyStore:
@@ -47,6 +48,7 @@ class MyStore:
         return cls(
             root=Path(target.bucket or "published"),
             base_url=target.base_url,
+            dry_run=target.dry_run,
         )
 
     def publish(self, source: Path, key: str) -> PublishedArtifact:
@@ -57,10 +59,19 @@ class MyStore:
                 published=False,
                 detail=f"no such file: {source}",
             )
-        destination = self.root / key
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source, destination)
         # An empty base URL means the bytes are stored but not addressable, so
         # reports keep pointing at the local file rather than a broken link.
         url = f"{self.base_url}/{key}" if self.base_url else ""
+        # A dry run names where the artifact would land without storing it.
+        if self.dry_run:
+            return PublishedArtifact(
+                source=source,
+                key=key,
+                url=url,
+                published=False,
+                detail="dry run: not uploaded",
+            )
+        destination = self.root / key
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
         return PublishedArtifact(source=source, key=key, url=url)

--- a/plugin-template/tests/test_config_wiring.py
+++ b/plugin-template/tests/test_config_wiring.py
@@ -22,6 +22,8 @@ class PluginConfigWiringTest(unittest.TestCase):
                   screen_count: termproof_my_plugin.assertions:ScreenCount
                 reporters:
                   json_summary: termproof_my_plugin.reporters:JsonSummaryReporter
+                artifact_publishers:
+                  my_store: termproof_my_plugin.publishers:MyStore
                 """),
                 encoding="utf-8",
             )
@@ -29,6 +31,7 @@ class PluginConfigWiringTest(unittest.TestCase):
             self.assertIn("wait_for_regex", cfg.steps)
             self.assertIn("screen_count", cfg.assertions)
             self.assertIn("json_summary", cfg.reporters)
+            self.assertIn("my_store", cfg.artifact_publishers)
 
             from termproof.runner import VerificationRunner
 
@@ -36,6 +39,7 @@ class PluginConfigWiringTest(unittest.TestCase):
             self.assertIn("wait_for_regex", runner.step_registry.names())
             self.assertIn("screen_count", runner.assertion_registry.names())
             self.assertIn("json_summary", runner.reporter_registry.names())
+            self.assertIn("my_store", runner.artifact_publisher_registry.names())
 
 
 if __name__ == "__main__":

--- a/plugin-template/tests/test_config_wiring.py
+++ b/plugin-template/tests/test_config_wiring.py
@@ -39,7 +39,12 @@ class PluginConfigWiringTest(unittest.TestCase):
             self.assertIn("wait_for_regex", runner.step_registry.names())
             self.assertIn("screen_count", runner.assertion_registry.names())
             self.assertIn("json_summary", runner.reporter_registry.names())
+            # Publishers are resolved on demand rather than at construction, so
+            # a store nothing publishes to cannot break an ordinary run.
             self.assertIn("my_store", runner.artifact_publisher_registry.names())
+            from termproof_my_plugin.publishers import MyStore
+
+            self.assertIsInstance(runner.artifact_publisher_registry.get("my_store"), MyStore)
 
 
 if __name__ == "__main__":

--- a/plugin-template/tests/test_publisher.py
+++ b/plugin-template/tests/test_publisher.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from termproof_my_plugin.publishers import MyStore
+
+from termproof.evidence_publish import PublishTarget, url_map_from_published
+
+
+class MyStorePublisherTest(unittest.TestCase):
+    def test_publish_copies_the_file_and_names_its_url(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "session.mp4"
+            source.write_bytes(b"video")
+            store = MyStore.from_target(
+                PublishTarget(bucket=str(root / "store"), base_url="https://evidence.example/")
+            )
+
+            published = store.publish(source, "pr/7/head/session.mp4")
+
+            self.assertTrue(published.published)
+            self.assertEqual("https://evidence.example/pr/7/head/session.mp4", published.url)
+            self.assertEqual(b"video", (root / "store" / "pr/7/head/session.mp4").read_bytes())
+
+    def test_publish_reports_a_missing_file_without_raising(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = MyStore(root=Path(tmp) / "store")
+
+            published = store.publish(Path(tmp) / "absent.mp4", "key")
+
+            self.assertFalse(published.published)
+            self.assertIn("no such file", published.detail)
+
+    def test_unaddressable_artifacts_are_left_out_of_the_url_map(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "session.mp4"
+            source.write_bytes(b"video")
+            store = MyStore(root=root / "store")
+
+            published = store.publish(source, "key")
+
+            self.assertTrue(published.published)
+            self.assertEqual({}, url_map_from_published([published]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin-template/tests/test_publisher.py
+++ b/plugin-template/tests/test_publisher.py
@@ -34,6 +34,26 @@ class MyStorePublisherTest(unittest.TestCase):
             self.assertFalse(published.published)
             self.assertIn("no such file", published.detail)
 
+    def test_dry_run_names_the_url_without_copying_anything(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "session.mp4"
+            source.write_bytes(b"video")
+            store = MyStore.from_target(
+                PublishTarget(
+                    bucket=str(root / "store"),
+                    base_url="https://evidence.example/",
+                    dry_run=True,
+                )
+            )
+
+            published = store.publish(source, "pr/7/head/session.mp4")
+
+            self.assertFalse(published.published)
+            self.assertEqual("dry run: not uploaded", published.detail)
+            self.assertEqual("https://evidence.example/pr/7/head/session.mp4", published.url)
+            self.assertFalse((root / "store").exists())
+
     def test_unaddressable_artifacts_are_left_out_of_the_url_map(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/termproof/__init__.py
+++ b/termproof/__init__.py
@@ -18,9 +18,17 @@ from .config import (
     VideoConfig,
     load_config,
 )
-from .models import AssertionResult, Recipe, RunResult, StepResult, load_recipe
+from .models import (
+    AssertionResult,
+    PublishedArtifact,
+    Recipe,
+    RunResult,
+    StepResult,
+    load_recipe,
+)
 from .protocols import (
     AgentRunner,
+    ArtifactPublisher,
     AssertionType,
     ExecutionMode,
     Reporter,
@@ -36,6 +44,7 @@ from .selection import select_names, select_recipes
 
 __all__ = [
     "AgentRunner",
+    "ArtifactPublisher",
     "AssertionResult",
     "AssertionType",
     "AttributedCell",
@@ -44,6 +53,7 @@ __all__ = [
     "EvidenceConfig",
     "ExecutionMode",
     "PngRenderConfig",
+    "PublishedArtifact",
     "Recipe",
     "Registry",
     "Reporter",

--- a/termproof/config.py
+++ b/termproof/config.py
@@ -56,6 +56,9 @@ BUILTIN_DEFAULTS: dict[str, Any] = {
         "agg_ffmpeg": "termproof.builtin_video:AggFfmpegBackend",
         "attributed_rsvg": "termproof.cast_video:RsvgFfmpegBackend",
     },
+    "artifact_publishers": {
+        "s3": "termproof.evidence_publish:S3ArtifactPublisher",
+    },
     "session_backend": "termproof.builtin_session:PexpectBackend",
     "docker": {
         "image": "",
@@ -207,6 +210,7 @@ class VerifierConfig:
     reporters: dict[str, str]
     screen_renderers: dict[str, str]
     video_backends: dict[str, str]
+    artifact_publishers: dict[str, str]
     session_backend: str
     docker: DockerBackendConfig
     defaults: GlobalDefaults
@@ -397,6 +401,7 @@ def _from_mapping(data: dict[str, Any]) -> VerifierConfig:
         reporters=dict(data.get("reporters", {})),
         screen_renderers=dict(data.get("screen_renderers", {})),
         video_backends=dict(data.get("video_backends", {})),
+        artifact_publishers=dict(data.get("artifact_publishers", {})),
         session_backend=str(data.get("session_backend", "")),
         docker=DockerBackendConfig(
             image=str(docker_raw.get("image", "")),

--- a/termproof/evidence_publish.py
+++ b/termproof/evidence_publish.py
@@ -187,6 +187,21 @@ class S3ArtifactPublisher:
         return PublishedArtifact(source=source, key=key, url=url)
 
 
+def artifact_publisher_class(name: str, config: VerifierConfig | None = None) -> type:
+    """Import the class configured for the publisher named ``name``.
+
+    Separate from :func:`resolve_artifact_publisher` so a caller can inspect
+    what a publisher supports — whether it accepts a target, and so whether it
+    can honour a dry run — before constructing one.
+    """
+    config = config or load_config()
+    qualname = config.artifact_publishers.get(name)
+    if qualname is None:
+        available = ", ".join(sorted(config.artifact_publishers))
+        raise KeyError(f"unknown artifact publisher {name!r}; available: {available}")
+    return import_class(qualname)
+
+
 def resolve_artifact_publisher(
     name: str,
     target: PublishTarget,
@@ -198,12 +213,7 @@ def resolve_artifact_publisher(
     same way renderers opt into evidence config with ``from_config``. One that
     does not is constructed with no arguments.
     """
-    config = config or load_config()
-    qualname = config.artifact_publishers.get(name)
-    if qualname is None:
-        available = ", ".join(sorted(config.artifact_publishers))
-        raise KeyError(f"unknown artifact publisher {name!r}; available: {available}")
-    cls = import_class(qualname)
+    cls = artifact_publisher_class(name, config)
     factory = getattr(cls, "from_target", None)
     return cls() if factory is None else factory(target)
 
@@ -213,7 +223,11 @@ def _hosted_url(base_url: str, key: str) -> str:
     return f"{base_url}/{quote(key, safe='/._-~')}" if base_url else ""
 
 
-def url_map_from_published(published: Iterable[PublishedArtifact]) -> dict[str, str]:
+def url_map_from_published(
+    published: Iterable[PublishedArtifact],
+    *,
+    include_unstored: bool = False,
+) -> dict[str, str]:
     """Map every published artifact's local path onto its hosted URL.
 
     Reports link evidence by local path, so this is the bridge between
@@ -221,10 +235,17 @@ def url_map_from_published(published: Iterable[PublishedArtifact]) -> dict[str, 
     both published and addressable is included: rewriting a link to an empty URL
     or to a URL whose bytes never arrived would break a report that currently
     points at a file the reader can still open.
+
+    ``include_unstored`` keeps artifacts the publisher declined but could still
+    name a URL for. That is the shape of a dry run, whose whole purpose is to
+    report where evidence would land without moving it, and it is the only case
+    where a link to bytes that are not there yet is what the caller asked for.
     """
     url_map: dict[str, str] = {}
     for artifact in published:
-        if not artifact.published or not artifact.url:
+        if not artifact.url:
+            continue
+        if not artifact.published and not include_unstored:
             continue
         for local in {str(artifact.source), artifact.source.as_posix()}:
             url_map[local] = artifact.url
@@ -393,6 +414,14 @@ def main(argv: list[str] | None = None) -> int:
         # Any other store states its own preconditions by refusing the target.
         if args.publisher == "s3" and not args.bucket and not args.dry_run:
             parser.error("--bucket is required (or set TERM_PROOF_VIDEO_BUCKET) unless --dry-run")
+        config = load_config()
+        # A publisher that takes no target never sees --dry-run, so honouring
+        # the flag would be a claim we cannot make: it would really transfer.
+        if args.dry_run and getattr(artifact_publisher_class(args.publisher, config), "from_target", None) is None:
+            parser.error(
+                f"--dry-run cannot be honoured by publisher {args.publisher!r}: "
+                "it takes no target, so it never sees the flag and would publish for real"
+            )
         publisher = resolve_artifact_publisher(
             args.publisher,
             PublishTarget(
@@ -401,6 +430,7 @@ def main(argv: list[str] | None = None) -> int:
                 base_url=args.video_base_url,
                 dry_run=args.dry_run,
             ),
+            config,
         )
         entries = _video_manifest_entries(
             args.base_dir,
@@ -410,34 +440,24 @@ def main(argv: list[str] | None = None) -> int:
             args.run_id,
         )
         published = [publisher.publish(Path(entry["source"]), entry["key"]) for entry in entries]
-        # A dry run declines every artifact by design, so nothing it reports is
-        # a failure; anything else the publisher declined is one, and the
-        # manifest records what was actually stored rather than what was offered.
-        declined = [] if args.dry_run else [artifact for artifact in published if not artifact.published]
-        stored = (
-            entries
-            if args.dry_run
-            else [entry for entry, artifact in zip(entries, published, strict=True) if artifact.published]
-        )
+        # Both lists come from what the publisher actually reported, never from
+        # what it was offered. A dry run declines everything by design, so its
+        # declines are not failures — which is exactly why one is refused above
+        # for a publisher that cannot see the flag: past that guard, an
+        # unstored artifact on a real publish is always a genuine refusal.
+        results = list(zip(entries, published, strict=True))
+        declined = [] if args.dry_run else [artifact for _, artifact in results if not artifact.published]
+        stored = [entry for entry, artifact in results if args.dry_run or artifact.published]
         if args.out is not None:
             root = args.out / "pr" / args.pr_number / args.run_id if args.pr_number and args.run_id else args.out
             root.mkdir(parents=True, exist_ok=True)
             (root / "video-manifest.json").write_text(json.dumps(stored, indent=2) + "\n", encoding="utf-8")
-        # Rewrite video links in reports for whatever the publisher could address.
-        # A dry run names URLs without moving bytes, so its map comes from the
-        # key layout rather than from results that report nothing as published.
-        url_map = (
-            build_video_url_map(
-                args.base_dir,
-                args.head_dir,
-                args.video_base_url,
-                pr_number=args.pr_number,
-                run_id=args.run_id,
-                prefix=args.prefix,
-            )
-            if args.dry_run
-            else url_map_from_published(published)
-        )
+        # Rewrite video links in reports for whatever the publisher could
+        # address, reading the URLs it reported rather than predicting them:
+        # only the store knows how a key maps onto an address, and a link one
+        # would never serve is worse in a report than no rewrite at all. A dry
+        # run reports where evidence would land, so its URLs count too.
+        url_map = url_map_from_published(published, include_unstored=args.dry_run)
         if url_map:
             for report_path in [
                 *args.base_dir.rglob("report.md"),
@@ -452,13 +472,18 @@ def main(argv: list[str] | None = None) -> int:
                         report_path.write_text(new_text, encoding="utf-8")
         for artifact in declined:
             print(f"not published: {artifact.source}" + (f" ({artifact.detail})" if artifact.detail else ""))
-        print(
-            f"{len(stored)} videos {'(dry-run) ' if args.dry_run else ''}published"
-            + (f" to s3://{args.bucket}/{args.prefix}" if args.bucket else "")
-        )
-        # Nothing stored out of something offered is a failed publish, not a
-        # successful publish of nothing.
-        return 1 if declined and not stored else 0
+        # Only the s3 publisher's destination has a scheme we can spell. Naming
+        # any other store's bucket as an s3 URL would report a location that
+        # does not exist, so name the publisher and let it own its addresses.
+        if args.publisher == "s3":
+            destination = f" to s3://{args.bucket}/{args.prefix}" if args.bucket else ""
+        else:
+            destination = f" via {args.publisher}"
+        print(f"{len(stored)} videos {'(dry-run) ' if args.dry_run else ''}published{destination}")
+        # Any refusal fails the command. A batch that stored most of its
+        # evidence and quietly dropped the rest is the same false success as
+        # one that stored none, only harder to notice.
+        return 1 if declined else 0
     raise AssertionError(args.command)
 
 

--- a/termproof/evidence_publish.py
+++ b/termproof/evidence_publish.py
@@ -5,8 +5,18 @@ import json
 import os
 import shutil
 import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import quote
+
+from .config import VerifierConfig, load_config
+from .models import PublishedArtifact
+from .registry import import_class
+
+if TYPE_CHECKING:
+    from .protocols import ArtifactPublisher
 
 IMAGE_SUFFIXES = {".gif", ".jpeg", ".jpg", ".png", ".svg"}
 VIDEO_SUFFIXES = {".mp4", ".webm", ".mov"}
@@ -107,40 +117,126 @@ def rewrite_video_links(text: str, root: Path, url_prefix: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# S3 / R2 publishing helpers (RUST-025)
+# Artifact publishing
 # ---------------------------------------------------------------------------
 
 
-def publish_videos_to_s3(
+@dataclass(frozen=True)
+class PublishTarget:
+    """Where a publisher should put artifacts, as supplied by CLI or environment.
+
+    These are deployment credentials and addresses rather than project
+    settings, so they are passed at publish time instead of being read from
+    ``.termproof/config.yaml``, which is checked in.
+    """
+
+    bucket: str = ""
+    endpoint_url: str | None = None
+    base_url: str = ""
+    dry_run: bool = False
+
+
+class S3ArtifactPublisher:
+    """Publish artifacts to an S3-compatible bucket (AWS S3, Cloudflare R2, ...).
+
+    Uses ``aws s3 cp`` via subprocess when available so no Python dependency is
+    required. Falls back to ``boto3`` when the CLI is absent.
+
+    ``base_url`` is the public URL prefix the bucket is served under, e.g.
+    ``https://pub-xxx.r2.dev`` or ``https://s3.amazonaws.com/my-bucket``. It is
+    separate from ``endpoint_url``, the S3 API endpoint used to write: a bucket
+    is commonly written through one host and read through another, and only the
+    read host belongs in a report link. Without it an upload still happens and
+    the result simply carries no URL.
+    """
+
+    name = "s3"
+
+    def __init__(
+        self,
+        bucket: str = "",
+        endpoint_url: str | None = None,
+        base_url: str = "",
+        dry_run: bool = False,
+    ) -> None:
+        self.bucket = bucket
+        self.endpoint_url = endpoint_url
+        self.base_url = base_url.rstrip("/")
+        self.dry_run = dry_run
+
+    @classmethod
+    def from_target(cls, target: PublishTarget) -> S3ArtifactPublisher:
+        return cls(
+            bucket=target.bucket,
+            endpoint_url=target.endpoint_url,
+            base_url=target.base_url,
+            dry_run=target.dry_run,
+        )
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        url = f"{self.base_url}/{quote(key, safe='/._-~')}" if self.base_url else ""
+        if self.dry_run:
+            return PublishedArtifact(
+                source=source,
+                key=key,
+                url=url,
+                published=False,
+                detail="dry run: not uploaded",
+            )
+        _upload_file(source, self.bucket, key, endpoint_url=self.endpoint_url)
+        return PublishedArtifact(source=source, key=key, url=url)
+
+
+def resolve_artifact_publisher(
+    name: str,
+    target: PublishTarget,
+    config: VerifierConfig | None = None,
+) -> ArtifactPublisher:
+    """Build the configured publisher named ``name``.
+
+    Publishers opt into deployment settings by exposing ``from_target``, the
+    same way renderers opt into evidence config with ``from_config``. One that
+    does not is constructed with no arguments.
+    """
+    config = config or load_config()
+    qualname = config.artifact_publishers.get(name)
+    if qualname is None:
+        available = ", ".join(sorted(config.artifact_publishers))
+        raise KeyError(f"unknown artifact publisher {name!r}; available: {available}")
+    cls = import_class(qualname)
+    factory = getattr(cls, "from_target", None)
+    return cls() if factory is None else factory(target)
+
+
+def url_map_from_published(published: Iterable[PublishedArtifact]) -> dict[str, str]:
+    """Map every published artifact's local path onto its hosted URL.
+
+    Reports link evidence by local path, so this is the bridge between
+    publishing and :func:`rewrite_report_video_links`. Artifacts the publisher
+    could not address are skipped: rewriting a link to an empty URL would break
+    a report that currently points at a file the reader can still open.
+    """
+    url_map: dict[str, str] = {}
+    for artifact in published:
+        if not artifact.url:
+            continue
+        for local in {str(artifact.source), artifact.source.as_posix()}:
+            url_map[local] = artifact.url
+    return url_map
+
+
+def _video_manifest_entries(
     base_dir: Path,
     head_dir: Path,
-    bucket: str,
     prefix: str = DEFAULT_VIDEO_PREFIX,
     pr_number: str = "",
     run_id: str = "",
-    endpoint_url: str | None = None,
-    dry_run: bool = False,
 ) -> list[dict[str, str]]:
-    """Upload video evidence to an S3-compatible bucket (AWS S3 or Cloudflare R2).
+    """Enumerate video evidence and assign each file its destination key.
 
-    Uses ``aws s3 cp`` via subprocess when available so no Python dependency is
-    required (works with R2 when ``endpoint_url`` is set to the R2 endpoint).
-    Falls back to ``boto3`` when the CLI is absent.
-
-    Args:
-        base_dir, head_dir: Evidence roots containing ``session.mp4`` files.
-        bucket: S3 bucket name (e.g. ``termproof-evidence`` or R2 bucket).
-        prefix: Key prefix inside the bucket (e.g. ``termproof/videos``).
-        pr_number, run_id: Used to build the object key layout
-            ``{prefix}/pr/{pr_number}/{run_id}/{base|head}/...``.
-        endpoint_url: S3-compatible endpoint (e.g. R2
-            ``https://<accountid>.r2.cloudflarestorage.com``).  When set, it
-            is passed as ``--endpoint-url`` to the AWS CLI or as
-            ``endpoint_url`` to boto3.
-        dry_run: When True, build the manifest without uploading.
-
-    Returns:
-        Manifest entries ``{scope, source, key, url}``.
+    The key layout ``{prefix}/pr/{pr_number}/{run_id}/{base|head}/...`` is the
+    caller's evidence layout, not a property of any store, which is why it is
+    computed here and handed to the publisher rather than left to it.
     """
     prefix = prefix.strip("/")
     entries: list[dict[str, str]] = []
@@ -155,12 +251,43 @@ def publish_videos_to_s3(
             # Normalise double slashes if pr/run omitted
             key = key.replace("//", "/")
             entries.append({"scope": scope, "source": video.as_posix(), "path": rel, "key": key})
+    return entries
+
+
+def publish_videos_to_s3(
+    base_dir: Path,
+    head_dir: Path,
+    bucket: str,
+    prefix: str = DEFAULT_VIDEO_PREFIX,
+    pr_number: str = "",
+    run_id: str = "",
+    endpoint_url: str | None = None,
+    dry_run: bool = False,
+) -> list[dict[str, str]]:
+    """Upload video evidence to an S3-compatible bucket.
+
+    Shorthand for driving :class:`S3ArtifactPublisher` over the video evidence
+    under ``base_dir``/``head_dir``.
+
+    Args:
+        base_dir, head_dir: Evidence roots containing ``session.mp4`` files.
+        bucket: S3 bucket name.
+        prefix: Key prefix inside the bucket (e.g. ``termproof/videos``).
+        pr_number, run_id: Used to build the object key layout
+            ``{prefix}/pr/{pr_number}/{run_id}/{base|head}/...``.
+        endpoint_url: S3-compatible endpoint, passed as ``--endpoint-url`` to
+            the AWS CLI or as ``endpoint_url`` to boto3.
+        dry_run: When True, build the manifest without uploading.
+
+    Returns:
+        Manifest entries ``{scope, source, path, key}``.
+    """
+    entries = _video_manifest_entries(base_dir, head_dir, prefix, pr_number, run_id)
     if dry_run or not entries:
         return entries
+    publisher = S3ArtifactPublisher(bucket=bucket, endpoint_url=endpoint_url)
     for entry in entries:
-        source = Path(entry["source"])
-        key = entry["key"]
-        _upload_file(source, bucket, key, endpoint_url=endpoint_url)
+        publisher.publish(Path(entry["source"]), entry["key"])
     return entries
 
 
@@ -172,28 +299,20 @@ def build_video_url_map(
     run_id: str = "",
     prefix: str = DEFAULT_VIDEO_PREFIX,
 ) -> dict[str, str]:
-    """Build a mapping from local video path -> hosted URL.
+    """Build a mapping from local video path -> hosted URL, without publishing.
 
-    Used to rewrite ``report.md`` / ``latest-report.md`` links after publishing.
-    ``base_url`` is the public bucket URL prefix, e.g.
-    ``https://pub-xxx.r2.dev`` or ``https://s3.amazonaws.com/my-bucket``.
+    Used to rewrite ``report.md`` / ``latest-report.md`` links when the videos
+    are known to be hosted already. After a publish, prefer
+    :func:`url_map_from_published`, which reads the URLs the publisher actually
+    reported instead of predicting them.
     """
-    prefix = prefix.strip("/")
-    url_map: dict[str, str] = {}
-    base_url = base_url.rstrip("/")
-    for scope, source_root in (("base", base_dir), ("head", head_dir)):
-        if not source_root.exists():
-            continue
-        for video in _video_files(source_root):
-            rel = video.relative_to(source_root).as_posix()
-            key = (
-                f"{prefix}/pr/{pr_number}/{run_id}/{scope}/{rel}" if pr_number and run_id else f"{prefix}/{scope}/{rel}"
-            )
-            key = key.replace("//", "/")
-            url = f"{base_url}/{quote(key, safe='/._-~')}"
-            for local in {str(video), video.as_posix()}:
-                url_map[local] = url
-    return url_map
+    # A dry run is precisely "name the URL without moving the bytes", which is
+    # what this asks for.
+    publisher = S3ArtifactPublisher(base_url=base_url, dry_run=True)
+    return url_map_from_published(
+        publisher.publish(Path(entry["source"]), entry["key"])
+        for entry in _video_manifest_entries(base_dir, head_dir, prefix, pr_number, run_id)
+    )
 
 
 def rewrite_report_video_links(text: str, url_map: dict[str, str]) -> str:
@@ -233,6 +352,11 @@ def main(argv: list[str] | None = None) -> int:
     publish.add_argument("--video-base-url", default=os.environ.get("TERM_PROOF_VIDEO_BASE_URL", ""))
     publish.add_argument("--out", type=Path, default=None, help="optional out dir to stage + write video-manifest.json")
     publish.add_argument("--dry-run", action="store_true")
+    publish.add_argument(
+        "--publisher",
+        default=os.environ.get("TERM_PROOF_ARTIFACT_PUBLISHER", "s3"),
+        help="name of a publisher registered under 'artifact_publishers' in config",
+    )
 
     args = parser.parse_args(argv)
     if args.command == "screenshots":
@@ -258,30 +382,30 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "publish-videos":
         if not args.bucket and not args.dry_run:
             parser.error("--bucket is required (or set TERM_PROOF_VIDEO_BUCKET) unless --dry-run")
-        entries = publish_videos_to_s3(
+        publisher = resolve_artifact_publisher(
+            args.publisher,
+            PublishTarget(
+                bucket=args.bucket,
+                endpoint_url=args.endpoint_url,
+                base_url=args.video_base_url,
+                dry_run=args.dry_run,
+            ),
+        )
+        entries = _video_manifest_entries(
             args.base_dir,
             args.head_dir,
-            bucket=args.bucket,
-            prefix=args.prefix,
-            pr_number=args.pr_number,
-            run_id=args.run_id,
-            endpoint_url=args.endpoint_url,
-            dry_run=args.dry_run,
+            args.prefix,
+            args.pr_number,
+            args.run_id,
         )
+        published = [publisher.publish(Path(entry["source"]), entry["key"]) for entry in entries]
         if args.out is not None:
             root = args.out / "pr" / args.pr_number / args.run_id if args.pr_number and args.run_id else args.out
             root.mkdir(parents=True, exist_ok=True)
             (root / "video-manifest.json").write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
-        # Optionally rewrite video links in reports when a base URL is known
-        if args.video_base_url:
-            url_map = build_video_url_map(
-                args.base_dir,
-                args.head_dir,
-                args.video_base_url,
-                pr_number=args.pr_number,
-                run_id=args.run_id,
-                prefix=args.prefix,
-            )
+        # Rewrite video links in reports for whatever the publisher could address
+        url_map = url_map_from_published(published)
+        if url_map:
             for report_path in [
                 *args.base_dir.rglob("report.md"),
                 *args.head_dir.rglob("report.md"),

--- a/termproof/evidence_publish.py
+++ b/termproof/evidence_publish.py
@@ -174,7 +174,7 @@ class S3ArtifactPublisher:
         )
 
     def publish(self, source: Path, key: str) -> PublishedArtifact:
-        url = f"{self.base_url}/{quote(key, safe='/._-~')}" if self.base_url else ""
+        url = _hosted_url(self.base_url, key)
         if self.dry_run:
             return PublishedArtifact(
                 source=source,
@@ -208,17 +208,23 @@ def resolve_artifact_publisher(
     return cls() if factory is None else factory(target)
 
 
+def _hosted_url(base_url: str, key: str) -> str:
+    """Name the public URL a key is served under, or nothing without a base URL."""
+    return f"{base_url}/{quote(key, safe='/._-~')}" if base_url else ""
+
+
 def url_map_from_published(published: Iterable[PublishedArtifact]) -> dict[str, str]:
     """Map every published artifact's local path onto its hosted URL.
 
     Reports link evidence by local path, so this is the bridge between
-    publishing and :func:`rewrite_report_video_links`. Artifacts the publisher
-    could not address are skipped: rewriting a link to an empty URL would break
-    a report that currently points at a file the reader can still open.
+    publishing and :func:`rewrite_report_video_links`. Only an artifact that is
+    both published and addressable is included: rewriting a link to an empty URL
+    or to a URL whose bytes never arrived would break a report that currently
+    points at a file the reader can still open.
     """
     url_map: dict[str, str] = {}
     for artifact in published:
-        if not artifact.url:
+        if not artifact.published or not artifact.url:
             continue
         for local in {str(artifact.source), artifact.source.as_posix()}:
             url_map[local] = artifact.url
@@ -306,13 +312,16 @@ def build_video_url_map(
     :func:`url_map_from_published`, which reads the URLs the publisher actually
     reported instead of predicting them.
     """
-    # A dry run is precisely "name the URL without moving the bytes", which is
-    # what this asks for.
-    publisher = S3ArtifactPublisher(base_url=base_url, dry_run=True)
-    return url_map_from_published(
-        publisher.publish(Path(entry["source"]), entry["key"])
-        for entry in _video_manifest_entries(base_dir, head_dir, prefix, pr_number, run_id)
-    )
+    base_url = base_url.rstrip("/")
+    url_map: dict[str, str] = {}
+    for entry in _video_manifest_entries(base_dir, head_dir, prefix, pr_number, run_id):
+        url = _hosted_url(base_url, entry["key"])
+        if not url:
+            continue
+        source = Path(entry["source"])
+        for local in {str(source), source.as_posix()}:
+            url_map[local] = url
+    return url_map
 
 
 def rewrite_report_video_links(text: str, url_map: dict[str, str]) -> str:
@@ -380,7 +389,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{len(manifest)} videos prepared")
         return 0
     if args.command == "publish-videos":
-        if not args.bucket and not args.dry_run:
+        # A bucket is what the S3 publisher needs, not what publishing needs.
+        # Any other store states its own preconditions by refusing the target.
+        if args.publisher == "s3" and not args.bucket and not args.dry_run:
             parser.error("--bucket is required (or set TERM_PROOF_VIDEO_BUCKET) unless --dry-run")
         publisher = resolve_artifact_publisher(
             args.publisher,
@@ -399,12 +410,34 @@ def main(argv: list[str] | None = None) -> int:
             args.run_id,
         )
         published = [publisher.publish(Path(entry["source"]), entry["key"]) for entry in entries]
+        # A dry run declines every artifact by design, so nothing it reports is
+        # a failure; anything else the publisher declined is one, and the
+        # manifest records what was actually stored rather than what was offered.
+        declined = [] if args.dry_run else [artifact for artifact in published if not artifact.published]
+        stored = (
+            entries
+            if args.dry_run
+            else [entry for entry, artifact in zip(entries, published, strict=True) if artifact.published]
+        )
         if args.out is not None:
             root = args.out / "pr" / args.pr_number / args.run_id if args.pr_number and args.run_id else args.out
             root.mkdir(parents=True, exist_ok=True)
-            (root / "video-manifest.json").write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
-        # Rewrite video links in reports for whatever the publisher could address
-        url_map = url_map_from_published(published)
+            (root / "video-manifest.json").write_text(json.dumps(stored, indent=2) + "\n", encoding="utf-8")
+        # Rewrite video links in reports for whatever the publisher could address.
+        # A dry run names URLs without moving bytes, so its map comes from the
+        # key layout rather than from results that report nothing as published.
+        url_map = (
+            build_video_url_map(
+                args.base_dir,
+                args.head_dir,
+                args.video_base_url,
+                pr_number=args.pr_number,
+                run_id=args.run_id,
+                prefix=args.prefix,
+            )
+            if args.dry_run
+            else url_map_from_published(published)
+        )
         if url_map:
             for report_path in [
                 *args.base_dir.rglob("report.md"),
@@ -417,11 +450,15 @@ def main(argv: list[str] | None = None) -> int:
                     new_text = rewrite_report_video_links(text, url_map)
                     if new_text != text:
                         report_path.write_text(new_text, encoding="utf-8")
+        for artifact in declined:
+            print(f"not published: {artifact.source}" + (f" ({artifact.detail})" if artifact.detail else ""))
         print(
-            f"{len(entries)} videos {'(dry-run) ' if args.dry_run else ''}published"
+            f"{len(stored)} videos {'(dry-run) ' if args.dry_run else ''}published"
             + (f" to s3://{args.bucket}/{args.prefix}" if args.bucket else "")
         )
-        return 0
+        # Nothing stored out of something offered is a failed publish, not a
+        # successful publish of nothing.
+        return 1 if declined and not stored else 0
     raise AssertionError(args.command)
 
 

--- a/termproof/models.py
+++ b/termproof/models.py
@@ -77,6 +77,39 @@ class AssertionResult:
 
 
 @dataclass(frozen=True)
+class PublishedArtifact:
+    """The outcome of handing one local evidence file to an artifact store.
+
+    ``source`` is the local path exactly as the caller supplied it, and it is
+    the reason this is a result object rather than a bare URL: a report links
+    to evidence by local path, so rewriting those links needs the pairing of
+    source and URL, not the URL alone.
+
+    ``url`` is empty when the store took the bytes but cannot name a public
+    address for them, and ``published`` is false when it did not take them at
+    all — a dry run, an unsupported file, or a failure the publisher chose to
+    report rather than raise. ``detail`` says which. Both a link rewrite and a
+    manifest entry are only warranted for an artifact that is published and
+    addressable, so callers can tell the two conditions apart.
+    """
+
+    source: Path
+    key: str
+    url: str = ""
+    published: bool = True
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source.as_posix(),
+            "key": self.key,
+            "url": self.url,
+            "published": self.published,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
 class RunResult:
     recipe_name: str
     passed: bool

--- a/termproof/models.py
+++ b/termproof/models.py
@@ -88,9 +88,11 @@ class PublishedArtifact:
     ``url`` is empty when the store took the bytes but cannot name a public
     address for them, and ``published`` is false when it did not take them at
     all — a dry run, an unsupported file, or a failure the publisher chose to
-    report rather than raise. ``detail`` says which. Both a link rewrite and a
-    manifest entry are only warranted for an artifact that is published and
-    addressable, so callers can tell the two conditions apart.
+    report rather than raise. ``detail`` says which. The two conditions warrant
+    different things: a link rewrite needs an artifact that is both published
+    and addressable, while a manifest entry needs only that it was published,
+    because bytes that were stored but cannot be named still belong in the
+    record of what was stored.
     """
 
     source: Path

--- a/termproof/plugins_cli.py
+++ b/termproof/plugins_cli.py
@@ -37,6 +37,7 @@ def installed_plugins(config: VerifierConfig) -> list[InstalledPlugin]:
         ("reporters", config.reporters),
         ("screen_renderers", config.screen_renderers),
         ("video_backends", config.video_backends),
+        ("artifact_publishers", config.artifact_publishers),
     ]
     for category, mapping in registries:
         for name, target in sorted(mapping.items()):

--- a/termproof/protocols.py
+++ b/termproof/protocols.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 from .before_after import BeforeAfterResult
 from .build_info import BuildInfo
 from .config import EvidenceConfig, PngRenderConfig, SvgRenderConfig, VideoConfig
-from .models import AssertionResult, Recipe, RunResult, StepResult
+from .models import AssertionResult, PublishedArtifact, Recipe, RunResult, StepResult
 from .session import TerminalSession
 
 if TYPE_CHECKING:
@@ -89,6 +89,27 @@ class VideoBackend(Protocol):
         ...
 
 
+class ArtifactPublisher(Protocol):
+    """Send a local evidence file somewhere durable and say where it landed.
+
+    ``key`` is the destination-relative identifier the caller has chosen — the
+    layout of the evidence, which is the caller's policy, not the store's. The
+    publisher decides only how a key maps onto its own namespace and onto a
+    public URL.
+
+    Returning a :class:`PublishedArtifact` rather than a URL string is what
+    makes the result usable downstream: reports reference evidence by local
+    path, so rewriting those links needs source and URL together, and a
+    publisher that could not place a file has to be able to say so without
+    aborting the artifacts that did publish.
+    """
+
+    name: str
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        ...
+
+
 class AgentRunner(Protocol):
     def run(self, recipe: Recipe, prompt: str, run_dir: Path) -> AgentOutcome:
         ...
@@ -109,10 +130,12 @@ class SessionBackend(Protocol):
 
 __all__ = [
     "AgentRunner",
+    "ArtifactPublisher",
     "AssertionType",
     "EvidenceConfig",
     "ExecutionMode",
     "PngRenderConfig",
+    "PublishedArtifact",
     "Reporter",
     "ScreenRenderer",
     "SessionBackend",

--- a/termproof/registry.py
+++ b/termproof/registry.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib
 from collections.abc import Callable
 from pathlib import Path
 from typing import Generic, TypeVar
 
+from .config import CURRENT_PLUGIN_MODULE_PREFIX, LEGACY_PLUGIN_MODULE_PREFIX
 from .models import Recipe, load_recipe
 
 T = TypeVar("T")
@@ -33,6 +35,27 @@ class Registry(Generic[T]):
 
     def names(self) -> list[str]:
         return sorted(self._factories)
+
+
+def import_class(qualname: str) -> type:
+    """Import a plugin class from a ``module.path:ClassName`` reference.
+
+    Configuration written for the pre-TermProof package can keep using its
+    plugin module prefix. This narrow alias avoids a compatibility shim package
+    while ensuring external plugin configuration remains loadable.
+    """
+    if ":" not in qualname:
+        raise ValueError(
+            f"expected 'module.path:ClassName', got {qualname!r}"
+        )
+    module_name, class_name = qualname.split(":", 1)
+    if module_name.startswith(LEGACY_PLUGIN_MODULE_PREFIX):
+        module_name = (
+            CURRENT_PLUGIN_MODULE_PREFIX
+            + module_name.removeprefix(LEGACY_PLUGIN_MODULE_PREFIX)
+        )
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)
 
 
 # -- recipe discovery --------------------------------------------------------

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -7,8 +7,6 @@ from typing import Any
 
 from .agent_driven import AgentDrivenRunner, AgentRunner, CodexCliAgentRunner
 from .config import (
-    CURRENT_PLUGIN_MODULE_PREFIX,
-    LEGACY_PLUGIN_MODULE_PREFIX,
     EvidenceConfig,
     VerifierConfig,
 )
@@ -21,7 +19,7 @@ from .models import (
     score_from_assertions,
 )
 from .protocols import SessionBackend
-from .registry import Registry
+from .registry import Registry, import_class
 from .screen import replay_cast
 from .session import TerminalSession
 
@@ -38,7 +36,7 @@ SESSION_BACKEND_ALIASES = {
 def _build_step_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.steps.items():
-        cls = _import_class(qualname)
+        cls = import_class(qualname)
         registry.register(name, lambda c=cls: c())
     return registry
 
@@ -46,7 +44,7 @@ def _build_step_registry(config: VerifierConfig) -> Registry[Any]:
 def _build_assertion_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.assertions.items():
-        cls = _import_class(qualname)
+        cls = import_class(qualname)
         registry.register(name, lambda c=cls: c())
     return registry
 
@@ -54,7 +52,7 @@ def _build_assertion_registry(config: VerifierConfig) -> Registry[Any]:
 def _build_reporter_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.reporters.items():
-        cls = _import_class(qualname)
+        cls = import_class(qualname)
         registry.register(name, lambda c=cls: c())
     return registry
 
@@ -73,7 +71,7 @@ def _construct_evidence_plugin(cls: type, evidence: EvidenceConfig) -> Any:
 def _build_renderer_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.screen_renderers.items():
-        cls = _import_class(qualname)
+        cls = import_class(qualname)
         registry.register(name, lambda c=cls: _construct_evidence_plugin(c, config.evidence))
     return registry
 
@@ -81,7 +79,7 @@ def _build_renderer_registry(config: VerifierConfig) -> Registry[Any]:
 def _build_execution_mode_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.execution_modes.items():
-        cls = _import_class(qualname)
+        cls = import_class(qualname)
         registry.register(name, lambda c=cls: c())
     return registry
 
@@ -89,7 +87,7 @@ def _build_execution_mode_registry(config: VerifierConfig) -> Registry[Any]:
 def _build_agent_runner_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.agent_runners.items():
-        cls = _import_class(qualname)
+        cls = import_class(qualname)
         registry.register(name, lambda c=cls: c())
     return registry
 
@@ -97,40 +95,17 @@ def _build_agent_runner_registry(config: VerifierConfig) -> Registry[Any]:
 def _build_video_backend_registry(config: VerifierConfig) -> Registry[Any]:
     registry: Registry[Any] = Registry()
     for name, qualname in config.video_backends.items():
-        cls = _import_class(qualname)
+        cls = import_class(qualname)
         registry.register(name, lambda c=cls: _construct_evidence_plugin(c, config.evidence))
     return registry
 
 
 def _resolve_session_backend(config: VerifierConfig) -> SessionBackend:
     qualname = SESSION_BACKEND_ALIASES.get(config.session_backend, config.session_backend)
-    cls = _import_class(qualname)
+    cls = import_class(qualname)
     if qualname == "termproof.builtin_session:DockerSessionBackend":
         return cls(config.docker)  # type: ignore[return-value]
     return cls()  # type: ignore[return-value]
-
-
-def _import_class(qualname: str) -> type:
-    """Import a plugin class from a ``module.path:ClassName`` reference.
-
-    Configuration written for the pre-TermProof package can keep using its
-    plugin module prefix. This narrow alias avoids a compatibility shim package
-    while ensuring external plugin configuration remains loadable.
-    """
-    if ":" not in qualname:
-        raise ValueError(
-            f"expected 'module.path:ClassName', got {qualname!r}"
-        )
-    module_name, class_name = qualname.split(":", 1)
-    if module_name.startswith(LEGACY_PLUGIN_MODULE_PREFIX):
-        module_name = (
-            CURRENT_PLUGIN_MODULE_PREFIX
-            + module_name.removeprefix(LEGACY_PLUGIN_MODULE_PREFIX)
-        )
-    import importlib
-
-    module = importlib.import_module(module_name)
-    return getattr(module, class_name)
 
 
 def _resolve_execution_mode_name(recipe: Recipe) -> str:

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -101,10 +101,16 @@ def _build_video_backend_registry(config: VerifierConfig) -> Registry[Any]:
 
 
 def _build_artifact_publisher_registry(config: VerifierConfig) -> Registry[Any]:
+    """Register configured publishers without importing them.
+
+    Unlike the other registries, this one resolves the class on demand: a run
+    never publishes, so an artifact store whose module needs an optional
+    dependency must not be able to break ``termproof run`` by merely being
+    configured.
+    """
     registry: Registry[Any] = Registry()
     for name, qualname in config.artifact_publishers.items():
-        cls = import_class(qualname)
-        registry.register(name, lambda c=cls: c())
+        registry.register(name, lambda q=qualname: import_class(q)())
     return registry
 
 

--- a/termproof/runner.py
+++ b/termproof/runner.py
@@ -100,6 +100,14 @@ def _build_video_backend_registry(config: VerifierConfig) -> Registry[Any]:
     return registry
 
 
+def _build_artifact_publisher_registry(config: VerifierConfig) -> Registry[Any]:
+    registry: Registry[Any] = Registry()
+    for name, qualname in config.artifact_publishers.items():
+        cls = import_class(qualname)
+        registry.register(name, lambda c=cls: c())
+    return registry
+
+
 def _resolve_session_backend(config: VerifierConfig) -> SessionBackend:
     qualname = SESSION_BACKEND_ALIASES.get(config.session_backend, config.session_backend)
     cls = import_class(qualname)
@@ -132,6 +140,7 @@ class VerificationRunner:
         self.execution_mode_registry = _build_execution_mode_registry(self.config)
         self.agent_runner_registry = _build_agent_runner_registry(self.config)
         self.video_backend_registry = _build_video_backend_registry(self.config)
+        self.artifact_publisher_registry = _build_artifact_publisher_registry(self.config)
         self.session_backend = _resolve_session_backend(self.config)
 
     def run(

--- a/tests/test_artifact_publisher.py
+++ b/tests/test_artifact_publisher.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from termproof.config import VerifierConfig
+from termproof.evidence_publish import (
+    PublishTarget,
+    S3ArtifactPublisher,
+    build_video_url_map,
+    main,
+    publish_videos_to_s3,
+    resolve_artifact_publisher,
+    rewrite_report_video_links,
+    url_map_from_published,
+)
+from termproof.models import PublishedArtifact
+from termproof.protocols import ArtifactPublisher
+from termproof.runner import VerificationRunner
+
+REPORT = """# Report
+
+| video | {head}/session.mp4 |
+| video | {base}/session.mp4 |
+"""
+
+
+class RecordingPublisher:
+    """A minimal third-party publisher: records what it was asked to publish."""
+
+    name = "recording"
+
+    def __init__(self, base_url: str = "https://artifacts.example/store") -> None:
+        self.base_url = base_url
+        self.calls: list[tuple[Path, str]] = []
+
+    @classmethod
+    def from_target(cls, target: PublishTarget) -> RecordingPublisher:
+        return cls(base_url=target.base_url)
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        self.calls.append((source, key))
+        return PublishedArtifact(source=source, key=key, url=f"{self.base_url}/{key}")
+
+
+class RefusingPublisher:
+    """A publisher that declines a file instead of raising."""
+
+    name = "refusing"
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        return PublishedArtifact(
+            source=source,
+            key=key,
+            published=False,
+            detail="unsupported artifact",
+        )
+
+
+def _evidence_tree(root: Path) -> tuple[Path, Path]:
+    base = root / "base"
+    head = root / "head"
+    for scope in (base, head):
+        run = scope / "run-1"
+        run.mkdir(parents=True)
+        (run / "session.mp4").write_bytes(b"video")
+    return base, head
+
+
+class ArtifactPublisherProtocolTests(unittest.TestCase):
+    def test_builtin_publisher_is_registered_and_resolvable(self) -> None:
+        runner = VerificationRunner()
+
+        publisher = runner.artifact_publisher_registry.get("s3")
+
+        self.assertEqual(["s3"], runner.artifact_publisher_registry.names())
+        self.assertIsInstance(publisher, S3ArtifactPublisher)
+        self.assertEqual("s3", publisher.name)
+
+    def test_publisher_satisfies_the_protocol(self) -> None:
+        publishers: list[ArtifactPublisher] = [
+            S3ArtifactPublisher(),
+            RecordingPublisher(),
+        ]
+
+        for publisher in publishers:
+            self.assertTrue(callable(publisher.publish))
+            self.assertIsInstance(publisher.name, str)
+
+    def test_third_party_publisher_round_trips_through_config(self) -> None:
+        config = replace(
+            VerifierConfig.builtin(),
+            artifact_publishers={
+                "recording": f"{__name__}:RecordingPublisher",
+            },
+        )
+
+        publisher = resolve_artifact_publisher(
+            "recording",
+            PublishTarget(base_url="https://artifacts.example/store"),
+            config=config,
+        )
+        published = publisher.publish(Path("/tmp/run/session.mp4"), "videos/head/session.mp4")
+
+        self.assertIsInstance(publisher, RecordingPublisher)
+        self.assertEqual([(Path("/tmp/run/session.mp4"), "videos/head/session.mp4")], publisher.calls)
+        self.assertEqual(
+            "https://artifacts.example/store/videos/head/session.mp4",
+            published.url,
+        )
+        self.assertTrue(published.published)
+
+    def test_publisher_without_from_target_is_constructed_bare(self) -> None:
+        config = replace(
+            VerifierConfig.builtin(),
+            artifact_publishers={"refusing": f"{__name__}:RefusingPublisher"},
+        )
+
+        publisher = resolve_artifact_publisher(
+            "refusing",
+            PublishTarget(bucket="ignored"),
+            config=config,
+        )
+
+        self.assertIsInstance(publisher, RefusingPublisher)
+
+    def test_unknown_publisher_names_the_available_ones(self) -> None:
+        with self.assertRaises(KeyError) as caught:
+            resolve_artifact_publisher(
+                "nope",
+                PublishTarget(),
+                config=VerifierConfig.builtin(),
+            )
+
+        self.assertIn("s3", str(caught.exception))
+
+    def test_url_map_skips_artifacts_the_publisher_could_not_address(self) -> None:
+        published = [
+            PublishedArtifact(source=Path("/tmp/a.mp4"), key="a", url="https://host/a"),
+            RefusingPublisher().publish(Path("/tmp/b.mp4"), "b"),
+        ]
+
+        url_map = url_map_from_published(published)
+
+        self.assertEqual({"/tmp/a.mp4": "https://host/a"}, url_map)
+
+    def test_url_map_drives_report_rewriting(self) -> None:
+        published = [
+            PublishedArtifact(
+                source=Path("/tmp/head/session.mp4"),
+                key="videos/head/session.mp4",
+                url="https://host/videos/head/session.mp4",
+            )
+        ]
+
+        rewritten = rewrite_report_video_links(
+            "see /tmp/head/session.mp4 for evidence",
+            url_map_from_published(published),
+        )
+
+        self.assertEqual(
+            "see https://host/videos/head/session.mp4 for evidence",
+            rewritten,
+        )
+
+
+class S3ArtifactPublisherTests(unittest.TestCase):
+    def test_dry_run_names_the_url_without_uploading(self) -> None:
+        publisher = S3ArtifactPublisher(
+            bucket="evidence",
+            base_url="https://cdn.example/",
+            dry_run=True,
+        )
+
+        # An upload would raise, since _upload_file is not stubbed here.
+        published = publisher.publish(Path("/tmp/session.mp4"), "videos/head/session.mp4")
+
+        self.assertFalse(published.published)
+        self.assertEqual("dry run: not uploaded", published.detail)
+        self.assertEqual("https://cdn.example/videos/head/session.mp4", published.url)
+
+    def test_upload_passes_bucket_key_and_endpoint_through(self) -> None:
+        uploads: list[tuple[Path, str, str, str | None]] = []
+        publisher = S3ArtifactPublisher(
+            bucket="evidence",
+            endpoint_url="https://api.example",
+            base_url="https://cdn.example",
+        )
+
+        with _stub_upload(uploads):
+            published = publisher.publish(Path("/tmp/session.mp4"), "videos/head/session.mp4")
+
+        self.assertEqual(
+            [(Path("/tmp/session.mp4"), "evidence", "videos/head/session.mp4", "https://api.example")],
+            uploads,
+        )
+        self.assertTrue(published.published)
+        self.assertEqual("https://cdn.example/videos/head/session.mp4", published.url)
+
+    def test_upload_without_a_base_url_reports_no_url(self) -> None:
+        publisher = S3ArtifactPublisher(bucket="evidence")
+
+        with _stub_upload([]):
+            published = publisher.publish(Path("/tmp/session.mp4"), "key")
+
+        self.assertTrue(published.published)
+        self.assertEqual("", published.url)
+
+
+class RefactoredS3PathTests(unittest.TestCase):
+    """The S3/R2 publishing path must behave exactly as it did before."""
+
+    def test_manifest_entries_keep_their_shape_and_key_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+
+            entries = publish_videos_to_s3(
+                base,
+                head,
+                bucket="evidence",
+                pr_number="7",
+                run_id="99",
+                dry_run=True,
+            )
+
+        self.assertEqual(
+            [
+                {
+                    "scope": "base",
+                    "source": (base / "run-1" / "session.mp4").as_posix(),
+                    "path": "run-1/session.mp4",
+                    "key": "termproof/videos/pr/7/99/base/run-1/session.mp4",
+                },
+                {
+                    "scope": "head",
+                    "source": (head / "run-1" / "session.mp4").as_posix(),
+                    "path": "run-1/session.mp4",
+                    "key": "termproof/videos/pr/7/99/head/run-1/session.mp4",
+                },
+            ],
+            entries,
+        )
+
+    def test_key_layout_omits_pr_and_run_when_they_are_unset(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+
+            entries = publish_videos_to_s3(base, head, bucket="evidence", dry_run=True)
+
+        self.assertEqual(
+            ["termproof/videos/base/run-1/session.mp4", "termproof/videos/head/run-1/session.mp4"],
+            [entry["key"] for entry in entries],
+        )
+
+    def test_missing_evidence_root_is_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, head = _evidence_tree(Path(tmp))
+
+            entries = publish_videos_to_s3(
+                Path(tmp) / "absent",
+                head,
+                bucket="evidence",
+                dry_run=True,
+            )
+
+        self.assertEqual(["head"], [entry["scope"] for entry in entries])
+
+    def test_dry_run_uploads_nothing(self) -> None:
+        uploads: list[tuple[Path, str, str, str | None]] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+
+            with _stub_upload(uploads):
+                publish_videos_to_s3(base, head, bucket="evidence", dry_run=True)
+
+        self.assertEqual([], uploads)
+
+    def test_every_video_is_uploaded_to_its_key(self) -> None:
+        uploads: list[tuple[Path, str, str, str | None]] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+
+            with _stub_upload(uploads):
+                publish_videos_to_s3(
+                    base,
+                    head,
+                    bucket="evidence",
+                    prefix="/custom/prefix/",
+                    pr_number="7",
+                    run_id="99",
+                    endpoint_url="https://api.example",
+                )
+
+        self.assertEqual(
+            [
+                "custom/prefix/pr/7/99/base/run-1/session.mp4",
+                "custom/prefix/pr/7/99/head/run-1/session.mp4",
+            ],
+            [key for _, _, key, _ in uploads],
+        )
+        self.assertEqual({"evidence"}, {bucket for _, bucket, _, _ in uploads})
+        self.assertEqual({"https://api.example"}, {endpoint for *_, endpoint in uploads})
+
+    def test_url_map_covers_both_path_spellings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+
+            url_map = build_video_url_map(
+                base,
+                head,
+                "https://cdn.example/",
+                pr_number="7",
+                run_id="99",
+            )
+
+        video = head / "run-1" / "session.mp4"
+        expected = "https://cdn.example/termproof/videos/pr/7/99/head/run-1/session.mp4"
+        self.assertEqual(expected, url_map[str(video)])
+        self.assertEqual(expected, url_map[video.as_posix()])
+
+    def test_url_map_percent_encodes_the_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "base"
+            (base / "run one").mkdir(parents=True)
+            (base / "run one" / "session.mp4").write_bytes(b"video")
+
+            url_map = build_video_url_map(base, Path(tmp) / "absent", "https://cdn.example")
+
+        self.assertEqual(
+            ["https://cdn.example/termproof/videos/base/run%20one/session.mp4"],
+            sorted(set(url_map.values())),
+        )
+
+    def test_missing_upload_tooling_still_raises(self) -> None:
+        publisher = S3ArtifactPublisher(bucket="evidence")
+
+        with _no_upload_tooling():
+            with self.assertRaises(RuntimeError) as caught:
+                publisher.publish(Path("/tmp/session.mp4"), "key")
+
+        self.assertIn("boto3", str(caught.exception))
+
+
+class PublishVideosCommandTests(unittest.TestCase):
+    def test_command_writes_the_manifest_and_rewrites_reports(self) -> None:
+        uploads: list[tuple[Path, str, str, str | None]] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+            out = Path(tmp) / "out"
+            (head / "latest-report.md").write_text(
+                REPORT.format(base=base / "run-1", head=head / "run-1"),
+                encoding="utf-8",
+            )
+
+            with _stub_upload(uploads), contextlib.redirect_stdout(io.StringIO()):
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--bucket",
+                        "evidence",
+                        "--pr-number",
+                        "7",
+                        "--run-id",
+                        "99",
+                        "--video-base-url",
+                        "https://cdn.example",
+                        "--out",
+                        str(out),
+                    ]
+                )
+
+            manifest = json.loads((out / "pr" / "7" / "99" / "video-manifest.json").read_text(encoding="utf-8"))
+            report = (head / "latest-report.md").read_text(encoding="utf-8")
+
+        self.assertEqual(0, code)
+        self.assertEqual(2, len(uploads))
+        self.assertEqual(
+            ["termproof/videos/pr/7/99/base/run-1/session.mp4", "termproof/videos/pr/7/99/head/run-1/session.mp4"],
+            [entry["key"] for entry in manifest],
+        )
+        self.assertIn("https://cdn.example/termproof/videos/pr/7/99/head/run-1/session.mp4", report)
+        self.assertIn("https://cdn.example/termproof/videos/pr/7/99/base/run-1/session.mp4", report)
+        self.assertNotIn(str(head / "run-1" / "session.mp4"), report)
+
+    def test_dry_run_still_rewrites_reports_without_uploading(self) -> None:
+        uploads: list[tuple[Path, str, str, str | None]] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+            (head / "latest-report.md").write_text(
+                REPORT.format(base=base / "run-1", head=head / "run-1"),
+                encoding="utf-8",
+            )
+
+            with _stub_upload(uploads), contextlib.redirect_stdout(io.StringIO()) as stdout:
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--video-base-url",
+                        "https://cdn.example",
+                        "--dry-run",
+                    ]
+                )
+
+            report = (head / "latest-report.md").read_text(encoding="utf-8")
+
+        self.assertEqual(0, code)
+        self.assertEqual([], uploads)
+        self.assertIn("(dry-run)", stdout.getvalue())
+        self.assertIn("https://cdn.example/termproof/videos/head/run-1/session.mp4", report)
+
+    def test_reports_are_untouched_without_a_base_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+            original = REPORT.format(base=base / "run-1", head=head / "run-1")
+            (head / "latest-report.md").write_text(original, encoding="utf-8")
+
+            with _stub_upload([]), contextlib.redirect_stdout(io.StringIO()):
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--bucket",
+                        "evidence",
+                    ]
+                )
+
+            report = (head / "latest-report.md").read_text(encoding="utf-8")
+
+        self.assertEqual(0, code)
+        self.assertEqual(original, report)
+
+
+@contextlib.contextmanager
+def _stub_upload(uploads: list[tuple[Path, str, str, str | None]]):
+    from termproof import evidence_publish
+
+    original = evidence_publish._upload_file
+
+    def record(source: Path, bucket: str, key: str, endpoint_url: str | None = None) -> None:
+        uploads.append((source, bucket, key, endpoint_url))
+
+    evidence_publish._upload_file = record
+    try:
+        yield
+    finally:
+        evidence_publish._upload_file = original
+
+
+@contextlib.contextmanager
+def _no_upload_tooling():
+    """Hide both the AWS CLI and boto3, as an unprovisioned machine would."""
+    import builtins
+
+    from termproof import evidence_publish
+
+    original_which = evidence_publish.shutil.which
+    original_import = builtins.__import__
+
+    def blocked_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "boto3":
+            raise ImportError("no boto3")
+        return original_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    evidence_publish.shutil.which = lambda _name: None
+    builtins.__import__ = blocked_import
+    try:
+        yield
+    finally:
+        evidence_publish.shutil.which = original_which
+        builtins.__import__ = original_import
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_artifact_publisher.py
+++ b/tests/test_artifact_publisher.py
@@ -88,6 +88,45 @@ class PartialPublisher:
         return PublishedArtifact(source=source, key=key, url=f"https://cdn.example/{key}")
 
 
+class TenantPublisher:
+    """Maps keys into its own namespace, and spells URLs its own way."""
+
+    name = "tenant"
+
+    def __init__(self, base_url: str = "", dry_run: bool = False) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.dry_run = dry_run
+
+    @classmethod
+    def from_target(cls, target: PublishTarget) -> TenantPublisher:
+        return cls(base_url=target.base_url, dry_run=target.dry_run)
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        url = f"{self.base_url}/tenant/{key}" if self.base_url else ""
+        if self.dry_run:
+            return PublishedArtifact(
+                source=source,
+                key=key,
+                url=url,
+                published=False,
+                detail="dry run: not uploaded",
+            )
+        return PublishedArtifact(source=source, key=key, url=url)
+
+
+class UnaddressablePublisher:
+    """Takes the bytes but cannot name a public address for them."""
+
+    name = "silent"
+
+    @classmethod
+    def from_target(cls, target: PublishTarget) -> UnaddressablePublisher:
+        return cls()
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        return PublishedArtifact(source=source, key=key)
+
+
 def _evidence_tree(root: Path) -> tuple[Path, Path]:
     base = root / "base"
     head = root / "head"
@@ -527,7 +566,7 @@ class PublishVideosResultReportingTests(unittest.TestCase):
         self.assertIn("0 videos published", stdout.getvalue())
         self.assertEqual(original, report)
 
-    def test_a_partly_declined_batch_reports_only_what_was_stored(self) -> None:
+    def test_a_partly_declined_batch_fails_and_stores_the_rest(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             base, head = _evidence_tree(Path(tmp))
             out = Path(tmp) / "out"
@@ -557,7 +596,9 @@ class PublishVideosResultReportingTests(unittest.TestCase):
             manifest = json.loads((out / "video-manifest.json").read_text(encoding="utf-8"))
             report = (head / "latest-report.md").read_text(encoding="utf-8")
 
-        self.assertEqual(0, code)
+        # One video silently missing is the same false success as none stored,
+        # so a partial decline fails the command too.
+        self.assertEqual(1, code)
         self.assertEqual(["termproof/videos/head/run-1/session.mp4"], [entry["key"] for entry in manifest])
         self.assertIn("1 videos published", stdout.getvalue())
         self.assertIn("store unavailable", stdout.getvalue())
@@ -607,6 +648,129 @@ class PublishVideosPublisherSelectionTests(unittest.TestCase):
             "https://artifacts.example/store/termproof/videos/head/run-1/session.mp4",
             report,
         )
+
+
+class DryRunSpeaksForItsOwnStoreTests(unittest.TestCase):
+    """A dry run must report where the *selected* publisher would put evidence."""
+
+    def test_report_links_use_the_publishers_own_urls_not_the_s3_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / "base"
+            head = root / "head"
+            for scope in (base, head):
+                run = scope / "run one"
+                run.mkdir(parents=True)
+                (run / "session.mp4").write_bytes(b"video")
+            (head / "latest-report.md").write_text(
+                REPORT.format(base=base / "run one", head=head / "run one"),
+                encoding="utf-8",
+            )
+
+            with _publishers(tenant=f"{__name__}:TenantPublisher"), contextlib.redirect_stdout(io.StringIO()):
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--publisher",
+                        "tenant",
+                        "--video-base-url",
+                        "https://evidence.example",
+                        "--dry-run",
+                    ]
+                )
+
+            report = (head / "latest-report.md").read_text(encoding="utf-8")
+
+        self.assertEqual(0, code)
+        # The store's own namespace, with the space left exactly as the store
+        # spelled it - not the percent-encoded s3 key layout.
+        self.assertIn("https://evidence.example/tenant/termproof/videos/head/run one/session.mp4", report)
+        self.assertNotIn("run%20one", report)
+
+    def test_a_publisher_that_cannot_address_an_artifact_keeps_the_local_link(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+            (head / "latest-report.md").write_text(
+                REPORT.format(base=base / "run-1", head=head / "run-1"),
+                encoding="utf-8",
+            )
+
+            with _publishers(silent=f"{__name__}:UnaddressablePublisher"), contextlib.redirect_stdout(io.StringIO()):
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--publisher",
+                        "silent",
+                        "--video-base-url",
+                        "https://evidence.example",
+                        "--dry-run",
+                    ]
+                )
+
+            report = (head / "latest-report.md").read_text(encoding="utf-8")
+
+        self.assertEqual(0, code)
+        self.assertIn(str(head / "run-1" / "session.mp4"), report)
+        self.assertNotIn("https://evidence.example", report)
+
+    def test_dry_run_is_refused_by_a_publisher_that_cannot_see_the_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+
+            with (
+                _publishers(refusing=f"{__name__}:RefusingPublisher"),
+                contextlib.redirect_stderr(io.StringIO()) as stderr,
+            ):
+                with self.assertRaises(SystemExit) as caught:
+                    main(
+                        [
+                            "publish-videos",
+                            "--base-dir",
+                            str(base),
+                            "--head-dir",
+                            str(head),
+                            "--publisher",
+                            "refusing",
+                            "--dry-run",
+                        ]
+                    )
+
+        self.assertEqual(2, caught.exception.code)
+        self.assertIn("--dry-run cannot be honoured by publisher 'refusing'", stderr.getvalue())
+
+    def test_the_destination_line_names_the_publisher_instead_of_guessing_a_scheme(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+
+            with (
+                _publishers(recording=f"{__name__}:RecordingPublisher"),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--publisher",
+                        "recording",
+                        "--bucket",
+                        "evidence-dir",
+                    ]
+                )
+
+        self.assertEqual(0, code)
+        self.assertIn("2 videos published via recording", stdout.getvalue())
+        self.assertNotIn("s3://", stdout.getvalue())
 
 
 @contextlib.contextmanager

--- a/tests/test_artifact_publisher.py
+++ b/tests/test_artifact_publisher.py
@@ -62,6 +62,32 @@ class RefusingPublisher:
         )
 
 
+class DecliningPublisher:
+    """Declines every artifact, but names the URL it would have used."""
+
+    name = "declining"
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        return PublishedArtifact(
+            source=source,
+            key=key,
+            url=f"https://cdn.example/{key}",
+            published=False,
+            detail="store unavailable",
+        )
+
+
+class PartialPublisher:
+    """Stores head evidence and declines base evidence."""
+
+    name = "partial"
+
+    def publish(self, source: Path, key: str) -> PublishedArtifact:
+        if "/base/" in key:
+            return PublishedArtifact(source=source, key=key, published=False, detail="store unavailable")
+        return PublishedArtifact(source=source, key=key, url=f"https://cdn.example/{key}")
+
+
 def _evidence_tree(root: Path) -> tuple[Path, Path]:
     base = root / "base"
     head = root / "head"
@@ -138,6 +164,24 @@ class ArtifactPublisherProtocolTests(unittest.TestCase):
             )
 
         self.assertIn("s3", str(caught.exception))
+
+    def test_registry_resolves_a_publisher_only_when_it_is_asked_for(self) -> None:
+        config = replace(
+            VerifierConfig.builtin(),
+            artifact_publishers={"absent": "termproof_absent_dependency.publishers:Store"},
+        )
+
+        runner = VerificationRunner(config=config)
+
+        self.assertIn("absent", runner.artifact_publisher_registry.names())
+        with self.assertRaises(ModuleNotFoundError):
+            runner.artifact_publisher_registry.get("absent")
+
+    def test_url_map_skips_an_artifact_that_was_never_transferred(self) -> None:
+        published = [DecliningPublisher().publish(Path("/tmp/a.mp4"), "a")]
+
+        self.assertEqual("https://cdn.example/a", published[0].url)
+        self.assertEqual({}, url_map_from_published(published))
 
     def test_url_map_skips_artifacts_the_publisher_could_not_address(self) -> None:
         published = [
@@ -444,6 +488,143 @@ class PublishVideosCommandTests(unittest.TestCase):
 
         self.assertEqual(0, code)
         self.assertEqual(original, report)
+
+
+class PublishVideosResultReportingTests(unittest.TestCase):
+    """What the command reports has to be what the publisher actually did."""
+
+    def test_a_wholly_declined_batch_fails_and_says_why(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+            out = Path(tmp) / "out"
+            original = REPORT.format(base=base / "run-1", head=head / "run-1")
+            (head / "latest-report.md").write_text(original, encoding="utf-8")
+
+            with (
+                _publishers(declining=f"{__name__}:DecliningPublisher"),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--publisher",
+                        "declining",
+                        "--out",
+                        str(out),
+                    ]
+                )
+
+            manifest = json.loads((out / "video-manifest.json").read_text(encoding="utf-8"))
+            report = (head / "latest-report.md").read_text(encoding="utf-8")
+
+        self.assertEqual(1, code)
+        self.assertEqual([], manifest)
+        self.assertIn("store unavailable", stdout.getvalue())
+        self.assertIn("0 videos published", stdout.getvalue())
+        self.assertEqual(original, report)
+
+    def test_a_partly_declined_batch_reports_only_what_was_stored(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+            out = Path(tmp) / "out"
+            (head / "latest-report.md").write_text(
+                REPORT.format(base=base / "run-1", head=head / "run-1"),
+                encoding="utf-8",
+            )
+
+            with (
+                _publishers(partial=f"{__name__}:PartialPublisher"),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--publisher",
+                        "partial",
+                        "--out",
+                        str(out),
+                    ]
+                )
+
+            manifest = json.loads((out / "video-manifest.json").read_text(encoding="utf-8"))
+            report = (head / "latest-report.md").read_text(encoding="utf-8")
+
+        self.assertEqual(0, code)
+        self.assertEqual(["termproof/videos/head/run-1/session.mp4"], [entry["key"] for entry in manifest])
+        self.assertIn("1 videos published", stdout.getvalue())
+        self.assertIn("store unavailable", stdout.getvalue())
+        self.assertIn("https://cdn.example/termproof/videos/head/run-1/session.mp4", report)
+        self.assertIn(str(base / "run-1" / "session.mp4"), report)
+
+
+class PublishVideosPublisherSelectionTests(unittest.TestCase):
+    def test_s3_still_demands_a_bucket_outside_a_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+
+            with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                with self.assertRaises(SystemExit) as caught:
+                    main(["publish-videos", "--base-dir", str(base), "--head-dir", str(head)])
+
+        self.assertEqual(2, caught.exception.code)
+        self.assertIn("--bucket is required (or set TERM_PROOF_VIDEO_BUCKET) unless --dry-run", stderr.getvalue())
+
+    def test_another_publisher_does_not_inherit_the_bucket_requirement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base, head = _evidence_tree(Path(tmp))
+            (head / "latest-report.md").write_text(
+                REPORT.format(base=base / "run-1", head=head / "run-1"),
+                encoding="utf-8",
+            )
+
+            with _publishers(recording=f"{__name__}:RecordingPublisher"), contextlib.redirect_stdout(io.StringIO()):
+                code = main(
+                    [
+                        "publish-videos",
+                        "--base-dir",
+                        str(base),
+                        "--head-dir",
+                        str(head),
+                        "--publisher",
+                        "recording",
+                        "--video-base-url",
+                        "https://artifacts.example/store",
+                    ]
+                )
+
+            report = (head / "latest-report.md").read_text(encoding="utf-8")
+
+        self.assertEqual(0, code)
+        self.assertIn(
+            "https://artifacts.example/store/termproof/videos/head/run-1/session.mp4",
+            report,
+        )
+
+
+@contextlib.contextmanager
+def _publishers(**publishers: str):
+    """Register extra publishers for the duration of a CLI invocation."""
+    from termproof import evidence_publish
+
+    builtin = VerifierConfig.builtin()
+    config = replace(
+        builtin,
+        artifact_publishers={**builtin.artifact_publishers, **publishers},
+    )
+    original = evidence_publish.load_config
+    evidence_publish.load_config = lambda *args, **kwargs: config
+    try:
+        yield
+    finally:
+        evidence_publish.load_config = original
 
 
 @contextlib.contextmanager

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -12,10 +12,12 @@ class ProtocolApiTests(unittest.TestCase):
         self.assertEqual(
             [
                 "AgentRunner",
+                "ArtifactPublisher",
                 "AssertionType",
                 "EvidenceConfig",
                 "ExecutionMode",
                 "PngRenderConfig",
+                "PublishedArtifact",
                 "Reporter",
                 "ScreenRenderer",
                 "SessionBackend",
@@ -62,6 +64,10 @@ class ProtocolApiTests(unittest.TestCase):
             protocols.SessionBackend.create_session: (
                 ["self", "argv", "cast_path", "cwd", "env", "cols", "rows"],
                 "TerminalSession",
+            ),
+            protocols.ArtifactPublisher.publish: (
+                ["self", "source", "key"],
+                "PublishedArtifact",
             ),
         }
         for method, (parameters, return_annotation) in cases.items():


### PR DESCRIPTION
## What

Adds an `ArtifactPublisher` plugin protocol — a ninth protocol alongside the existing eight (`StepAction`, `AssertionType`, `Reporter`, `ScreenRenderer`, `VideoBackend`, `SessionBackend`, `ExecutionMode`, `AgentRunner`).

*Where evidence goes* was the one part of the pipeline that was not an extension point. Publishing was hardcoded to S3/R2 as free functions in `termproof/evidence_publish.py`, so a project with its own artifact store had nowhere to plug in.

```python
class ArtifactPublisher(Protocol):
    name: str

    def publish(self, source: Path, key: str) -> PublishedArtifact: ...
```

Registered under the `artifact_publishers` config key and selected by name, exactly like the other eight.

## Design notes

**Why not `upload(path) -> url`.** A bare URL return cannot express what the call sites need. Reports link evidence by *local path*, so `rewrite_report_video_links` needs the pairing of source and URL — in both the `str(path)` and `path.as_posix()` spellings. `PublishedArtifact` carries that pairing and `url_map_from_published()` is the bridge to the rewrite step.

**The caller supplies the key.** The layout of published evidence is the shape of the evidence — caller policy — not a property of any store. A publisher decides only how a key maps onto its own namespace and onto a public URL.

**Two distinct failure shapes, neither an exception.** `published=False` means the bytes were not transferred; an empty `url` means they were, but cannot be addressed. A link rewrite requires both conditions; a manifest entry requires only the first, because bytes that were stored but cannot be named still belong in the record of what was stored.

**Deployment settings via `from_target`.** Buckets, endpoints and credentials reach a publisher through an optional `from_target(target: PublishTarget)` classmethod rather than through the checked-in `.termproof/config.yaml`, mirroring the existing `from_config` convention for renderers. A publisher without it is constructed with no arguments.

**Composition, not shipped.** A wrapper that tries one store, falls back to a second and records the degradation in `detail` is a plain implementation of the same protocol. The docs say so; nothing here ships one.

## Additive only

The existing S3/R2 path becomes the first implementation (`S3ArtifactPublisher`, registered as `s3`) rather than a parallel special case. Observable behaviour is unchanged: same object keys, same manifests, same hosted URLs, same report rewriting, same success lines with and without a base URL, same exit codes, and the same `RuntimeError` when neither the AWS CLI nor boto3 is installed. Verified differentially against `main`'s implementation over the same evidence tree — identical manifests, identical URL maps, identical `_upload_file` call sequences — and re-confirmed by CLI smoke after the final commit.

Tests cover both sides: the protocol round-trip with third-party publishers, and the refactored S3 path behaving as before.

No version bump — features accumulate under `[Unreleased]` per repo convention.

## Found and fixed during review

An automated review round ran over the first two commits and surfaced ten findings; nine were acted on. They were all on the *new* extension point rather than the refactor, and the theme was consistent: the generic path kept assuming it was S3.

- **`--bucket` gated every publisher.** An S3-specific precondition blocked the generic `--publisher` path — the plugin template's own documented invocation failed with a parser error. Now scoped to `s3`.
- **Declined artifacts counted as published.** The CLI collected `PublishedArtifact` results but never inspected `published` or `detail`: declined videos still landed in `video-manifest.json`, still counted in the success message, and the command still exited 0. It now counts and reports from actual results, surfaces `detail` for each decline, and **exits non-zero if anything was declined** — a batch that stored nineteen of twenty and dropped one is the same false success as storing none, just harder to notice.
- **Report links could be rewritten to URLs that 404.** `url_map_from_published` filtered on empty `url` alone, so an artifact whose transfer failed after its URL was computed still got its local path replaced. Tightened to require `published` *and* `url`; a link that 404s while the local file still exists is strictly worse than no rewrite.
- **Dry runs predicted S3-style URLs for every publisher** and wrote them into `report.md`. A store mapping keys into its own namespace got links baked in that it would never serve. The map now comes from the URL the publisher itself reported.
- **`--dry-run` was unenforceable** for a publisher taking no target: it never saw the flag and would publish for real. Now refused up front, naming the publisher.
- **The success line claimed an `s3://` destination for any publisher** with a bucket set, reporting a location that does not exist. Non-S3 publishers are named instead of given a scheme.
- **The publisher registry was built eagerly** on every `VerificationRunner` construction, importing every configured publisher — so a publisher whose module imports an optional dependency at module scope would break every `termproof run`, even though no run publishes. Now resolved on demand, keeping shape parity with the other eight.
- **The example publisher dropped `target.dry_run`,** making `--dry-run` silently ineffective for the pattern plugin authors copy.
- **`PublishedArtifact`'s docstring contradicted the caller** on what a manifest entry requires. Reworded to match.

One informational finding was correct and worth recording: the structural commit originally claimed that moving `import_class` keeps pexpect/pyte out of the lightweight publish CLI. It does not — `termproof/__init__.py` imports the runner, so they load regardless. The move is still a sound decoupling of `import_class` from the runner; the false claim was removed from the commit message rather than left to mislead.

## Verified by hand

The validation pipeline could not complete for environmental reasons unrelated to this change (its review agent could not start), so the final state was verified directly:

- `uv run ruff check .` — clean
- `uv run mypy termproof/` — clean, 35 source files
- `uv run python -m unittest discover -s tests` — **485 passed**
- `PYTHONPATH=plugin-template/src uv run python -m unittest discover -s plugin-template/tests` — **51 passed**
- `uv run termproof run examples/generic --video` — 1/1 passed, video produced
- `publish-videos` CLI smoke against a real evidence tree: S3 dry run prints `1 videos (dry-run) published to s3://demo-bucket/termproof/videos` and rewrites the report link, byte-identical to the behaviour before this change; the no-base-URL dry run still prints no destination and exits 0

Note for anyone reproducing: `uv run pytest` does not work in this repo — pytest is not a project dependency. CI uses `unittest discover`, as above.

## Found by CI

The first run of the evidence job failed on the plugin-template wheel smoke test: it
pins the template package's `__all__` literally, and the template now exports the
example publisher. Both copies of that check — the one in this repository's workflow
and the one the template ships to a scaffolded project — were updated to expect
`MyStore`, and the smoke test was reproduced locally (build, install the wheel into a
clean venv, compare the export set) before pushing. All 11 checks pass, 2 skipped.

## Coordination

Additive with the concurrent per-step-screens work. `ArtifactPublisher` was appended to `protocols.py` rather than reorganising it, and the new `plugin-template/docs/protocol.md` section was inserted *before* "Context availability for assertions" rather than rewriting it, so the two changes stay trivially mergeable.

