### PR TITLE
release: 0.3.4, one version across both artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,69 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.3.4] — 2026-08-17
+
+One project, one version. The two repositories became one: the Rust
+implementation was consolidated into `md-mt/termproof`, the repository root
+became a front door for the project rather than for one implementation, the
+community-health documents converged onto a single set, and the CI, release,
+container and documentation pipelines were renamed so each says which
+implementation it serves. Both artifacts move on one version number from here.
+Two registries still mean two tags, `py-v` and `rs-v`, but one version and one
+entry.
+
+**The two implementations did not change by the same amount, and neither
+changed much.** The Python package's runtime code did not change at all; the
+Rust crate's changed in one function. Read the sections below rather than
+assuming a release this size moved both.
+
+### Python — Changed
+
+- **The package's runtime code did not change.** `python/termproof/` is
+  byte-identical to the previous release — same modules, same CLI, same
+  behaviour. What follows is payload that ships beside it in the sdist and the
+  wheel, not a reason to expect the tool to behave differently.
+- **The README that ships in the sdist is rewritten** as the Python
+  implementation's reference rather than the project's front door, which is
+  the repository README now. It points at the Rust implementation, carries the
+  renamed CI and release badges, and drops the star and fork counts.
+- **The examples are presented as a set rather than a flagship showcase.**
+  `examples/generic` is self-contained and needs no external binary, so it is
+  the starting point; the colour-stress example, the multi-turn conversation
+  and the `pi_workflow_*` recipes are listed beside it as different shapes of
+  terminal program. The recipes themselves are unchanged. TermProof knows
+  nothing about the program it drives beyond what a recipe says, and naming one
+  example the flagship read as though it did.
+- **The agent-driven test fixture names no organisation.** The fake agent in
+  `tests/test_agent_driven.py` emitted a transcript carrying a company's name.
+  Nothing asserts on that text — it only has to be a multi-line string that
+  echoes part of the prompt — and the file ships in the sdist, so the payload
+  is neutral now.
+- **The documentation that ships beside the package** — the release, Docker
+  and launch pages — describes the consolidated layout and the renamed
+  workflows.
+
+### Rust — Changed
+
+- **Almost nothing in the crate's source moved, and what did is one function.**
+  Four files under `crates/termproof/src/` differ from the previous release.
+  Three carry doc-comment corrections only — `assertions.rs`, `pyschema.rs` and
+  `terminal/session.rs`, which referred to a `harness/` directory since renamed
+  to `conformance/` and to a two-repository layout that no longer exists. The
+  fourth is `schema.rs`, and its change is described under *Rust — Fixed*
+  below. Everything else that moved for Rust is documentation, CI and packaging
+  metadata. A consumer upgrading for any reason other than
+  `load_canonical_schema` should expect no behavioural difference.
+- **cargo:** `repository`, `homepage` and `documentation` name
+  `md-mt/termproof`. They named the Rust-only repository, which no longer holds
+  the source, so the links on crates.io and docs.rs pointed at the wrong place.
+  This is the substantive reason to publish the crate again.
+- **cargo:** `tests/canonical_schema.rs` is excluded from the package. It reads
+  `python/docs/recipe-schema-v1.json`, which sits outside the crate, so
+  shipping it would put a test in the tarball that cannot pass from there.
+
 ### Rust — Fixed
 
 - **release:** the auto-release moves the whole version train. It bumped
@@ -43,6 +106,15 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   `python/docs/recipe-schema-v1.json`. Its candidate paths described
   side-by-side checkouts from before the two implementations shared a
   repository, so it returned `None` everywhere.
