### PR TITLE
deps: narrow the fancy-regex requirement to ^0.16

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -77,17 +77,23 @@ jobs:
               --no-default-features --features "$combo" -- -D warnings
             cargo test --manifest-path rust/Cargo.toml -p termproof --no-default-features --features "$combo"
           done
-      # A widened requirement is a claim that the code works at the bottom of
-      # the range, and nothing above tests that: the committed lockfile resolves
-      # every range to its top. So each floor widened in #28 is pinned here and
-      # the suite is run against it. Rewriting the requirement to `=` beats
-      # `cargo update --precise`, which cannot name a crate the graph contains
-      # twice — which is exactly the fancy-regex case this widening exists to
-      # let a consumer collapse. Last step in the job: it dirties Cargo.toml
+      # A requirement is a claim that the code works at the bottom of its range,
+      # and nothing above tests that: the committed lockfile resolves each one
+      # to whatever cargo picked, which is not the floor. So each floor declared
+      # in the workspace manifest is pinned here and the suite is run against
+      # it. Rewriting the requirement to `=` beats `cargo update --precise`,
+      # which cannot name a crate the graph contains twice — and this graph does
+      # contain fancy-regex twice at the jsonschema floor, because jsonschema
+      # 0.32.0 asks for `^0.15` while we ask for `^0.16` (sharing one engine
+      # with it starts at 0.32.1). Last step in the job: it dirties Cargo.toml
       # and Cargo.lock, and the checkout is thrown away straight after.
+      #
+      # fancy-regex pins to 0.16.0, the bottom of `^0.16`, and not to the 0.16.2
+      # the lockfile resolves: pinning the version the lock already picks would
+      # re-run what the steps above ran and test nothing new (#177).
       - name: test at the declared dependency floors
         run: |
           set -eux
-          perl -pi -e 's{^fancy-regex = .*}{fancy-regex = "=0.16.2"}' rust/Cargo.toml
+          perl -pi -e 's{^fancy-regex = .*}{fancy-regex = "=0.16.0"}' rust/Cargo.toml
           perl -pi -e 's{^jsonschema = .*}{jsonschema = "=0.32.0"}' rust/Cargo.toml
           cargo test --manifest-path rust/Cargo.toml --workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,42 @@ Nothing yet.
 
 ## [0.4.0] — 2026-08-19
 
