### PR TITLE
Put the canonical recipe schema inside each distributable

### DIFF
--- a/.github/scripts/rust/verify-package-contents.sh
+++ b/.github/scripts/rust/verify-package-contents.sh
@@ -6,10 +6,12 @@
 # is the authoritative manifest of the tarball, so this script checks that
 # list rather than the files on disk.
 #
-# Required: the snapshot test and its fixture ship (issue #33 added the
-# snapshot on the promise that consumers could run it), and the differential
-# tests, which replay the root conformance corpus and cannot run without it,
-# do not.
+# Required: the canonical recipe schema and the test that proves the seam
+# reads it (issue #174 — the crate used to reach outside itself for the schema,
+# so neither shipped), the snapshot test and its fixture (issue #33 added the
+# snapshot on the promise that consumers could run it), and *not* the
+# differential tests, which replay the root conformance corpus and cannot run
+# without it.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)/rust"
@@ -24,6 +26,8 @@ for required in \
   LICENSE \
   README.md \
   src/lib.rs \
+  resources/recipe-schema-v1.json \
+  tests/canonical_schema.rs \
   tests/schema_snapshot.rs \
   tests/snapshots/recipe_schema_v1.json
 do
@@ -34,13 +38,11 @@ do
 done
 
 # Absent: repository-only artifacts that must not reach consumers. The
-# differential tests replay the root conformance corpus and the canonical-schema
-# test reads python/docs/recipe-schema-v1.json — neither is shipped, so a
-# tarball that carries those tests cannot run them.
+# differential tests replay the root conformance corpus, which is not shipped,
+# so a tarball that carries those tests cannot run them.
 for forbidden in \
   tests/differential_steps.rs \
   tests/differential_assertions.rs \
-  tests/canonical_schema.rs \
   conformance/
 do
   if grep -q "^${forbidden}" <<<"$LIST"; then

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,6 +17,12 @@ name: CI (Python)
 # `test_docs_site.py` read the Pages and docs-site workflows. Eight of the nine
 # were outside this filter, so editing one ran nothing that reads it.
 #
+# `rust/crates/termproof/resources/**` is the crate's copy of the canonical
+# recipe schema. Each package carries the schema inside itself (#174), so
+# `check_schema_copies.py` in the `lint` job holds every copy byte-identical
+# against the Python package resource — and it has to run when *any* of them
+# moves, which is why a `rust/` path is in a Python workflow's filter.
+#
 # The two lists are identical and written out twice: GitHub Actions does not
 # expand YAML anchors, so an alias here would be read as a literal string and
 # match nothing.
@@ -33,6 +39,7 @@ on:
       - "SECURITY.md"
       - "SUPPORT.md"
       - "rust/Cargo.toml"
+      - "rust/crates/termproof/resources/**"
       - ".github/workflows/**"
       - ".github/scripts/**"
   push:
@@ -49,6 +56,7 @@ on:
       - "SECURITY.md"
       - "SUPPORT.md"
       - "rust/Cargo.toml"
+      - "rust/crates/termproof/resources/**"
       - ".github/workflows/**"
       - ".github/scripts/**"
 
@@ -119,6 +127,16 @@ jobs:
       # pyproject.toml, rust/Cargo.toml and the root CHANGELOG to it.
       - name: Version and changelog drift
         run: uv run python scripts/check_version.py
+
+      # Each package carries the canonical recipe schema inside itself, and
+      # `docs/` keeps a copy at the path the schema is published at (#174).
+      # This is what keeps all three one file. It lives here, in the job that
+      # already owns cross-implementation drift, and not in CI (Rust): this
+      # workflow's path filter covers every copy, so any of them changing runs
+      # it, while `rust/**` would miss an edit to the Python side entirely.
+      # The release paths repeat it — see check_schema_copies.py.
+      - name: Canonical recipe schema drift across all copies
+        run: uv run python scripts/check_schema_copies.py
 
   test:
     name: Unit tests and coverage (py${{ matrix.python-version }})

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -68,6 +68,14 @@ jobs:
       - name: Run unit tests
         run: uv run python -m unittest discover -s tests
 
+      # The schema ships inside the artifact built below, and every other copy
+      # of it — the crate's and the published docs path — has to be the same
+      # bytes (#174). CI (Python) runs this on pull requests and on `main`, but
+      # a tag can be cut from a commit that went through neither, so the gate
+      # is repeated where the artifact is actually built.
+      - name: Canonical recipe schema drift across all copies
+        run: python3 scripts/check_schema_copies.py
+
       - name: Build package
         run: uv build
 

--- a/.github/workflows/rust-auto-release.yml
+++ b/.github/workflows/rust-auto-release.yml
@@ -304,6 +304,16 @@ jobs:
       - name: Verify the version train
         run: python3 python/scripts/check_version.py
 
+      # The same argument, for the other thing both artifacts have to agree
+      # on: each carries its own copy of the canonical recipe schema, and the
+      # tag cut below is what turns a mismatched copy into two published
+      # artifacts that disagree about what a recipe is (#174). CI (Python)
+      # runs this on pull requests and on `main`; this job can reach a commit
+      # that went through neither. Standard library only, like the check
+      # above.
+      - name: Verify the canonical recipe schema copies
+        run: python3 python/scripts/check_schema_copies.py
+
       # Exactly the check publish-crates.yml makes on `release: published`,
       # made here instead — where a mismatch costs a failed run rather than a
       # tag that publishes nothing.

--- a/.github/workflows/rust-publish-crates.yml
+++ b/.github/workflows/rust-publish-crates.yml
@@ -118,6 +118,13 @@ jobs:
         run: cargo test --manifest-path rust/Cargo.toml --workspace
       - name: build
         run: cargo build --manifest-path rust/Cargo.toml --workspace --release
+      # The crate embeds the canonical schema, so this gate has to see the
+      # Python package's copy of it too (#174). CI (Python) runs the same check
+      # on pull requests and on `main`; a release can be published from a
+      # commit that went through neither, and the tarball uploaded below is
+      # exactly where a mismatched copy would become permanent.
+      - name: Canonical recipe schema drift across all copies
+        run: python3 python/scripts/check_schema_copies.py
 
   # Verifies every publishable package by building it from its own tarball,
   # with the not-yet-published ones overlaid in a temporary local registry.

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -83,6 +83,14 @@ jobs:
         with:
           toolchain: "1.96.0"
           targets: ${{ matrix.target }}
