### PR TITLE
release: 0.3.3, aligned with the Rust implementation's version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,75 @@ All notable changes to TermProof are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - Unreleased
+## [0.3.3] — 2026-08-16
+
+There is no 0.3.1 and no 0.3.2. TermProof is also implemented in Rust, in
+[md-mt/termproof-rust](https://github.com/md-mt/termproof-rust), which had
+already reached 0.3.3; the two projects are being brought together into one
+repository, so this release moves the Python package's version onto the Rust
+one rather than continuing its own count. From here a version number means the
+same set of changes in both implementations. Nothing was released as 0.3.1 or
+0.3.2 and nothing is missing from this file.
+
+### Added
+
+- **An `ArtifactPublisher` plugin protocol.** Where evidence goes is now an
+  extension point like every other part of the pipeline, registered under the
+  `artifact_publishers` config key and selected by name. A publisher implements
+  `publish(source, key) -> PublishedArtifact`: the caller decides the key layout,
+  because that is the shape of the evidence rather than a property of any store,
+  and the publisher maps the key onto its own namespace and onto a public URL.
+  The result is a record rather than a bare URL because publishing is not the
+  last step — reports link evidence by local path, so rewriting those links
+  needs the source and the URL together, which `url_map_from_published` builds.
+  A publisher reports `published=False` when it did not transfer the bytes and
+  an empty `url` when it did but cannot address them, so neither has to be an
+  exception. Neither is treated as a success either: only an artifact that is
+  both published and addressable is rewritten into a report, `publish-videos`
+  reports each declined artifact with its `detail`, records only what was stored
+  in `video-manifest.json`, and exits non-zero if anything was declined — a
+  batch that stored most of its evidence and quietly dropped the rest is the
+  same false success as one that stored none. Report links are rewritten to the
+  URLs the selected publisher reported rather than to a predicted S3 layout, so
+  no store's address scheme can speak for another, and `--dry-run` is refused by
+  a publisher that takes no target, since it would never see the flag and would
+  publish for real. The existing S3/R2 path is the first implementation
+  (`termproof.evidence_publish:S3ArtifactPublisher`, registered as `s3`) rather
+  than a parallel special case, and `publish-videos` gained `--publisher` to
+  select another one; `--bucket` is a precondition of that publisher rather than
+  of publishing, so another one may run without it. Publishing behaviour is
+  unchanged: same keys, same URLs, same report rewriting, same failure when
+  neither the AWS CLI nor boto3 is installed. A configured publisher is imported
+  when it is asked for rather than when a runner is built, so a store that
+  nothing publishes to cannot break an ordinary run. Deployment settings reach a
+  publisher through an optional
+  `from_target` classmethod, mirroring `from_config` for renderers, so
+  credentials stay out of the checked-in config file. See
+  `docs/plugin-protocols.md`.
+- **Assertions can read the screen captured after each step.** Until now an
+  assertion saw only the final screen, which makes anything about a state the
+  run passes through and then leaves — a dialog that was dismissed, a mid-flow
+  confirmation — inexpressible. The data already existed: `StepResult` carries a
+  per-step `screen`, and the scripted execution modes simply did not pass it on.
+  They now do, via a new `steps` argument on `VerificationRunner.evaluate_assertions`
+  and on assertion evaluation, plus a `StepAwareAssertionType` protocol exported
+  from `termproof.protocols` alongside the existing nine. The new built-in
+  `step_screen_contains` assertion takes a `step` name and a `value` substring
+  and reads that step's screen.
+
+  The change is additive: TermProof passes `steps` only to an `evaluate` that
+  declares a parameter of that name, so an assertion written against
+  `AssertionType` is still called with the original five arguments and keeps
+  working without source changes. A bare `**kwargs` deliberately does not count
+  as opting in, so an assertion that forwards unrecognised arguments to another
+  one written against the older signature cannot break either. `steps` is
+  keyword-only with a default of `None`, which also lets a step-aware assertion
+  run unchanged on a TermProof that never passes it — `None` means the execution
+  mode supplied no per-step screens, which is not the same as a run in which no
+  step ran. See `docs/plugin-protocols.md` and the `StepScreenMatches` example in
+  `plugin-template/`.
+
+## [0.3.0] — 2026-08-16
 
 ### Added
 
@@ -72,61 +140,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   binary that exists — previously any commit at all was enough, including the
   working tree's, which says nothing about what was tested.
 - **`asciinema` is now an optional extra, `termproof[record]`.** See Changed.
-- **An `ArtifactPublisher` plugin protocol.** Where evidence goes is now an
-  extension point like every other part of the pipeline, registered under the
-  `artifact_publishers` config key and selected by name. A publisher implements
-  `publish(source, key) -> PublishedArtifact`: the caller decides the key layout,
-  because that is the shape of the evidence rather than a property of any store,
-  and the publisher maps the key onto its own namespace and onto a public URL.
-  The result is a record rather than a bare URL because publishing is not the
-  last step — reports link evidence by local path, so rewriting those links
-  needs the source and the URL together, which `url_map_from_published` builds.
-  A publisher reports `published=False` when it did not transfer the bytes and
-  an empty `url` when it did but cannot address them, so neither has to be an
-  exception. Neither is treated as a success either: only an artifact that is
-  both published and addressable is rewritten into a report, `publish-videos`
-  reports each declined artifact with its `detail`, records only what was stored
-  in `video-manifest.json`, and exits non-zero if anything was declined — a
-  batch that stored most of its evidence and quietly dropped the rest is the
-  same false success as one that stored none. Report links are rewritten to the
-  URLs the selected publisher reported rather than to a predicted S3 layout, so
-  no store's address scheme can speak for another, and `--dry-run` is refused by
-  a publisher that takes no target, since it would never see the flag and would
-  publish for real. The existing S3/R2 path is the first implementation
-  (`termproof.evidence_publish:S3ArtifactPublisher`, registered as `s3`) rather
-  than a parallel special case, and `publish-videos` gained `--publisher` to
-  select another one; `--bucket` is a precondition of that publisher rather than
-  of publishing, so another one may run without it. Publishing behaviour is
-  unchanged: same keys, same URLs, same report rewriting, same failure when
-  neither the AWS CLI nor boto3 is installed. A configured publisher is imported
-  when it is asked for rather than when a runner is built, so a store that
-  nothing publishes to cannot break an ordinary run. Deployment settings reach a
-  publisher through an optional
-  `from_target` classmethod, mirroring `from_config` for renderers, so
-  credentials stay out of the checked-in config file. See
-  `docs/plugin-protocols.md`.
-- **Assertions can read the screen captured after each step.** Until now an
-  assertion saw only the final screen, which makes anything about a state the
-  run passes through and then leaves — a dialog that was dismissed, a mid-flow
-  confirmation — inexpressible. The data already existed: `StepResult` carries a
-  per-step `screen`, and the scripted execution modes simply did not pass it on.
-  They now do, via a new `steps` argument on `VerificationRunner.evaluate_assertions`
-  and on assertion evaluation, plus a `StepAwareAssertionType` protocol exported
-  from `termproof.protocols` alongside the existing nine. The new built-in
-  `step_screen_contains` assertion takes a `step` name and a `value` substring
-  and reads that step's screen.
-
-  The change is additive: TermProof passes `steps` only to an `evaluate` that
-  declares a parameter of that name, so an assertion written against
-  `AssertionType` is still called with the original five arguments and keeps
-  working without source changes. A bare `**kwargs` deliberately does not count
-  as opting in, so an assertion that forwards unrecognised arguments to another
-  one written against the older signature cannot break either. `steps` is
-  keyword-only with a default of `None`, which also lets a step-aware assertion
-  run unchanged on a TermProof that never passes it — `None` means the execution
-  mode supplied no per-step screens, which is not the same as a run in which no
-  step ran. See `docs/plugin-protocols.md` and the `StepScreenMatches` example in
-  `plugin-template/`.
 - **An `evidence:` block in `.termproof/config.yaml`.** The SVG and PNG
   renderers and the video pipeline no longer hardcode their rendering
   parameters: `evidence.svg` (character width, line height, padding, font size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "termproof"
-version = "0.3.0"
+version = "0.3.3"
 description = "Evidence-first verification for TUI and terminal applications"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "termproof"
-version = "0.3.0"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },


### PR DESCRIPTION
Aligns the Python package with the Rust implementation's version, and corrects two things the changelog was saying that were not true.

## The 0.3.0 heading was wrong

`CHANGELOG.md` had `## [0.3.0] - Unreleased`, but 0.3.0 is on PyPI. The release's own metadata gives the date:

```
$ curl -s https://pypi.org/pypi/termproof/json | jq -r '.releases["0.3.0"][].upload_time_iso_8601'
2026-08-16T06:30:58.125135Z   # termproof-0.3.0-py3-none-any.whl
2026-08-16T06:30:59.562550Z   # termproof-0.3.0.tar.gz
```

That matches the `v0.3.0` tag (`1b621c9`, #164). The heading is now `## [0.3.0] — 2026-08-16`.

## Two merged features were filed under a version that had already shipped

`#163` (`ArtifactPublisher`) and `#162` (step-aware assertions) both landed *after* the `v0.3.0` tag, but their entries were written under the `0.3.0` heading. A reader who installed 0.3.0 would have looked for them there and not found them. They move to the new `## [0.3.3]` section, unchanged in substance — both were already written for a plugin author rather than as a PR log.

Between them, what a plugin author can now do that they could not on 0.3.0:

- Send evidence somewhere other than S3/R2, by implementing `publish(source, key) -> PublishedArtifact` and registering it under `artifact_publishers`. Credentials stay out of the checked-in config via the optional `from_target` classmethod. The existing S3 path is the first implementation of the protocol rather than a special case beside it.
- Assert on a screen the run passed through and then left — a dismissed dialog, a mid-flow confirmation — via the `StepAwareAssertionType` protocol and the built-in `step_screen_contains`. Additive: an assertion written against `AssertionType` is still called with the original five arguments.

## Why there is no 0.3.1 or 0.3.2

Stated at the top of the 0.3.3 section rather than left as a gap for a reader to interpret as two withdrawn releases: TermProof is also implemented in Rust, which had already reached 0.3.3, and the two projects are being brought into one repository. Moving the Python version onto the Rust one now means a version number identifies the same set of changes in both.

## Everywhere else the version appears

| Surface | Action |
| --- | --- |
| `pyproject.toml` | `0.3.0` → `0.3.3` |
| `uv.lock` (editable root entry) | regenerated by `uv lock` |
| `termproof/**` | no `__version__` exists — `importlib.metadata` is the single source, so nothing to bump |
| `action.yml` | states a `v0.2.1+` floor, not a pin. Unchanged |
| `scripts/smoke-install.sh` | takes the version as an argument. Unchanged |
| `docs-site/`, `site/`, `docs/` | no version pins; `docs/evidence-quality.md` and `examples/colorstress/README.md` reference 0.3.0 as *when* something changed, which stays true |
| `Formula/termproof.rb` | **left at v0.2.0** — see below |

`Formula/termproof.rb` is not generated at release time: `.github/workflows/release.yml` never touches it, and `tests/test_homebrew_formula.py:17-18` asserts the exact `v0.2.0` URL and its sha256. It was not bumped for 0.3.0 either. Bumping it means a new sha256 over a release tarball that does not exist yet plus re-resolving 13 pinned resources, and it would have to change that test — a separate change, after the tag.

`scripts/check_version.py` (the drift check) passes: `version 0.3.3 consistent across pyproject.toml and CHANGELOG.md`.

## Verification

- `uv run ruff check .` — all checks passed
- `uv run mypy termproof` — no issues in 40 source files
- `uv run python -m unittest discover -s tests` — **646 tests, OK**
- `tests/test_public_claims.py` — 3 tests OK. The claims guard reads `CHANGELOG.md` as a tracked surface, so it judged the moved and new prose
- `uv build` — `termproof-0.3.3.tar.gz` and `termproof-0.3.3-py3-none-any.whl`
- That wheel installed into a fresh venv: `import termproof` works, `importlib.metadata.version('termproof')` reports `0.3.3`, `termproof --help` runs

No tag, no publish. The release goes out on a `v0.3.3` tag after this merges.