+### Rust — Changed
+
+- **cargo:** the `fancy-regex` requirement was narrowed to `0.16` from
+  `>=0.16, <0.20`. The headroom bought nothing and cost a duplicate. Cargo does
+  not unify across `0.x` minors: handed a range it takes the top of it, not a
+  copy the graph already holds. Resolved fresh, the old requirement put
+  `fancy-regex` 0.16.2 *and* 0.19.0 in this workspace's own lockfile —
+  `jsonschema`'s copy and ours — and only the committed lockfile, written when
+  the requirement was narrower, kept the pair out of sight. `deny.toml` sets
+  `bans.multiple-versions = "deny"` with no skip for `fancy-regex`, so the
+  first regeneration of that lockfile would have failed the security job.
+  `^0.16` was what `jsonschema` 0.32.1 and 0.33.0 asked for themselves, so a
+  default build shared one backtracking regex engine with it by construction.
+  Nothing in the crate needed a newer one: the suite and both differential
+  harnesses were run at 0.16.0, 0.16.1, 0.16.2, 0.17.0, 0.18.0 and 0.19.0, and
+  the parity numbers were identical at every one. The committed lockfile did
+  not change — it already resolved 0.16.2.
+
+  **It cost a consumer nothing, which is a property this release had to buy
+  first.** While `pyregex::compile` returned a `fancy_regex::Regex`, changing
+  this requirement changed which single version a consumer could name that type
+  from: under `>=0.16, <0.20` a consumer pinned to 0.19.0 compiled and one
+  pinned to 0.16.2, 0.17.0 or 0.18.0 did not, and narrowing would only have
+  swapped the ends. With no `fancy-regex` type left in the public API, a
+  consumer on any version compiled either way, and the most the requirement
+  could cost was a second copy in the graph — which narrowing it removed.
+  ([#177](https://github.com/md-mt/termproof/issues/177))
+
+- **ci:** the `test at the declared dependency floors` step was retargeted to
+  pin `fancy-regex` to 0.16.0, the bottom of the new requirement, rather than
+  to the 0.16.2 the lockfile already resolved — pinning what the lock picks
+  would have re-run what the earlier steps already ran. Its comment had also
+  claimed the committed lockfile resolves every range to its top, which was
+  never true of this entry and is what let the duplicate hide.
+  ([#177](https://github.com/md-mt/termproof/issues/177))
+
 ### Rust — Changed (breaking)
 
 **No dependency reaches this crate's public API any more, except `schemars`.**

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,16 +58,49 @@ all = "warn"
 # is a comment naming the API that put it there (#28). The `test at the declared
 # dependency floors` step in .github/workflows/rust-ci.yml runs the suite at each
 # floor, so a floor that stops being true fails CI rather than rotting quietly.
+#
+# A ceiling costs that same copy in the other direction, and headroom does not
+# buy sharing: given a range, cargo takes the top of it, not whatever version
+# the consumer already has. So an upper bound written above what the code needs
+# is a floor written too high, mirrored, and wants the same kind of comment
+# naming what it buys (#177).
 [workspace.dependencies]
 termproof = { path = "crates/termproof", version = "0.4.0" }
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode"] }
-# Floor 0.16, tested at 0.16.2. `jsonschema` 0.33 asks for `^0.16` itself, so a
-# caret on 0.19 put two copies of a backtracking regex engine in the graph of
-# every default build — ours and its — which pinning to 0.16.2 now collapses.
-# Nothing here needs 0.19: the one thing that did was a type annotation naming
-# `Captures`, which gained a haystack parameter in 0.19 and is now left to
-# inference (see `steps::try_match`).
-fancy-regex = ">=0.16, <0.20"
+# 0.16 at both ends, tested at 0.16.0. `jsonschema` 0.32.1 and 0.33.0 both ask
+# for `^0.16` themselves, and across the whole `>=0.32, <0.34` declared below
+# those are the only versions that ask for a 0.16 at all — 0.32.0 asks `^0.15`.
+# So `^0.16` is the one requirement a default build can satisfy out of
+# `jsonschema`'s copy of the backtracking engine instead of standing up a
+# second one, and it cannot rot while the `jsonschema` range is what it is.
+#
+# Nothing here needs anything above it. Measured in #177 rather than assumed:
+# the workspace builds and the whole suite passes at 0.16.0, 0.16.1, 0.16.2,
+# 0.17.0, 0.18.0 and 0.19.0, and both differential harnesses report the same
+# parity at every one — steps 82/115 full and 113/115 verdict, assertions
+# 124/147 full and 143/147 verdict. The one thing that ever needed 0.19 was a
+# type annotation naming `Captures`, which gained a second generic parameter
+# there and is now never named at all — `pyregex::PyRegex::captures` reads the
+# groups out under inference.
+#
+# The ceiling is narrow because a wide one does not let a consumer *share*.
+# Cargo does not unify across 0.x minors; handed a range it takes the top. The
+# previous `>=0.16, <0.20` proved it on this very workspace: resolved fresh it
+# put 0.16.2 *and* 0.19.0 in the lock, `jsonschema`'s and ours, and only the
+# committed lockfile — written when the requirement was narrower — hid the pair
+# from us. `bans.multiple-versions = "deny"` in deny.toml carries no skip for
+# `fancy-regex`, so the first regeneration of that lockfile would have failed
+# the security job (#177).
+#
+# This costs a consumer nothing, and that is a property 0.4.0 had to buy first.
+# While `pyregex::compile` returned a `fancy_regex::Regex`, moving this bound
+# moved which single version a consumer could name that type from — measured on
+# `>=0.16, <0.20`, a consumer pinned to 0.19.0 compiled and one pinned to
+# 0.16.2, 0.17.0 or 0.18.0 did not, and narrowing would merely have swapped the
+# ends. No `fancy-regex` type is in the public API now, so a consumer on any
+# version compiles either way; the most this requirement can cost anyone is a
+# second copy in the graph, which is exactly what narrowing it removes.
+fancy-regex = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
@@ -82,11 +115,11 @@ serde_yaml = "0.9"
 #
 #    This used to read "Releases here bump the patch digit only." That was
 #    never a rule, only a description of the releases that had happened, and
-#    this one makes it false. The rule, from docs/publishing.md, is that pre-1.0 a
-#    breaking change to any public API is a *minor* bump and everything else is
-#    a patch — so a `schemars` major would be permitted, at the price of a
-#    minor. It is still not taken, for reason 2, which does not depend on the
-#    version digit at all.
+#    this one makes it false. The rule, from docs/publishing.md, is that
+#    pre-1.0 a breaking change to any public API is a *minor* bump and
+#    everything else is a patch — so a `schemars` major would be permitted, at
+#    the price of a minor. It is still not taken, for reason 2, which does not
+#    depend on the version digit at all.
 #
 # 2. `preserve_order` does not mean the same thing across the majors, and the
 #    difference is graph-global. In 0.8 it is `["indexmap"]`, scoped to


### PR DESCRIPTION
Closes #177. Diff 3 of 3. **Stacked on #186** — review that first; the diff here is against it.

The narrowing itself is unchanged from the first round. What changed is what it *costs*, and that is the whole point of the stack.

## Why this is now safe

Round 1 was blocked because `pyregex::compile` returned a `fancy_regex::Regex`, so this requirement decided which version a consumer could name that type from. Round 2 found the re-exports were a second door onto the same thing — `termproof::fancy_regex::Captures` broke `E0107` across exactly this narrowing. #186 has now closed both, plus the derived `Debug`, so this requirement decides nothing but the shape of the graph.

Measured on a consumer that annotates the type, before and after the wrap:

| Consumer pins `fancy-regex` | `>=0.16, <0.20`, types leaked | `0.16`, types leaked | **`0.16`, types wrapped (this stack)** |
|---|---|---|---|
| 0.16.2 | fail `E0308` | pass | **pass** |
| 0.17.0 | fail `E0308` | fail | **pass** |
| 0.18.0 | fail `E0308` | fail | **pass** |
| 0.19.0 | pass | fail `E0308` | **pass** |

And through the re-export path the reviewer used, which #186 removed: `termproof::fancy_regex::Captures<'_, str>` compiled on the old #186 head and failed `E0107` here. It is now `E0433` — the path is gone, rather than breaking on a version.

The middle column is why round 1 was rejected. The first column is the finding that came out of investigating it: the wide range was never buying range-wide compatibility — cargo takes the **top** of a range, so exactly one version ever unified, and narrowing would only have swapped which one. It also means `main` today is source-incompatible with 0.16.2, the version its own `jsonschema` forces into every default build.

With the types wrapped, all four compile. Verified by building and **running** a consumer that carries its own `fancy-regex 0.19.0`, `jsonschema 0.32.1` and `vt100 0.15.2` against this head.

## What the narrowing still buys

A fresh resolve of this workspace under `>=0.16, <0.20` produced **two** copies — 0.16.2 for `jsonschema`, 0.19.0 for us — and the committed lockfile was the only thing hiding it. `deny.toml` sets `bans.multiple-versions = "deny"` with no skip for `fancy-regex`, so the first regeneration would have failed the security job.

`^0.16` is exactly what `jsonschema` 0.32.1 and 0.33.0 ask for, so a default build shares one engine by construction. Within the declared `>=0.32, <0.34` those are the only versions asking for a 0.16 at all (0.32.0 asks `^0.15`), so it cannot rot while that range stands.

**The cost is now zero.** The most this requirement can do to anyone is add a second copy to their graph, which is what narrowing removes.

## Parity, unchanged at every version

Suite plus both differential harnesses at 0.16.0, 0.16.1, 0.16.2, 0.17.0, 0.18.0, 0.19.0 — steps 82/115 full and 113/115 verdict, assertions 124/147 full and 143/147 verdict, identical at all six.

`rust/Cargo.lock` is **unchanged**: it already resolved 0.16.2.

## The floor CI step, and what it caught

Retargeted to pin `=0.16.0`, the bottom of `^0.16`, instead of `=0.16.2` — which is what the lock now resolves, so pinning it would re-run the earlier steps and test nothing.

That retarget immediately earned itself: it failed, because `fancy_regex::Regex::as_str()` returns `x$` on 0.16.0 and `x\z` on 0.16.2. `PyRegex::as_str` was forwarding to it, which would have put an engine-*version*-dependent answer in the public API — the same leak as a leaked type, in behavioural form. Fixed in #186, where the method is introduced, so this PR does not ship a bug the stack below it fixes.

Its comment also claimed the lockfile resolves every range to its top. That was never true of this entry, and is precisely what let the duplicate hide.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check --all` | pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --workspace` | 24 binaries, 0 failed |
| `python -m unittest discover -s tests` | 741 tests, OK |
| All 16 feature combinations | 16/16 pass |
| `test at the declared dependency floors`, as CI runs it | pass |
| `cargo semver-checks check-release -p termproof` | pass |
| Differential harnesses | steps 82/115 and 113/115, assertions 124/147 and 143/147 |
| `cargo deny check` | `advisories ok, bans ok, licenses ok, sources ok` |
| `python/scripts/check_version.py` | `0.4.0 consistent` |
| Consumer on 0.19.0 / 0.32.1 / 0.15.2 | compiles and runs |
| `rust/Cargo.lock` | unchanged |

## Stack

1. ~~#184~~ — re-exports + docs (merged, `a729c71`)
2. #186 — wrap the leaked types + 0.4.0 (breaking)
3. **this PR** — narrow `fancy-regex` to `^0.16` (unchanged since round 1; what changed is #186 beneath it)