+      # The binary built below embeds the canonical recipe schema, so the copy
+      # it embeds has to be the one the Python package ships (#174). Cheap
+      # enough to repeat per target, and a release tag can be pushed by hand
+      # from a commit that never went through CI (Python), which is the only
+      # other place this runs on a non-release path.
+      - name: Canonical recipe schema drift across all copies
+        run: python3 python/scripts/check_schema_copies.py
+
       - name: Build release
         run: cargo build --manifest-path rust/Cargo.toml --release --target ${{ matrix.target }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,11 +75,58 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   keeps its `0.2.0` numbers — they are what that plan said — under a header
   saying plainly that it was never executed at that version.
 
+### Python — Fixed
+
+- The canonical recipe schema is a package resource
+  (`termproof/_resources/recipe-schema-v1.json`) rather than a docs file
+  relocated into the package at wheel-build time. It shipped in the wheel and
+  nowhere else: a build system that consumes the sdist's sources directly runs
+  no hatchling force-include, so `recipe_schema.load_recipe_schema()` found
+  nothing and had to be patched back by hand on every version bump. The wheel
+  layout is unchanged — same path, no force-include — and the sdist now carries
+  the schema too. `load_recipe_schema()` lost its `docs/` fallback, which
+  existed only because the resource was conditional (#174).
+
+### Rust — Fixed
+
+- `schema::load_canonical_schema` returns the canonical schema for every
+  consumer, including a crates.io one. It resolved
+  `../../../python/docs/recipe-schema-v1.json` from `CARGO_MANIFEST_DIR`; a
+  registry checkout has no repository above it, so the function returned `None`
+  for its actual audience. The crate now carries the schema at
+  `resources/recipe-schema-v1.json` and embeds it with `include_str!`, so it
+  reads no path outside itself and no working directory can influence the
+  answer — the property the 0.3.4 removal of the cwd fallback was protecting,
+  now held without giving up the schema (#174).
+
+### Rust — Added
+
+- `schema::CANONICAL_SCHEMA_JSON`, the embedded canonical schema as text.
+- `tests/canonical_schema.rs` ships in the published package. It was excluded
+  in 0.3.4 because it read outside the crate; it no longer does, so the seam is
+  testable from the artifact that is published — including the decoy-directory
+  regression (#174).
+
 ### Changed
 
 - **`python/tests/test_docs_pages.py` no longer forbids `pip install
   termproof`.** It asserted the command's absence because the package was
   unpublished, and went on passing after the publish made that wrong.
+- **`python/docs/recipe-schema-v1.json` stays where it is.** It is now a
+  byte-identical copy rather than the original. It is not in the wheel, so no
+  installed package carries it and no import path reaches it; the sdist ships
+  it, as it ships all of `docs/`, and nothing loads it there either. It is kept
+  because it is a *published path*: the schema has always been linked from
+  `docs/recipe-format-v1.md`, so it may already be in a `$schema` line, a
+  script or a bookmark, and moving a file inside the packages is no reason to
+  404 a URL. The packaging argument against a third copy is about artifacts and
+  answers a different question (#174).
+- CI holds every copy of the canonical schema byte-identical against the
+  package resource (`python/scripts/check_schema_copies.py`). It runs in `CI
+  (Python)` and in all four release paths — Python release, Rust release, Rust
+  publish and Rust auto-release — because a tag can be cut from a commit that
+  passed neither pull-request nor `main` CI, and a mismatch there is two
+  published artifacts disagreeing about what a recipe is (#174).
 
 ### Python — Added
 

--- a/python/docs-site/api/index.md
+++ b/python/docs-site/api/index.md
@@ -10,7 +10,7 @@ TermProof stabilizes the recipe format and plugin protocols as public integratio
 - `assertions` evaluate output, screen text, exit code, files, or JSON Schema.
 - `renderers` fan one recipe out across multiple frontend implementations.
 
-See `docs/recipe-format-v1.md` and `docs/recipe-schema-v1.json` in the repository for the complete schema and migration policy.
+See `docs/recipe-format-v1.md` and `docs/recipe-schema-v1.json` in the repository for the complete schema and migration policy. The installed package validates against `termproof/_resources/recipe-schema-v1.json`, a byte-identical copy inside the package.
 
 ## Plugin Protocols
 

--- a/python/docs/recipe-format-v1.md
+++ b/python/docs/recipe-format-v1.md
@@ -54,7 +54,21 @@ termproof validate .termproof/recipes
 
 The validator checks JSON shape, required fields, configured step/action names, configured assertion names, and basic timeout/dimension sanity. It accepts `--config` with the same config cascade behavior as `termproof run`.
 
-The formal JSON Schema is published at [`recipe-schema-v1.json`](recipe-schema-v1.json).
+The formal JSON Schema is published at
+[`recipe-schema-v1.json`](recipe-schema-v1.json), beside this page, as it
+always has been.
+
+That file is a byte-identical copy, kept so the published path does not move.
+The schema the code reads is a resource *inside* each package —
+[`termproof/_resources/recipe-schema-v1.json`](../termproof/_resources/recipe-schema-v1.json)
+for Python, `rust/crates/termproof/resources/recipe-schema-v1.json` for the
+Rust crate — because a copy under `docs/` is outside the Python package and
+outside the Rust crate. The sdist does carry this one, as it carries all of
+`docs/`, but no import path reaches it and the wheel does not have it at all:
+the Python package only carried the schema if a build-time relocation had run,
+and the crate could not reach it from a registry checkout (#174). Load it from
+Python with `termproof.recipe_schema.load_recipe_schema()`; CI holds all three
+copies byte-identical (`python/scripts/check_schema_copies.py`).
 
 Recipes that verify JSON-producing CLIs can use the built-in `json_schema` assertion. Set `schema` to either an inline JSON Schema object or a recipe-relative schema file path.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -46,8 +46,14 @@ termproof = "termproof.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["termproof"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"docs/recipe-schema-v1.json" = "termproof/_resources/recipe-schema-v1.json"
+# The canonical recipe schema is a package resource
+# (`termproof/_resources/recipe-schema-v1.json`), not a docs file relocated at
+# build time. It used to be force-included here from `docs/`, which put it in
+# the wheel and nowhere else: a build system that consumes the sdist's sources
+# directly never runs a hatchling force-include, so
+# `recipe_schema.load_recipe_schema()` found nothing (#174). Owning the file
+# inside the package means every artifact that carries `termproof/` carries the
+# schema, with no build step to reproduce.
 
 [tool.hatch.build.hooks.custom]
 path = "hatch_build.py"

--- a/python/scripts/check_schema_copies.py
+++ b/python/scripts/check_schema_copies.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Byte-equality gate for every copy of the canonical recipe schema (#174).
+
+The Python package resource is the reference. Every other copy is compared
+against it, byte for byte, and each exists for a reason it cannot be talked out
+of:
+
+  python/termproof/_resources/recipe-schema-v1.json
+      The reference. `recipe_schema.load_recipe_schema()` reads this and only
+      this, so it is what the wheel and the sdist ship and what a build system
+      assembling the package from sdist sources gets.
+
+  rust/crates/termproof/resources/recipe-schema-v1.json
+      The crate's copy, embedded with `include_str!`. A registry checkout has
+      no repository above it, so a crate that looks outside itself for the
+      schema does not have it.
+
+  python/docs/recipe-schema-v1.json
+      Compatibility only. This is the path the schema was published at, linked
+      from `docs/recipe-format-v1.md`, and a URL someone may already have in a
+      `$schema` line, a script or a bookmark. It is not in the wheel, so it is
+      not in an installed package and no import path reaches it; the sdist does
+      carry it, because the sdist ships `docs/` and a source distribution
+      missing a checked-in source file would be the anomaly. Nothing loads it
+      either way, so it costs a file here and nothing downstream.
+
+One copy per self-contained artifact is the floor; a wheel cannot read a file
+out of a crate. The docs copy is above that floor and is kept anyway, because
+breaking a published URL is a separate decision from fixing packaging and this
+change is not making it.
+
+The check is on bytes, not on parsed JSON: the crate embeds the text with
+`include_str!`, so whitespace and key order are part of what ships, and a
+published URL should serve the same bytes it always did.
+
+There is no `--fix`. Which copy is right is a decision, and silently rewriting
+one of them would turn an edit made in the wrong place into a green build.
+Change the schema everywhere, in the same commit.
+
+Usage:
+  python scripts/check_schema_copies.py
+
+Exit codes: 0 all identical, 1 drift or a missing copy.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+REPO_ROOT = ROOT.parent
+
+# The path `load_recipe_schema()` reads. Every other copy answers to it.
+REFERENCE = ROOT / "termproof" / "_resources" / "recipe-schema-v1.json"
+COPIES = (
+    REPO_ROOT / "rust" / "crates" / "termproof" / "resources" / "recipe-schema-v1.json",
+    ROOT / "docs" / "recipe-schema-v1.json",
+)
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def main() -> int:
+    missing = [_rel(path) for path in (REFERENCE, *COPIES) if not path.is_file()]
+    if missing:
+        print(
+            "canonical recipe schema is missing at: " + ", ".join(missing),
+            file=sys.stderr,
+        )
+        print(
+            "Hint: each copy exists for a reason — the package resource is what "
+            "the artifacts ship, the crate copy is what a registry consumer can "
+            "reach, and the docs copy is a published URL. None is optional; see "
+            "the docstring in this script.",
+            file=sys.stderr,
+        )
+        return 1
+
+    reference = REFERENCE.read_bytes()
+    drifted = [path for path in COPIES if path.read_bytes() != reference]
+    if not drifted:
+        print(
+            f"canonical recipe schema identical across {1 + len(COPIES)} copies "
+            f"({len(reference)} bytes)"
+        )
+        return 0
+
+    for path in drifted:
+        print(
+            f"canonical recipe schema drift: {_rel(path)} ({len(path.read_bytes())} bytes) "
+            f"differs from {_rel(REFERENCE)} ({len(reference)} bytes)",
+            file=sys.stderr,
+        )
+    print(
+        "Hint: these are one file. Apply the change to every copy, in the same "
+        "commit, and re-run this check.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/termproof/_resources/recipe-schema-v1.json
+++ b/python/termproof/_resources/recipe-schema-v1.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/md-mt/termproof/docs/recipe-schema-v1.json",
+  "title": "TermProof recipe v1",
+  "type": "object",
+  "required": ["name", "command"],
+  "properties": {
+    "recipe_version": {"const": 1},
+    "name": {"type": "string", "minLength": 1},
+    "description": {"type": "string"},
+    "intent": {"type": "string"},
+    "priority": {"type": "string"},
+    "execution": {"type": "string"},
+    "determinism": {"type": "string"},
+    "ci_paths": {"type": "array", "items": {"type": "string"}},
+    "checks": {"type": "array", "items": {"type": "string"}},
+    "operator": {"type": "object"},
+    "renderers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["argv"],
+      "properties": {
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string"}
+        },
+        "cwd": {"type": ["string", "null"]},
+        "env": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "pty": {"type": "boolean"}
+      },
+      "additionalProperties": true
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["action"],
+        "properties": {
+          "action": {"type": "string"},
+          "name": {"type": "string"},
+          "timeout_seconds": {"type": "number", "exclusiveMinimum": 0}
+        },
+        "additionalProperties": true
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {"type": "string"},
+          "name": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "expect_exit_code": {"type": ["integer", "null"]},
+    "timeout_seconds": {"type": "number", "exclusiveMinimum": 0},
+    "cols": {"type": "integer", "minimum": 1},
+    "rows": {"type": "integer", "minimum": 1}
+  },
+  "additionalProperties": true
+}

--- a/python/termproof/recipe_schema.py
+++ b/python/termproof/recipe_schema.py
@@ -30,14 +30,17 @@ def has_errors(issues: list[ValidationIssue]) -> bool:
 
 @lru_cache(maxsize=1)
 def load_recipe_schema() -> dict[str, Any]:
-    """Load the canonical recipe JSON schema shipped as a package resource."""
+    """Load the canonical recipe JSON schema shipped as a package resource.
+
+    The schema is a file inside this package, so it is present wherever
+    ``termproof/`` is — a wheel, an sdist, a source checkout, or a tree a build
+    system assembled from the sdist's sources. There is no fallback path and
+    nothing to relocate at build time: this used to read ``docs/`` when the
+    resource was missing, because the resource only existed if a hatchling
+    force-include had run (#174).
+    """
     resource = resources.files("termproof").joinpath("_resources", _SCHEMA_RESOURCE)
-    if resource.is_file():
-        return json.loads(resource.read_text(encoding="utf-8"))
-    # Source-tree fallback: the canonical schema lives under docs/ and is only
-    # force-included into the built wheel under termproof/_resources/.
-    docs_schema = Path(__file__).resolve().parent.parent / "docs" / _SCHEMA_RESOURCE
-    return json.loads(docs_schema.read_text(encoding="utf-8"))
+    return json.loads(resource.read_text(encoding="utf-8"))
 
 
 @lru_cache(maxsize=1)

--- a/python/tests/test_sdist_artifact_content.py
+++ b/python/tests/test_sdist_artifact_content.py
@@ -39,6 +39,18 @@ _INTENTIONALLY_REMOVED = frozenset(
     }
 )
 
+# The canonical recipe schema, at the path
+# `termproof.recipe_schema.load_recipe_schema` reads.
+_SCHEMA_IN_PACKAGE = "termproof/_resources/recipe-schema-v1.json"
+# The published docs path -- a byte-identical copy kept so the URL the schema
+# has always been linked at does not move (#174). It is a URL, not a package
+# resource: nothing loads it, and where it ships is a decision, not an
+# accident. In the sdist, because the sdist ships all of `docs/` and a source
+# distribution missing a checked-in source file would be the anomaly. Not in
+# the wheel, because two loadable copies at two import paths is the ambiguity
+# the package resource exists to remove. Both halves are asserted below.
+_SCHEMA_IN_DOCS = "docs/recipe-schema-v1.json"
+
 
 _DIST_INFO = re.compile(r"^termproof-[^/]+\.dist-info/")
 
@@ -166,6 +178,52 @@ class SdistArtifactContentTest(unittest.TestCase):
     def test_wheel_contains_no_rust_entries(self) -> None:
         rust_entries = [name for name in self._wheel_names() if any(part == "rust" for part in name.split("/"))]
         self.assertEqual([], rust_entries, f"wheel must not contain any rust/ entries: {rust_entries}")
+
+    def test_sdist_ships_the_canonical_schema_in_the_package(self) -> None:
+        """The sdist carries the schema, with no build step to reproduce.
+
+        This is the regression for #174. The schema used to live under
+        ``docs/`` and reach ``termproof/_resources/`` only through a hatchling
+        wheel force-include, so a build system that consumes the sdist's
+        sources directly assembled a ``termproof/`` with no schema in it and
+        ``load_recipe_schema()`` found nothing. Asserting on the sdist member,
+        rather than on the manifest, is the point: the manifest is what was
+        wrong.
+        """
+        self.assertIn(
+            _SCHEMA_IN_PACKAGE,
+            self._sdist_relative_names(),
+            f"sdist must carry {_SCHEMA_IN_PACKAGE}; a consumer building from "
+            "these sources runs no force-include",
+        )
+
+    def test_wheel_ships_the_canonical_schema_at_the_same_path(self) -> None:
+        """Existing wheel consumers see no layout change.
+
+        The wheel always had the schema at this path — via the force-include —
+        so moving the file into the package must leave that untouched.
+        """
+        self.assertIn(_SCHEMA_IN_PACKAGE, set(self._wheel_names()))
+
+    def test_wheel_does_not_ship_the_docs_copy(self) -> None:
+        """The docs copy is a published URL, not a second package resource.
+
+        It is kept so `docs/recipe-schema-v1.json` does not 404, and it must
+        stay out of the installed package: two loadable copies at two import
+        paths is the ambiguity the package resource exists to remove.
+        """
+        self.assertNotIn(_SCHEMA_IN_DOCS, set(self._wheel_names()))
+
+    def test_sdist_ships_the_docs_copy(self) -> None:
+        """And the sdist does carry it, deliberately.
+
+        The sdist is a source distribution and ships all of ``docs/``; a source
+        tree missing a checked-in source file would be the anomaly, and it is
+        the same bytes as the package resource in any case. Asserted rather
+        than left to the include list so that where this copy ships is a
+        recorded decision on both sides, not an accident of pattern matching.
+        """
+        self.assertIn(_SCHEMA_IN_DOCS, self._sdist_relative_names())
 
     def test_sdist_preserves_base_non_rust_payload_paths(self) -> None:
         base_paths = _load_fixture("base_sdist_paths.txt") - _INTENTIONALLY_REMOVED

--- a/rust/crates/termproof/Cargo.toml
+++ b/rust/crates/termproof/Cargo.toml
@@ -28,8 +28,6 @@ categories = [
 exclude = [
     "tests/differential_steps.rs",
     "tests/differential_assertions.rs",
-    # Reads python/docs/recipe-schema-v1.json, which is outside the crate.
-    "tests/canonical_schema.rs",
 ]
 
 # Features gate public modules, so `docs.rs` must build with all of them on or

--- a/rust/crates/termproof/README.md
+++ b/rust/crates/termproof/README.md
@@ -201,10 +201,12 @@ carries the full inventory of what a run still cannot do.
 
 The canonical recipe schema and the example corpus are the contract both
 implementations answer to, and they are owned by the Python implementation.
-Both implementations now live in one repository, so `load_canonical_schema`
-reads that schema from `python/docs/recipe-schema-v1.json` and the corpus is
-the shared `conformance/` tree at the repository root. It is not vendored into
-this crate, so from a published tarball the seam still returns `None`.
+The schema is vendored into this crate at `resources/recipe-schema-v1.json`
+and embedded with `include_str!`, so `load_canonical_schema` answers the same
+from a published tarball as it does from the repository, and reads no path
+outside the crate. `python/scripts/check_schema_copies.py` holds that copy
+byte-identical to the Python package's in CI. The corpus is the shared
+`conformance/` tree at the repository root and is not vendored.
 
 What this crate does pin is its *own* generated schema, to a checked-in
 snapshot (`tests/snapshots/recipe_schema_v1.json`, guarded by

--- a/rust/crates/termproof/resources/recipe-schema-v1.json
+++ b/rust/crates/termproof/resources/recipe-schema-v1.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/md-mt/termproof/docs/recipe-schema-v1.json",
+  "title": "TermProof recipe v1",
+  "type": "object",
+  "required": ["name", "command"],
+  "properties": {
+    "recipe_version": {"const": 1},
+    "name": {"type": "string", "minLength": 1},
+    "description": {"type": "string"},
+    "intent": {"type": "string"},
+    "priority": {"type": "string"},
+    "execution": {"type": "string"},
+    "determinism": {"type": "string"},
+    "ci_paths": {"type": "array", "items": {"type": "string"}},
+    "checks": {"type": "array", "items": {"type": "string"}},
+    "operator": {"type": "object"},
+    "renderers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["argv"],
+      "properties": {
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string"}
+        },
+        "cwd": {"type": ["string", "null"]},
+        "env": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "pty": {"type": "boolean"}
+      },
+      "additionalProperties": true
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["action"],
+        "properties": {
+          "action": {"type": "string"},
+          "name": {"type": "string"},
+          "timeout_seconds": {"type": "number", "exclusiveMinimum": 0}
+        },
+        "additionalProperties": true
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {"type": "string"},
+          "name": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "expect_exit_code": {"type": ["integer", "null"]},
+    "timeout_seconds": {"type": "number", "exclusiveMinimum": 0},
+    "cols": {"type": "integer", "minimum": 1},
+    "rows": {"type": "integer", "minimum": 1}
+  },
+  "additionalProperties": true
+}

--- a/rust/crates/termproof/src/schema.rs
+++ b/rust/crates/termproof/src/schema.rs
@@ -13,10 +13,11 @@
 //!
 //! The snapshot proves only that this crate's own output does not drift; it
 //! does not establish agreement with the canonical schema. That schema is
-//! owned by the Python implementation and, since the two implementations were
-//! consolidated, sits in the same repository at
-//! `python/docs/recipe-schema-v1.json` — `load_canonical_schema` reads it from
-//! there. Comparing the two is still parity-gate work; having the file
+//! owned by the Python implementation; this crate carries its own copy at
+//! `resources/recipe-schema-v1.json`, embedded by [`CANONICAL_SCHEMA_JSON`],
+//! and CI holds that copy byte-identical to the Python package's
+//! (`python/scripts/check_schema_copies.py`). Comparing the two *schemas* —
+//! generated against canonical — is still parity-gate work; having the file
 //! reachable is the precondition, not the gate.
 
 use schemars::gen::{SchemaGenerator, SchemaSettings};
@@ -33,7 +34,10 @@ pub fn generate_recipe_schema() -> serde_json::Value {
     let schema = generator.into_root_schema_for::<Recipe>();
 
     // Ensure the schema declares Draft 2020-12 and carries identifying metadata
-    // matching the checked-in `docs/recipe-schema-v1.json`.
+    // matching the canonical schema in `resources/recipe-schema-v1.json`. The
+    // `$id` is that schema's own, verbatim: it identifies the recipe schema,
+    // not the file's location, and rewriting it here would make the two
+    // disagree over which schema they are.
     let mut value = serde_json::to_value(&schema).expect("schema serializes");
     if let Some(obj) = value.as_object_mut() {
         obj.insert(
@@ -65,49 +69,50 @@ pub fn generate_recipe_schema() -> serde_json::Value {
     value
 }
 
-/// The canonical recipe schema's path, relative to this crate's directory.
+/// The canonical recipe schema, embedded from this crate's own copy.
 ///
-/// The schema is owned by the Python implementation and both implementations
-/// live in one repository, so it is three levels up from
-/// `rust/crates/termproof`.
-const CANONICAL_SCHEMA_FROM_MANIFEST: &str = "../../../python/docs/recipe-schema-v1.json";
-
-/// Load the canonical recipe schema relative to a crate directory.
+/// The schema is owned by the Python implementation, but a crate that has to
+/// look outside itself to find it does not have it: a registry checkout has no
+/// repository above it, so the previous manifest-relative
+/// `../../../python/docs/recipe-schema-v1.json` resolved for this repository
+/// and for nobody else (#174). The crate now carries the file, and
+/// `python/scripts/check_schema_copies.py` holds it byte-identical to
+/// `python/termproof/_resources/recipe-schema-v1.json` in CI.
 ///
-/// Split out from [`load_canonical_schema`] so the published-crate case is
-/// directly testable: a registry checkout is just a different `manifest_dir`,
-/// one that does not have the repository above it.
-fn load_canonical_schema_from(manifest_dir: &std::path::Path) -> Option<serde_json::Value> {
-    let path = manifest_dir.join(CANONICAL_SCHEMA_FROM_MANIFEST);
-    let content = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&content).ok()
-}
+/// This is the text, exactly as shipped. [`load_canonical_schema`] parses it.
+pub const CANONICAL_SCHEMA_JSON: &str = include_str!("../resources/recipe-schema-v1.json");
 
-/// Load the canonical recipe schema, or `None` when it is not reachable.
+/// Load the canonical recipe schema.
 ///
 /// This is the seam the parity gate will compare `generate_recipe_schema()`
-/// against. Reaching the file is the precondition; agreeing with it is the
+/// against. Reaching the schema is the precondition; agreeing with it is the
 /// gate, and that is still open work.
 ///
-/// Resolved **only** from `CARGO_MANIFEST_DIR`, never from the working
-/// directory. That is a correctness property, not a tidiness one. This
-/// function had a `docs/recipe-schema-v1.json` cwd fallback, and in a
-/// published crate — where the manifest-relative path lands in the registry
-/// checkout and misses — it would have read whatever file of that name
-/// happened to sit in the consumer's working directory and returned it as the
-/// canonical TermProof schema. A wrong schema presented as canonical is worse
-/// than no schema, so the answer for a consumer is `None`, which is what the
-/// crate not vendoring the file means.
-#[allow(dead_code)]
+/// Reads **only** [`CANONICAL_SCHEMA_JSON`] — no filesystem access, so no
+/// working directory and no path outside this crate can influence the answer.
+/// That is a correctness property, not a tidiness one. This function once had
+/// a `docs/recipe-schema-v1.json` cwd fallback, and in a published crate —
+/// where the manifest-relative path landed in the registry checkout and missed
+/// — it would have read whatever file of that name happened to sit in the
+/// consumer's working directory and returned it as the canonical TermProof
+/// schema. A wrong schema presented as canonical is worse than no schema.
+///
+/// The `Option` is vestigial: the schema is embedded at compile time and
+/// `canonical_schema_is_the_recipe_schema` below holds it to being valid JSON,
+/// so the result is always `Some`. `serde_json::Value` is the honest return
+/// type and the right shape for the next minor bump. It is kept as-is here by
+/// choice, not by constraint: narrowing it breaks every caller that matches on
+/// the result, which is a minor bump under the pre-1.0 convention
+/// (`docs/publishing.md`), and a packaging fix is the wrong change to carry
+/// one.
+///
+/// Do not read the green `cargo semver-checks` gate as agreement. It was
+/// measured: narrowing this return type passes it. (Making the function
+/// private fails, so the gate is wired — it just has no lint for this.) The
+/// compatibility argument above is the whole reason; the tooling is not
+/// enforcing it.
 pub fn load_canonical_schema() -> Option<serde_json::Value> {
-    load_canonical_schema_from(std::path::Path::new(env!("CARGO_MANIFEST_DIR")))
-}
-
-/// The manifest-relative lookup, exposed for the test that proves a packaged
-/// crate cannot be tricked into reading a consumer's file.
-#[doc(hidden)]
-pub fn load_canonical_schema_from_dir(manifest_dir: &std::path::Path) -> Option<serde_json::Value> {
-    load_canonical_schema_from(manifest_dir)
+    serde_json::from_str(CANONICAL_SCHEMA_JSON).ok()
 }
 
 #[cfg(test)]
@@ -136,5 +141,14 @@ mod tests {
     fn schema_recipe_version_is_const_one() {
         let schema = generate_recipe_schema();
         assert_eq!(schema["properties"]["recipe_version"]["const"], 1);
+    }
+
+    /// The embedded text is what makes [`load_canonical_schema`]'s `Option`
+    /// vestigial, so hold it to being the schema and not, say, a stray file.
+    #[test]
+    fn canonical_schema_is_the_recipe_schema() {
+        let canonical = load_canonical_schema().expect("the embedded schema parses");
+        assert_eq!(canonical["title"], "TermProof recipe v1");
+        assert_eq!(canonical["properties"]["recipe_version"]["const"], 1);
     }
 }

--- a/rust/crates/termproof/tests/canonical_schema.rs
+++ b/rust/crates/termproof/tests/canonical_schema.rs
@@ -1,28 +1,29 @@
-//! The canonical schema seam must reach the right file, or no file.
+//! The canonical schema seam reads the crate's own copy, and only that.
 //!
 //! Two properties, and the second is the one that matters to a consumer.
 //!
-//! **It resolves in this repository.** Before the two implementations were
-//! consolidated, `load_canonical_schema` could not reach the canonical recipe
-//! schema from any checkout layout, and the crate README, the architecture
-//! document and the engineering baseline all said so. Both now live in one
-//! repository and the schema is at `python/docs/recipe-schema-v1.json`, so the
-//! seam resolves — and this stops that regressing into a `None` that reads as
-//! "there is no canonical schema" rather than "it moved".
+//! **It resolves anywhere.** The schema is embedded from
+//! `resources/recipe-schema-v1.json` with `include_str!`, so
+//! `load_canonical_schema` answers the same from this repository, from a
+//! registry checkout, and from a vendored copy. It used to be read through
+//! `../../../python/docs/recipe-schema-v1.json`, which resolved for this
+//! repository and returned `None` for every published-crate consumer (#174).
 //!
 //! **It cannot be tricked by the working directory.** The lookup briefly had
 //! `docs/recipe-schema-v1.json` and `python/docs/recipe-schema-v1.json` cwd
 //! fallbacks after the manifest-relative one. In a published crate the
-//! manifest-relative path lands in the registry checkout and misses, so those
+//! manifest-relative path landed in the registry checkout and missed, so those
 //! fallbacks would have read whatever file of that name sat in the consumer's
 //! working directory and returned it as the canonical TermProof schema. A
 //! wrong schema presented as canonical is worse than no schema. The decoy test
-//! below is that reproduction, kept as a regression.
+//! below is that reproduction, kept as a regression — the fix for the `None`
+//! must not be a fix that reintroduces path searching.
 //!
-//! The file lives in `tests/` and is excluded from the package, for the same
-//! reason the differential tests are: it reads a path outside the crate. A
-//! consumer running `cargo test` against the published tarball would have no
-//! repository around it and no way to pass.
+//! This file ships in the package. It used to be excluded, because it read a
+//! path outside the crate and a consumer running `cargo test` against the
+//! published tarball had no repository around it and no way to pass. It reads
+//! nothing outside the crate now, so the part of the crate that a consumer
+//! most needs to trust is finally testable from the artifact they were given.
 //!
 //! `schema` is a feature, and CI runs the whole feature powerset, so the file
 //! compiles to nothing without it. An integration test cannot be gated from
@@ -30,14 +31,14 @@
 
 #![cfg(feature = "schema")]
 
-use termproof::schema::{load_canonical_schema, load_canonical_schema_from_dir};
+use termproof::schema::{load_canonical_schema, CANONICAL_SCHEMA_JSON};
 
 const DECOY: &str = r#"{"title": "DECOY - a consumer's unrelated file"}"#;
 
 /// One test, because it changes the process-wide working directory and the
 /// tests in a binary run in parallel threads.
 #[test]
-fn the_seam_reads_the_repository_schema_and_never_the_working_directory() {
+fn the_seam_reads_the_embedded_schema_and_never_the_working_directory() {
     let temp =
         std::env::temp_dir().join(format!("termproof-canonical-schema-{}", std::process::id()));
     // Both cwd shapes the removed fallbacks accepted.
@@ -50,27 +51,36 @@ fn the_seam_reads_the_repository_schema_and_never_the_working_directory() {
     let original = std::env::current_dir().expect("cwd");
     std::env::set_current_dir(&temp).expect("enter the decoy directory");
 
-    // Results are captured before asserting: the cwd must be restored even if
-    // an assertion fails, or every later test in this binary would run from
+    // The result is captured before asserting: the cwd must be restored even
+    // if an assertion fails, or every later test in this binary would run from
     // the temporary directory.
-    let from_repo = load_canonical_schema();
-    // A registry checkout is just a manifest directory with no repository
-    // above it — exactly what a published crate has.
-    let from_packaged = load_canonical_schema_from_dir(&temp);
+    let from_decoy_dir = load_canonical_schema();
 
     std::env::set_current_dir(&original).expect("restore cwd");
     let _ = std::fs::remove_dir_all(&temp);
 
-    let canonical = from_repo.expect("the repository schema should be reachable");
+    let canonical = from_decoy_dir.expect("the embedded schema is always reachable");
     assert_eq!(
         canonical["title"], "TermProof recipe v1",
-        "the seam read a file from the working directory instead of the repository"
+        "the seam read a file from the working directory instead of the crate"
     );
     assert_eq!(canonical["properties"]["recipe_version"]["const"], 1);
+}
 
-    assert!(
-        from_packaged.is_none(),
-        "a packaged crate must return None rather than a file found near the \
-         consumer's working directory; got {from_packaged:?}"
+/// The embedded text is the shipped file verbatim, which is what the
+/// cross-package byte-equality gate (`python/scripts/check_schema_copies.py`)
+/// compares. Parsing and re-serializing would make that gate meaningless.
+#[test]
+fn the_embedded_text_is_the_packaged_file_verbatim() {
+    let packaged = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join("recipe-schema-v1.json");
+    let on_disk = std::fs::read_to_string(&packaged)
+        .unwrap_or_else(|e| panic!("{} is unreadable ({e})", packaged.display()));
+    assert_eq!(
+        on_disk,
+        CANONICAL_SCHEMA_JSON,
+        "the embedded schema text differs from {}",
+        packaged.display()
     );
 }

--- a/rust/crates/termproof/tests/schema_snapshot.rs
+++ b/rust/crates/termproof/tests/schema_snapshot.rs
@@ -17,10 +17,10 @@
 //!
 //! - it **does** catch accidental changes to our generated schema;
 //! - it does **not** establish agreement with the canonical schema, which is
-//!   owned by the Python implementation and lives at
-//!   `python/docs/recipe-schema-v1.json` in this repository, reachable through
-//!   `schema::load_canonical_schema` but not vendored into the crate.
-//!   Comparing the two remains parity-gate work.
+//!   owned by the Python implementation and vendored into this crate at
+//!   `resources/recipe-schema-v1.json`, reachable through
+//!   `schema::load_canonical_schema`. Comparing the two remains parity-gate
+//!   work.
 //!
 //! Re-blessing is deliberate and never the default. To update the snapshot
 //! after an intentional schema change:

--- a/rust/docs/architecture.md
+++ b/rust/docs/architecture.md
@@ -55,10 +55,11 @@ shared rather than remote.
 
 - **The recipe schema and the example corpus are owned by the Python
   implementation.** They are the contract both implementations answer to. The
-  schema is `python/docs/recipe-schema-v1.json`, which
-  `load_canonical_schema` in `termproof` reads; the corpus is the shared
-  `conformance/` tree at the repository root. Neither is vendored into the
-  crate, so the seam returns `None` from a published tarball. What the crate
+  schema is vendored into the crate at `resources/recipe-schema-v1.json` and
+  embedded by `load_canonical_schema` with `include_str!`, held byte-identical
+  to `python/termproof/_resources/recipe-schema-v1.json` by
+  `python/scripts/check_schema_copies.py`; the corpus is the shared
+  `conformance/` tree at the repository root and is not vendored. What the crate
   does pin is its *own* generated schema, to a checked-in snapshot
   (`tests/snapshots/recipe_schema_v1.json`, guarded by
   `tests/schema_snapshot.rs`) — a local structural stability check, not a

--- a/rust/docs/engineering-baseline.md
+++ b/rust/docs/engineering-baseline.md
@@ -272,12 +272,16 @@ workspace README in the same change.
 - What the snapshot does and does not prove: it **does** catch accidental
   changes to this crate's generated schema; it does **not** establish
   agreement with the canonical schema. That schema is owned by the Python
-  implementation and, since consolidation, sits in this repository at
-  `python/docs/recipe-schema-v1.json`; `schema::load_canonical_schema` reads
-  it from there and a unit test holds that path open. Comparing the two
+  implementation and is vendored into this crate at
+  `resources/recipe-schema-v1.json`, embedded by
+  `schema::load_canonical_schema` with `include_str!` and held byte-identical
+  to `python/termproof/_resources/recipe-schema-v1.json` by
+  `python/scripts/check_schema_copies.py` in CI. The seam therefore answers
+  the same from a published tarball as it does here, and reads no path outside
+  the crate; `tests/canonical_schema.rs` ships and proves both, including that
+  a decoy file in the working directory cannot displace it. Comparing the two
   schemas is parity-gate work and is still open — reaching the file is the
-  precondition, not the gate. It is not vendored into the crate, so the seam
-  returns `None` from a published tarball.
+  precondition, not the gate.
 - Every Rust pull request must pass locally, before push:
   `cargo fmt --check --all`, `cargo clippy --workspace --all-targets
   --all-features -- -D warnings`, and `cargo test --workspace`. Where the

--- a/rust/docs/publishing.md
+++ b/rust/docs/publishing.md
@@ -264,6 +264,17 @@ Everything else the crate needs at build time is inside its own directory, and
 the dry run proves it: the package is verified by compiling it from its own
 tarball.
 
+That is also why `crates/termproof/resources/recipe-schema-v1.json` and
+`crates/termproof/tests/canonical_schema.rs` **are** shipped. The canonical
+recipe schema is owned by the Python implementation, and the crate used to
+reach it at `../../../python/docs/recipe-schema-v1.json` — a path that resolves
+in this repository and in no registry checkout, so `load_canonical_schema`
+returned `None` for every consumer and its test had to be excluded for the same
+reason as the differential ones (#174). The crate carries the schema now and
+embeds it with `include_str!`; `python/scripts/check_schema_copies.py` holds
+that copy byte-identical to `python/termproof/_resources/recipe-schema-v1.json`
+in CI, and `verify-package-contents.sh` requires both files in the tarball.
+
 ## Licensing
 
 Every crate declares `license = "MIT"`, inherited from `[workspace.package]`,

--- a/spec/001-recipe-format/spec.md
+++ b/spec/001-recipe-format/spec.md
@@ -24,7 +24,7 @@ requirement came from:
 
 | Authority | Meaning |
 |---|---|
-| `SCHEMA` | `docs/recipe-schema-v1.json` in the Python repo — a published JSON Schema |
+| `SCHEMA` | `python/termproof/_resources/recipe-schema-v1.json` — a published JSON Schema, shipped inside the Python package and served byte-identically at `python/docs/recipe-schema-v1.json` |
 | `DOC` | `docs/recipe-format-v1.md` |
 | `OBSERVED` | A recorded run of the Python implementation; see `spec/OBSERVATION-LOG.md` |
 | `TEST` | A test in the Python repo that encodes the intent |
@@ -173,8 +173,12 @@ confirm neither reports an error for them.
   "object"`).
 
 - **FR-002** `[BYTE-EXACT]` The set of top-level field names, their JSON types, and their
-  nesting is exactly as given in `docs/recipe-schema-v1.json`. The Rust implementation MUST
-  read that schema file as its authority rather than transcribing it, so the two cannot drift.
+  nesting is exactly as given in `python/termproof/_resources/recipe-schema-v1.json`. The Rust
+  implementation MUST read that schema file as its authority rather than transcribing it, so the
+  two cannot drift. It reads it as a byte-identical vendored copy
+  (`rust/crates/termproof/resources/recipe-schema-v1.json`, embedded with `include_str!`), which
+  is what lets a published crate reach it at all; `python/scripts/check_schema_copies.py` is the
+  gate that keeps the copy from being a transcription.
   **Authority**: `SCHEMA`.
 
 - **FR-003** `[BYTE-EXACT]` Required fields are `name` and `command`; `command` requires
@@ -456,9 +460,9 @@ largest source of the divergences the review found. FR-009 through FR-013 define
   constitution Principle I.
 - **SC-006**: No recipe document in the corpus, however malformed, causes either runtime to
   panic or to exit other than through its normal result path.
-- **SC-007**: The Rust implementation reads `docs/recipe-schema-v1.json` as a build- or
-  run-time input. A drift check fails if the schema file changes and the Rust behaviour does
-  not.
+- **SC-007**: The Rust implementation reads the canonical schema as a build- or run-time
+  input — its own byte-identical copy, embedded at compile time. A drift check fails if the
+  schema file changes and the Rust behaviour does not.
 
 ---
 
@@ -467,9 +471,12 @@ largest source of the divergences the review found. FR-009 through FR-013 define
 - The oracle environment for every `OBSERVED` claim here is CPython 3.12 with `jsonschema`
   4.26.0. `pyproject.toml` declares `jsonschema>=4.0`, a floor rather than a pin, so FR-017's
   message table can shift under a different resolution. See OQ-003.
-- The canonical schema is `docs/recipe-schema-v1.json` in the Python repo at the revision the
-  port targets. The Python package also force-includes it at
-  `termproof/_resources/recipe-schema-v1.json`; the two are the same file.
+- The canonical schema is `python/termproof/_resources/recipe-schema-v1.json` at the revision
+  the port targets — a resource of the Python package, not a docs file relocated into it at
+  build time. The crate carries a byte-identical copy at
+  `rust/crates/termproof/resources/recipe-schema-v1.json`, and
+  `python/docs/recipe-schema-v1.json` is a third at the path the schema is published at; all
+  three are the same file, and `python/scripts/check_schema_copies.py` is what says so.
 - The recipe format is v1 and no `recipe_version: 2` exists. A future major version is
   explicitly reserved by `DOC` §"Versioning" and is out of scope here.
 - Recipes are UTF-8 encoded. Every read in the Python implementation passes


### PR DESCRIPTION
Closes #174. Rebased on `main` after #176.

The reporter's suggested shape, adopted in full: the schema lives inside each package, and `python/docs/` keeps a byte-identical copy at the path it is published at.

## The defect

`recipe-schema-v1.json` lived at `python/docs/`, outside the Python package and outside the Rust crate. The sdist carried it there, as it carries all of `docs/`, but nothing importable did.

| | Before | After |
| --- | --- | --- |
| Wheel | `termproof/_resources/…` via a build-time force-include | `termproof/_resources/…`, the real file — **layout unchanged** |
| Sdist | `docs/…` only; a consumer of the sources gets no schema | `termproof/_resources/…`, no build step to reproduce |
| Crate (registry) | `load_canonical_schema()` → `None` | the schema, embedded with `include_str!` |
| `tests/canonical_schema.rs` | excluded from the package | ships and passes from the tarball |
| `docs/recipe-schema-v1.json` | the original | a byte-identical copy — **same path, same bytes** |

## How many copies, and why

Two copies of one file is duplication and a CI equality check is a mitigation, not a cure. I looked for a shape with one and there isn't one, because the constraint forbids it: each artifact must carry the schema with no traversal outside itself, and a wheel cannot read a file out of a crate. **N self-contained artifacts means N copies is the floor.**

The third copy, under `docs/`, is above that floor and is kept anyway — for a reason that is not about artifacts at all. It is the path the schema is *published* at, linked from `docs/recipe-format-v1.md`, so it may already be in a `$schema` line, a script or a bookmark. Round 1 was right that my artifact argument, though sound, answered a different question; moving a file inside the packages is no reason to 404 a URL. The copy costs one file and one entry in a check that already existed.

**Where it ships is now a decision on both sides, not an accident of the include list.** It is *not* in the wheel — two loadable copies at two import paths is the ambiguity the package resource exists to remove — and it *is* in the sdist, because the sdist ships all of `docs/` and a source distribution missing a checked-in source file would be the anomaly. `test_wheel_does_not_ship_the_docs_copy` and `test_sdist_ships_the_docs_copy` assert one half each; both were proven non-vacuous by mutation (adding a wheel force-include, and excluding the path from the sdist).

Rejected alternatives, for the record: a symlink at the docs path (the sdist would carry whatever the build frontend decides a symlink is, and a Windows checkout without developer mode ships a text file containing a path); generating the crate copy in `build.rs` (still needs a file outside the crate at package time, and `cargo package` would not carry the output); dropping the canonical file for the schemars-generated one (a different artifact — agreeing the two is the open parity gate, not a packaging change).

## Drift check

`python/scripts/check_schema_copies.py` compares every copy against the package resource — the path `load_recipe_schema()` reads — byte for byte, not as parsed JSON, because the crate embeds the text verbatim and a published URL should serve the bytes it always did.

No `--fix`. Which copy is right is a decision, and silently regenerating one would turn an edit made in the wrong place into a green build.

It runs in five places. CI (Python)'s `lint` job, whose path filter now covers all three copies; and the four paths that build or publish an artifact — Python release, Rust release, Rust publish and Rust auto-release. Round 1's point stands: a tag can be cut from a commit that passed neither pull-request nor `main` CI, and the whole point of more than one copy is that something guarantees they match. Stdlib-only, so the Rust workflows need no Python toolchain.

## Verification

Against the built artifacts, not the manifests.

**The sdist carries the schema with no build step.** Extracted the sdist, copied only `termproof/` into a bare directory — a build system mapping the sdist's sources into its own tree — and loaded it: `TermProof recipe v1`. Same procedure against `main`, which is the reported symptom:

```
FileNotFoundError [Errno 2] No such file or directory:
  '/private/tmp/tp-base-monorepo/docs/recipe-schema-v1.json'
```

The wheel has exactly one copy at the path it always had; the sdist has the package resource and the docs copy, and no wheel has the latter.

**The published URL.** `git diff origin/main -- python/docs/recipe-schema-v1.json` is empty: same path, same bytes as `main`.

**The packaged crate.** `cargo package -p termproof` → 77 files including `resources/recipe-schema-v1.json` and `tests/canonical_schema.rs`; `verify-package-contents.sh` requires both and no longer forbids the test.

**The decoy test.** A consumer crate built from the extracted tarball in `/tmp`, no repository above it, run from a directory holding decoy `docs/recipe-schema-v1.json` and `python/docs/recipe-schema-v1.json` — both shapes the removed fallbacks accepted — returned `title = "TermProof recipe v1"`, `const = 1`. `cargo test --test canonical_schema` inside the extracted tarball with the same decoys: 2 passed. No path-searching fallback was reintroduced; the seam reads no path at all.

**The drift check bites**, on each of the three copies independently and on a missing copy — `exit=1` every time, with the offending path named:

```
canonical recipe schema drift: python/docs/recipe-schema-v1.json (2156 bytes)
  differs from python/termproof/_resources/recipe-schema-v1.json (2155 bytes)
```

**Suites.** `ruff`, `mypy`, 687 Python tests, the stdlib-only subset (118), `cargo fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace`, all 16 feature combinations, `cargo deny check`, `cargo semver-checks check-release -p termproof`.

## Correction to round 3's PR body

Round 3 found the same overclaim I "fixed" in round 2 surviving in places the round-2 fix did not look — because I patched the two files I was pointed at instead of sweeping. Fixed at the source (`python/docs/recipe-format-v1.md`), in the commit message, and in this body's "The defect" above, which now uses the framing the issue itself used: *outside the Python package and outside the Rust crate*.

How I swept this time, rather than spot-fixing:

- `git grep -iE "neither published artifact|inside neither|in neither|in no artifact|no artifact at all|inside no artifact|not in either artifact|neither artifact|outside both"` over the whole tree;
- the same pattern again with plain `grep -rn`, so untracked and gitignored files were included — which is how `python/_site/` got looked at;
- every line pairing `docs/` with `artifact`/`ship`/`carry`/`distribut`, to catch paraphrases the literal patterns would miss;
- the commit message and this PR body, which `git grep` does not read.

Three surviving hits, all now fixed, and the remaining `neither`s are unrelated uses.

One correction to the review: `python/_site/docs/recipe-format-v1.md` is **not** a checked-in generated copy. `python/_site/` is gitignored and untracked at both this head and `origin/main` — it was a local artifact left behind by my own `test_docs_pages.py` run. Regenerating rather than hand-editing was the right instruction regardless, and that is what I did: deleted it, re-ran the builder, confirmed it picked up the corrected source.

## Correction to round 2's PR body

Round 2 caught a false sentence I had written in `CHANGELOG.md` and in the drift-check docstring: that the docs copy is "in no artifact". **The sdist contains it** — I listed that output myself and wrote the wrong summary of it anyway. Both now say what is true and is the useful claim: not in the wheel, so no installed package carries it and no import path reaches it; in the sdist, deliberately, and nothing loads it there either.

## Correction to round 1's PR body

I claimed narrowing `load_canonical_schema()` to `serde_json::Value` would fail the semver gate. **That was wrong** — the reviewer measured it and `cargo semver-checks check-release` passes the narrowed signature (making the function private does fail, so the tool is wired; it has no lint for this).

`Option` is still kept, on the correct reason: narrowing it breaks every caller that matches on the result, which is a minor bump under the pre-1.0 convention, and a packaging fix is the wrong change to carry one. The docstring now says exactly that, and records that the gate does not catch it so nobody later reads green CI as agreement. The gap in `cargo semver-checks` seems worth an issue of its own; say the word and I'll file it.

**The schema's content is untouched**, `$id` included — out of scope per round 1, and changing it would be a compatibility event in its own right.