+
+  **This is the one behavioural change a consumer of the published crate can
+  observe.** The path is resolved from `CARGO_MANIFEST_DIR` alone. One of the
+  old candidates was `docs/recipe-schema-v1.json` relative to the working
+  directory, so the function could read whatever file of that name happened to
+  sit in a consumer's tree and hand it back as TermProof's canonical schema.
+  The crate does not vendor the schema, so `None` is the correct answer from a
+  registry checkout, and `None` is what it returns. `load_canonical_schema_from_dir`
+  is new and doc-hidden; it exists so a test can prove the packaged case.
 
 ## [0.3.3] — 2026-08-16
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "termproof"
-version = "0.3.3"
+version = "0.3.4"
 description = "Evidence-first verification for TUI and terminal applications"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "termproof"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "termproof"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "avt",
  "chrono",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "termproof-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "serde_json",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "termproof-plugin-protocol"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.96"
 license = "MIT"
@@ -59,7 +59,7 @@ all = "warn"
 # dependency floors` step in .github/workflows/rust-ci.yml runs the suite at each
 # floor, so a floor that stops being true fails CI rather than rotting quietly.
 [workspace.dependencies]
-termproof = { path = "crates/termproof", version = "0.3.3" }
+termproof = { path = "crates/termproof", version = "0.3.4" }
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode"] }
 # Floor 0.16, tested at 0.16.2. `jsonschema` 0.33 asks for `^0.16` itself, so a
 # caret on 0.19 put two copies of a backtracking regex engine in the graph of
@@ -187,4 +187,4 @@ avt = "0.16"
 chrono = "0.4"
 globset = "0.4"
 clap = { version = "4.5", features = ["derive"] }
-termproof-plugin-protocol = { path = "crates/termproof-plugin-protocol", version = "0.3.3" }
+termproof-plugin-protocol = { path = "crates/termproof-plugin-protocol", version = "0.3.4" }


### PR DESCRIPTION
## Summary

Cuts **0.3.4** across the consolidated repository: one version number, one
changelog entry, both artifacts. The two registries still mean two tags
(`py-v0.3.4`, `rs-v0.3.4`), but the version and the entry are shared.

Produced by `.github/scripts/rust/version-bump.py 0.3.4`, plus `uv lock` for
the Python lockfile, which the script does not touch. Nothing else was edited
by hand except the `[Unreleased]` prose the script then promoted.

| Surface | Moved |
| --- | --- |
| `rust/Cargo.toml` `[workspace.package] version` | 0.3.3 → 0.3.4 |
| `rust/Cargo.toml` `[workspace.dependencies]` `termproof`, `termproof-plugin-protocol` | 0.3.3 → 0.3.4 |
| `python/pyproject.toml` `[project] version` | 0.3.3 → 0.3.4 |
| `rust/Cargo.lock` (`cargo update -w`) | all three members |
| `python/uv.lock` (`uv lock`) | `termproof` editable |
| `CHANGELOG.md` | `[Unreleased]` → `[0.3.4] — 2026-08-17` |

## The changelog entry says what each artifact actually gained — and it differs

This is the part worth reviewing.

- **Python: no runtime change at all.** `python/termproof/` is byte-identical
  to 0.3.3. Everything under *Python — Changed* is sdist payload: the rewritten
  README, the examples presented as a set rather than a flagship showcase, the
  neutral agent fixture, the reworked docs.
- **Rust: nearly unchanged, but not identical, and the entry says so.** Four
  files under `crates/termproof/src/` differ from 0.3.3. Three are doc-comment
  corrections. The fourth, `schema.rs`, is a real behavioural change a crate
  consumer can observe — `load_canonical_schema` no longer falls back to a
  working-directory path, so a registry checkout can no longer read an
  unrelated `docs/recipe-schema-v1.json` and hand it back as TermProof's
  canonical schema. It returns `None`, which is the honest answer for a crate
  that does not vendor the file.
- The crate's `repository`, `homepage` and `documentation` links also stop
  pointing at the retired Rust-only repository. That is the substantive reason
  to publish the crate again.

The entry is not padded to make the two sides look equally substantial.

### Correction to the premise this release was scoped on

The release brief stated the Rust crate source is byte-identical to 0.3.3,
verified by `git diff rs-baseline-v0.3.3..main -- rust/crates/termproof/src/`
being empty. That check is vacuous: `rs-baseline-v0.3.3` is a lightweight tag
**on `main` itself** (`51a49617`), so the diff compares `main` to `main`.

Against the state the Rust implementation was consolidated at
(`808c92d`, which carried `version = "0.3.3"`), the crate source *does*
differ — the four files above. The changelog reflects what is actually there.

## Which implementation

- [x] Python (`python/`)
- [x] Rust (`rust/`)
- [x] Shared — `spec/`, `conformance/`, `.github/`, or a root document

## Linked issue

None — release chore.

## Test plan

Every gate run locally on this commit.

| Gate | Result |
| --- | --- |
| `python/scripts/check_version.py` | `version 0.3.4 consistent across pyproject.toml, rust/Cargo.toml and CHANGELOG.md` |
| `uv run ruff check .` | all checks passed |
| `uv run mypy termproof` | no issues, 40 source files |
| `uv run python -m unittest discover -s tests` | 684 tests, OK |
| `uv lock --check` | clean |
| `uv build` | `termproof-0.3.4.tar.gz`, `termproof-0.3.4-py3-none-any.whl` |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo test --workspace` | 0 failed |
| 16 feature combinations (clippy + test) | all 16 exit 0 |
| `cargo package --list -p termproof` | 75 files, byte-identical path list to 0.3.3 |
| `verify-package-contents.sh` | `termproof tarball contents verified (75 files)` |
| `publish-plan.py` | `{"version": "0.3.4", "order": ["termproof"], "held": [...]}` |

The public-claims guard (`test_public_claims.py`) and the single-current-version
guard (`test_current_version_claims.py`) both pass against the new prose. The
"published" claims in `SECURITY.md` and `rust/docs/publishing.md` deliberately
stay at 0.3.3: nothing is published at 0.3.4 yet, and a version bump legitimately
precedes the publish it enables.

- [ ] Added/updated unit tests for behavioural changes — N/A, no behavioural change here
- [ ] Screenshots / evidence attached — N/A

## `release-decide.py --to HEAD` — read this before merging

It does **not** report "no release", which is what was expected. It reports:

```json
{
  "release": true,
  "reason": "1 commit(s) and 2 releasable path(s) changed since rs-baseline-v0.3.3",
  "base": "rs-baseline-v0.3.3",
  "current_version": "0.3.4",
  "next_version": "0.3.5",
  "tag": "rs-v0.3.5",
  "bump": "patch",
  "changed_paths": ["rust/Cargo.lock", "rust/Cargo.toml"]
}
```

Why: the belt-and-braces exclusion in `release-decide.py` drops only subjects
matching `^chore\(release\):`, which is the automation's own voice. This is a
hand-cut release commit (`release: 0.3.4, …`, matching the `release: 0.3.3`
precedent), so it is not excluded, and `rust/Cargo.toml` + `rust/Cargo.lock`
are both releasable paths.

**Consequence, once this merges:** `rust-auto-release.yml` runs on the Monday
07:00 UTC schedule. If it fires while this bump sits on `main` untagged, it
will cut `rs-v0.3.5` and publish the crate at **0.3.5**, skipping 0.3.4
entirely. Tagging `rs-v0.3.4` on the merge commit closes the window — the tag
becomes the new base and the range goes empty. Left as a maintainer decision;
this PR creates no tags.

## Tidy First

- [x] N/A (release chore)

## Checklist

- [x] Title and commits follow Conventional Commits
- [x] No comments/docstrings/type hints added to untouched code
- [x] Branch follows naming convention
- [x] No large binaries checked in
- [x] `CHANGELOG.md` updated
- [x] No new claim the code does not support — guard run, green
- [x] Backward-compatibility contract respected
- [x] The two implementations' divergence for this release is recorded in the entry

## Not done, on purpose

No tag created or pushed, nothing published, no repository settings touched,
not merged.
