### PR TITLE
Carry the attributed grid to the per-step screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,16 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   non-letter finals. A fresh `ESC` now also abandons a sequence in progress
   rather than being read as one of its parameter bytes.
 
+- Escape sequences that are not CSI are recognised rather than rendered as
+  glyphs. Only CSI was handled; every other family had its `ESC` dropped and
+  its body printed, so an OSC-8 hyperlink — which `capture-pane -e` really does
+  emit — turned `beforeTXTafter` into `before]8;;url\TXT]8;;\after` in a step
+  screenshot and in the `.txt` beside it. OSC, DCS, SOS, PM and APC are now
+  consumed to either terminator (`BEL` or `ESC \`), as are charset designation,
+  the DEC line-size controls and the two-byte escapes; SS2 and SS3 consume
+  their introducer and leave the character they shift. None of them contributes
+  anything visible, which is what a terminal shows for them too.
+
 ### Python — Changed
 
 - The attributed grid builders share one cell object between cells that compare
@@ -144,12 +154,17 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   retains go from 37.1 MiB to 2.9 MiB — 506 KiB down to 40 KiB per step. That
   is what makes keeping a grid per step affordable.
 
+  The saving is in the repetition and nowhere else, so the floor is exactly no
+  saving: a screen whose 3,200 cells are all distinct measures 527 KiB pooled
+  and 527 KiB unpooled. No real screen looks like that, and the number states
+  the mechanism rather than qualifying it.
+
   Measured with `tracemalloc`, summing allocations made in
   `termproof/attributed.py` that are still alive once the run's results are in
   hand. A `sys.getsizeof` walk of the same objects reads higher — around 46-55
   MiB unshared depending on what the walk counts — because `getsizeof` on a
   key-sharing instance dict reports more than the allocator handed out. Same
-  conclusion, and the ratio is 12-16x on every method tried.
+  conclusion either way.
 
 [#175]: https://github.com/md-mt/termproof/issues/175
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,14 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
   The field is deliberately absent from `StepResult.to_dict()`: `result.json` is
   a shape shared with the Rust implementation and read by the run cache, and
-  nothing downstream of it re-renders an image.
+  nothing downstream of it re-renders an image. It is `compare=False` for the
+  same reason — equality tracks the serialised shape, so a live result still
+  equals `RunResult.from_dict(result.to_dict())` as it always has.
+
+  `AttributedScreen` also grows a compact `__repr__`. The generated dataclass
+  one was an `AttributedCell(...)` per cell, around half a megabyte for a
+  100x32 grid, and a grid now hangs off every `StepResult` — which is what a
+  failing assertion would have printed.
 
 - `termproof.screen.capture_screen`, one read of a session's screen returning
   text and grid together, and `termproof.builtin_steps.step_result` for step
@@ -122,13 +129,27 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   a literal `[31` in the middle of a screenshot; a terminal waiting for the
   terminator displays nothing, and now neither does the parser.
 
+- A CSI sequence ending in a final byte that is not a letter no longer eats the
+  first letter of the text after it. ECMA-48 puts the final byte at 0x40-0x7E;
+  the parser scanned for `isalpha()`, so `before\x1b[1~after` rendered as
+  `beforefter`. Same for `\x1b[5@`, `\x1b[2^`, `\x1b[?25l` and the rest of the
+  non-letter finals. A fresh `ESC` now also abandons a sequence in progress
+  rather than being read as one of its parameter bytes.
+
 ### Python — Changed
 
 - The attributed grid builders share one cell object between cells that compare
-  equal. A terminal screen is mostly repetition, so this takes a 100x32 grid
-  from roughly 750 KiB to roughly 48 KiB — measured over the example corpus,
-  55 MiB of retained grids for a 75-step run becomes 3.5 MiB — which is what
-  makes keeping a grid per step affordable.
+  equal. A terminal screen is mostly repetition, so a typical 100x32 grid goes
+  from 527 KiB to 31 KiB, and the 75 step grids a run over the example corpus
+  retains go from 37.1 MiB to 2.9 MiB — 506 KiB down to 40 KiB per step. That
+  is what makes keeping a grid per step affordable.
+
+  Measured with `tracemalloc`, summing allocations made in
+  `termproof/attributed.py` that are still alive once the run's results are in
+  hand. A `sys.getsizeof` walk of the same objects reads higher — around 46-55
+  MiB unshared depending on what the walk counts — because `getsizeof` on a
+  key-sharing instance dict reports more than the allocator handed out. Same
+  conclusion, and the ratio is 12-16x on every method tried.
 
 [#175]: https://github.com/md-mt/termproof/issues/175
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,57 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   termproof`.** It asserted the command's absence because the package was
   unpublished, and went on passing after the publish made that wrong.
 
+### Python — Added
+
+- `StepResult.screen_attributed`, an optional `AttributedScreen | None`
+  alongside the existing flattened `screen`. When it is present the per-step
+  screenshot is rendered from it, so the images under `steps/` carry the colour
+  and text attributes `final.svg` already did ([#175]).
+
+  Every built-in session backend fills it — `pexpect`, `pexpect_asciinema` and
+  `docker` from the session's `pyte.Screen`, `tmux` from `capture-pane -e` —
+  and the agent-driven mode fills it from its cast replay. Over the 13 example
+  recipes, step screenshots carrying attributed rendering went from 0/76 to
+  11/76 (9 in colour, 11 with text attributes); the other 65 are byte-identical
+  because those recipes drive genuinely monochrome TUIs.
+
+  Optional means optional. A `SessionBackend` whose session does not implement
+  `screen_attributed()` reports no grid, and its step screenshots render from
+  the text exactly as before. The `png` renderer takes text only, so PNG step
+  screenshots stay monochrome either way, and dim (SGR 2) reaches the grid on
+  the tmux path but not the pty one.
+
+  The field is deliberately absent from `StepResult.to_dict()`: `result.json` is
+  a shape shared with the Rust implementation and read by the run cache, and
+  nothing downstream of it re-renders an image.
+
+- `termproof.screen.capture_screen`, one read of a session's screen returning
+  text and grid together, and `termproof.builtin_steps.step_result` for step
+  actions that want the same. The grid is read first and the text derived from
+  it, so `steps/NN.txt` and `steps/NN.svg` cannot describe different instants.
+
+### Python — Fixed
+
+- Step-screenshot dedup fingerprints the rendered grid so that a colour-only
+  change between two steps counts as a change. That was inert for the artifacts
+  dedup applies to, because the grid was rebuilt from already-flattened text; it
+  now compares the grid the session reported ([#175]).
+
+- A CSI escape sequence cut before its final byte no longer emits its parameter
+  bytes as glyphs. `\x1b[31` at the end of a `capture-pane -e` line rendered as
+  a literal `[31` in the middle of a screenshot; a terminal waiting for the
+  terminator displays nothing, and now neither does the parser.
+
+### Python — Changed
+
+- The attributed grid builders share one cell object between cells that compare
+  equal. A terminal screen is mostly repetition, so this takes a 100x32 grid
+  from roughly 750 KiB to roughly 48 KiB — measured over the example corpus,
+  55 MiB of retained grids for a 75-step run becomes 3.5 MiB — which is what
+  makes keeping a grid per step affordable.
+
+[#175]: https://github.com/md-mt/termproof/issues/175
+
 ## [0.3.4] — 2026-08-17
 
 One project, one version. The two repositories became one: the Rust

--- a/README.md
+++ b/README.md
@@ -95,9 +95,14 @@ The Python implementation writes, per run:
 
 Two things worth knowing before you promise them to anyone:
 
-- **The per-step screenshots under `steps/` are monochrome.** They are rendered
-  from plain text. `final.svg` and the `attributed_rsvg` video backend render
-  from the attributed grid and carry colour; the per-step images do not.
+- **Per-step screenshots carry colour only when the session can report a
+  grid.** All four built-in session backends can — pty, pty+asciinema, Docker
+  and tmux — and so does the agent-driven mode, so on a stock install the
+  `steps/` images are as attributed as `final.svg`. A third-party session
+  backend that does not implement `screen_attributed()` still works and still
+  gets its screenshots, in monochrome. Two limits hold either way: the `png`
+  screen renderer takes text only, so PNG step images are always monochrome,
+  and dim (SGR 2) survives on the tmux path but not on the pty one.
 - **Video needs external tools.** `agg` + `ffmpeg` for the default backend, or
   `rsvg-convert` + `ffmpeg` for `attributed_rsvg`. A prebuilt `agg` is bundled
   in the platform wheels.

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -75,15 +75,33 @@ not a tracked file, so it stays a manual check.
 Two limits, both pinned by tests; check them before making any blanket claim
 about colour in the artifacts:
 
-- **Only `final.svg` and the `attributed_rsvg` video render from the grid.** Step
-  screenshots render from `StepResult.screen`, which is pyte's flattened
-  `display`, so they are monochrome — and they are the large majority of the
-  rendered corpus. The dedup tests that inject SGR escapes into a `StepResult`
-  are helper coverage of `_render_step_screens`, not evidence that a real step
-  screenshot has colour.
-- **Dim (SGR 2) is lost on the cast-replay path**, because pyte 0.8.2's `Char`
-  has no dim field. A grid parsed from SGR text does carry it. Do not list dim
-  as a supported attribute of a screenshot without saying which path.
+- **A step screenshot renders from the grid only when the session reported
+  one.** `StepResult.screen_attributed` is optional and defaults to `None`;
+  `evidence._render_step_screens` falls back to re-parsing `StepResult.screen`,
+  which is flattened text and therefore monochrome. Every built-in session
+  backend reports a grid, so on a stock install the `steps/` images carry
+  colour — but "TermProof step screenshots are in colour" is still an
+  overclaim, because a third-party `SessionBackend` need not implement
+  `screen_attributed()`. Say "when the session supplies a grid".
+- **The `png` renderer has no `render_attributed`,** so a PNG step screenshot is
+  monochrome however colourful the grid is. Colour in step screenshots is a
+  property of the `svg` renderer.
+- **Dim (SGR 2) is lost on the cast-replay path and on the pty session**,
+  because pyte 0.8.2's `Char` has no dim field. A grid parsed from SGR text —
+  the tmux backend's `capture-pane -e` — does carry it. Do not list dim as a
+  supported attribute of a screenshot without saying which path.
+- **The corpus gate re-renders step entries from their recorded `.txt`.** That
+  matches how those entries were recorded, but it is no longer how a live run
+  produces a step image. Nothing on disk carries a step's grid, so regenerating
+  the corpus from a colour-emitting recipe needs the gate extended at the same
+  time. See `CorpusByteIdentityTest`.
+
+Reading a screen for a step goes through `screen.capture_screen`, which reads
+the grid first and derives the text from it. Do not "simplify" it back into two
+reads: text and grid fetched separately can come from different instants, and
+the result is a `steps/NN.txt` that describes one screen while `steps/NN.svg`
+and the dedup verdict describe another. The Rust `ScreenSource::capture_screen`
+makes the same choice for the same reason.
 
 The defaults are load-bearing: `tests/test_evidence_config.py` replays every
 `session.cast` under `examples/artifacts/` and asserts the re-rendered SVG is

--- a/python/README.md
+++ b/python/README.md
@@ -266,9 +266,17 @@ ffmpeg -y -loglevel error -i session.agg.gif \
 
 The `attributed_rsvg` video backend skips `agg` entirely and renders each frame
 from the same attributed grid `final.svg` is rendered from, so a video frame and
-the final screenshot of the same moment are the same image. This does not extend
-to the per-step screenshots under `steps/`, which are still rendered from plain
-text and are monochrome. It needs `rsvg-convert` and `ffmpeg`.
+the final screenshot of the same moment are the same image. It needs
+`rsvg-convert` and `ffmpeg`.
+
+A per-step screenshot is rendered from the grid its session reported at that
+step, when the session had one to report. Every built-in backend does, so the
+`steps/` images carry the same colour and text attributes as `final.svg` — but
+they are read from the live session rather than replayed from the cast, so a
+frame of the video and a *step* image are not guaranteed to be the same bytes
+the way the final screenshot and its frame are. A session backend with no
+`screen_attributed()` renders its step screenshots from the flattened text, in
+monochrome; so does the `png` screen renderer, which accepts text only.
 
 If you specifically want a cast that the asciinema CLI wrote, install the extra
 and select that backend:

--- a/python/docs/evidence-quality.md
+++ b/python/docs/evidence-quality.md
@@ -1,9 +1,9 @@
 # Evidence quality: what the research found
 
-**Last updated:** 2026-08-15
+**Last updated:** 2026-08-18
 
 > **Status, 0.3.0.** This page is the record of what the research measured, and
-> it is kept in the tense it was written in. Three of the things it describes as
+> it is kept in the tense it was written in. Four of the things it describes as
 > defects or as deferred have since been done, and the sections below have not
 > been rewritten around them:
 >
@@ -16,11 +16,16 @@
 > - **The GIF-free direct-frame video backend exists** as the opt-in
 >   `attributed_rsvg` backend, and remains opt-in for the reason given below.
 > - **Step-screenshot dedup exists**, opt-in via `evidence.dedup_step_screenshots`,
->   and fingerprints the attributed grid rather than the screen text.
+>   and fingerprints the attributed grid rather than the screen text. Until
+>   step grids existed that fingerprint could only ever see the text; it can
+>   now see colour.
+> - **Per-step screenshots now render from a grid too**, when the session that
+>   produced the step reported one. `StepResult` carries an optional
+>   `screen_attributed`; every built-in session backend fills it. The last
+>   section has what is still true of the ones that do not.
 >
 > Still open: no font ships with TermProof, the browser half of SVG font
-> embedding is still unverified, per-step screenshots are still rendered from
-> plain text (see the last section), and **dim still does not survive the
+> embedding is still unverified, and **dim still does not survive the
 > cast-replay path** — the finding below about SGR 2 is unchanged, and it is now
 > pinned by `test_dim_does_not_survive_the_cast_replay_path`.
 
@@ -162,10 +167,11 @@ evidence:
     font_size: 14
     scale: 2
 
-  # --- Parses today, but has no effect until the attributed-grid change -----
-  # The renderers only ever receive flat text, so these set a single global
-  # foreground and background rather than per-cell colour. They are here so the
-  # theme can be matched; they cannot recover the colour that screen.py drops.
+  # --- Effective, with the attributed-grid path in place --------------------
+  # These are the *defaults* a cell falls back to, not a global override: a cell
+  # that names no colour of its own is drawn in them. They were inert when every
+  # renderer received flat text; now that final.svg and the per-step images
+  # render from a grid, they set the theme around the colour the grid carries.
   svg:
     fg: "#e6edf3"
     bg: "#101418"
@@ -188,16 +194,37 @@ no effect.
 
 ## What is deferred, and why
 
-**Per-step screenshots are still rendered from plain text.** `final.svg` is
-rendered from the attributed replay of the cast and carries colour.
-`StepResult.screen`, though, is `session.screen` — pyte's `display`, already
-flattened — so the images under `steps/` are monochrome even though the
-renderer drawing them is not. Closing this needs the session to hand each step
-an attributed grid alongside its text, and it needs an answer for how the
-corpus pins those images: a step screenshot is a moment during a live session,
-and `CorpusByteIdentityTest` can only replay what is checked in, which for a
-step is its plain-text `.txt`. `TmuxSession.screen_attributed()` is the seam a
-fix would build on.
+**Per-step screenshots render from a grid when the session supplies one — and
+three things about that are still open.** `StepResult` now carries an optional
+`screen_attributed`, filled by `screen.capture_screen`, which reads the grid
+first and derives the step's text from it so the `.txt` and the `.svg` beside it
+cannot describe different instants. All four built-in session backends supply a
+grid (pty via pyte, pty+asciinema and Docker through the same session class, and
+tmux through `capture-pane -e`), as does the agent-driven mode from its cast
+replay. Measured over the 13 example recipes, step screenshots carrying
+attributed rendering went from 0/76 to 11/76 — 9 in colour and 11 with text
+attributes — with the other 65 byte-identical, because the recipes behind them
+drive genuinely monochrome TUIs. What remains:
+
+- **A session backend that reports no grid still renders from plain text.**
+  That is the designed fallback, not a defect, but it means "step screenshots
+  are in colour" is not a claim the code supports in general.
+- **The `png` renderer implements only the text-only protocol**, so PNG step
+  screenshots are monochrome regardless. That is the same licence-blocked
+  per-cell PNG work described below.
+- **The corpus cannot pin a colour step image.** `CorpusByteIdentityTest`
+  re-renders each step entry from its recorded `.txt`, which is correct for the
+  entries checked in — they predate the grid — but nothing on disk carries a
+  step's grid, so a regenerated corpus would produce images the gate cannot
+  reproduce. Recording the grid beside the text (an SGR-encoded `.ans`
+  alongside each `.txt`, say) is the follow-up.
+
+**A step image and a video frame of the same moment are not the same bytes.**
+`final.svg` and the `attributed_rsvg` video both come from replaying the cast,
+which is why the final screenshot and its frame match exactly. A step grid is
+read from the live session at the moment of the step, which is the only place
+that moment exists. The correspondence claim belongs to the final screenshot
+only.
 
 **No font ships with TermProof.** `evidence.png.font_path` loads a TrueType face
 when you give it one, but bundling a default requires a licence decision (DejaVu
@@ -244,7 +271,10 @@ Small, independently reviewable, each one useful alone.
 
 1. **Colour-stress fixture and the config surface.** Done — this page, plus
    `examples/colorstress/` and the `evidence:` config block.
-2. **Attributed grid path** — the additive interface change.
+2. **Attributed grid path** — the additive interface change. Done, in two
+   parts: the renderer's optional `render_attributed`, then
+   `StepResult.screen_attributed` carrying the grid as far as the per-step
+   screenshots.
 3. **PNG renderer: bundled scalable font, drawn per cell.** Needs the licence
    decision.
 4. **Deduplicate identical consecutive step screens via a manifest** — the

--- a/python/docs/plugin-protocols.md
+++ b/python/docs/plugin-protocols.md
@@ -53,7 +53,41 @@ When the method is present and the pipeline has a grid to offer, TermProof calls
 it in preference to `render`, so nothing is lost re-parsing text that the
 terminal emulator already parsed. This is additive: a renderer that defines only
 `render` keeps working unchanged and keeps receiving the screen as text. Both
-builtin `svg` and `png_rsvg` implement it; `png` does not.
+builtin `svg` and `png_rsvg` implement it; `png` does not, which is why PNG step
+screenshots are monochrome however colourful the grid is.
+
+The pipeline has a grid for `final.svg` and for the `attributed_rsvg` video
+always, and for a per-step screenshot whenever the session reported one.
+
+### Optional: `screen_attributed` on a session backend
+
+A `SessionBackend` returns a session object, and TermProof reads that session's
+screen after each step. If the session defines
+
+```python
+def screen_attributed(self) -> AttributedScreen: ...
+```
+
+TermProof reads the grid through it, puts it on `StepResult.screen_attributed`,
+and renders the step's screenshot from it — so the step image carries the colour
+and text attributes the pane actually had. It also derives the step's `screen`
+text from that same grid, so the `.txt` and the `.svg` beside it describe one
+instant rather than two reads that may disagree.
+
+The method is optional in the full sense. A session without it keeps working
+unchanged: TermProof reads its `screen` string, reports no grid, and renders the
+step screenshot from the text, in monochrome, exactly as before. Do not add the
+method unless the session can actually answer it — reporting an inaccurate grid
+is worse than reporting none.
+
+All four built-in backends implement it: `pexpect` and `pexpect_asciinema` and
+`docker` through `TerminalSession` (from its `pyte.Screen`), and `tmux` through
+`capture-pane -e`. Dim differs between them: the tmux path parses the escapes
+itself and carries SGR 2, the pyte path cannot.
+
+A `StepAction` that builds its own `StepResult` can pick this up by calling
+`termproof.builtin_steps.step_result(name, passed, detail, session)` instead of
+constructing one by hand.
 
 `ScreenRenderer` and `VideoBackend` plugins can optionally define a
 `from_config(cls, evidence: EvidenceConfig) -> Self` classmethod. When it is
@@ -71,13 +105,18 @@ state the run passes through and then leaves inexpressible. `StepAwareAssertionT
 extends it with `steps`: the `StepResult` list for the steps that ran, in order,
 each carrying the screen captured after that step.
 
-`StepResult.screen` is plain text — pyte's already-flattened `display` — not an
-`AttributedScreen`. Colour, bold and reverse video are gone by the time an
-assertion sees a per-step screen, so a step-aware assertion can match glyphs and
-layout but not styling. The `render_attributed` grid described above is built
-for the final screen and the video, not for these; see
-[`docs/evidence-quality.md`](evidence-quality.md) for why per-step screens are
-still flat.
+`StepResult.screen` is plain text: the screen flattened the way `screen_text`
+flattens it. Match glyphs and layout against it and nothing else — a screen text
+never carries an escape sequence.
+
+`StepResult.screen_attributed` is the same screen as an `AttributedScreen`, or
+`None`. It is what the per-step screenshot is rendered from, and a step-aware
+assertion may read it to match on styling. Treat it as genuinely optional: it is
+`None` whenever the session backend behind the run does not implement
+`screen_attributed()`, and it is also `None` on a `StepResult` rebuilt from
+`result.json`, which does not carry the grid. An assertion that requires styling
+should report that it had no grid rather than fail the run as though the styling
+were absent.
 
 The two protocols are one opt-in apart. TermProof passes `steps` only to an
 `evaluate` that declares a parameter of that name, so an assertion written

--- a/python/plugin-template/docs/protocol.md
+++ b/python/plugin-template/docs/protocol.md
@@ -78,9 +78,11 @@ The following are **NOT** available and must not be relied upon:
   stale prior runs at best, nothing at worst
 - **Accumulated raw output** — assertion receives the final raw output, not
   the incremental stream
-- **Screen attributes** — every screen an assertion sees, final or per-step, is
-  flattened text. Colour, bold and reverse video are available to renderers via
-  `render_attributed`, not to assertions
+- **Attributes on the final screen** — the `screen` argument is flattened text,
+  and there is no attributed form of it available to an assertion. Per-step
+  screens are the exception: `StepResult.screen_attributed` carries the grid
+  when the session reported one, and is `None` when it did not, so an assertion
+  that reads it must handle both
 
 Plugin authors should not attempt filesystem-based workarounds. To enforce
 timing constraints, use TermProof core features (e.g. recipe-level

--- a/python/site/index.html
+++ b/python/site/index.html
@@ -40,7 +40,7 @@
     <h2>What is it?</h2>
     <div class="card-grid">
       <div class="card"><h3>Recipe → PTY → Cast</h3><p>JSON recipes describe how to drive your TUI. The runner spawns a real pexpect PTY — not a mock — and writes the session out in asciinema v2 format itself; the <code>asciinema</code> CLI is optional, behind <code>termproof[record]</code>. The cast is the source of truth.</p></div>
-      <div class="card"><h3>Screenshots + Video</h3><p>Every step writes a screenshot and text snapshot. <code>final.svg</code> is rendered in colour from the terminal grid; the per-step images are rendered from plain text. With <code>--video</code>, agg + ffmpeg render a 60-fps MP4 from the same cast.</p></div>
+      <div class="card"><h3>Screenshots + Video</h3><p>Every step writes a screenshot and text snapshot. <code>final.svg</code> is rendered in colour from the terminal grid, and so is each step image when the session can report a grid — every built-in session backend can; one that cannot falls back to plain text. With <code>--video</code>, agg + ffmpeg render a 60-fps MP4 from the same cast.</p></div>
       <div class="card"><h3>Reports + PR Comments</h3><p><code>latest-report.md</code> embeds assertion tables and evidence links. CI posts a sticky comment on every PR and uploads <code>termproof-ci-evidence</code>.</p></div>
     </div>
   </section>

--- a/python/termproof/agent_driven.py
+++ b/python/termproof/agent_driven.py
@@ -8,10 +8,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .attributed import AttributedScreen
 from .cast import CastRecorder
 from .models import AssertionResult, Recipe, StepResult
 from .protocols import AgentRunner
-from .screen import replay_cast
+from .screen import replay_cast_both
 from .session import TerminalSession
 
 
@@ -140,13 +141,14 @@ class AgentDrivenRunner:
         (run_dir / "agent_prompt.md").write_text(prompt, encoding="utf-8")
         outcome = self.agent_runner.run(recipe, prompt, run_dir)
         _write_agent_files(run_dir, outcome)
-        screen = _screen_from_agent_cast(recipe, run_dir, outcome)
+        screen, grid = _screen_from_agent_cast(recipe, run_dir, outcome)
         steps = [
             StepResult(
                 name="codex-operator",
                 passed=outcome.exit_code == 0,
                 detail=f"operator exit code {outcome.exit_code}",
                 screen=screen,
+                screen_attributed=grid,
             )
         ]
         assertions = _agent_assertions(recipe, outcome)
@@ -239,15 +241,23 @@ def _write_agent_files(run_dir: Path, outcome: AgentOutcome) -> None:
     )
 
 
-def _screen_from_agent_cast(recipe: Recipe, run_dir: Path, outcome: AgentOutcome) -> str:
+def _screen_from_agent_cast(
+    recipe: Recipe,
+    run_dir: Path,
+    outcome: AgentOutcome,
+) -> tuple[str, AttributedScreen]:
+    """The operator's end state, as text and as a grid.
+
+    Both come from one replay of the cast, so the step's screenshot and its
+    recorded text describe the same final screen. An agent-driven run has a
+    single step, and this is the whole of what it can show.
+    """
     cast_path = run_dir / "session.cast"
-    if cast_path.exists():
-        screen, _, _ = replay_cast(cast_path)
-        return screen
-    with CastRecorder(cast_path, recipe.cols, recipe.rows, ["codex-operator", recipe.name]) as recorder:
-        recorder.output(outcome.transcript)
-    screen, _, _ = replay_cast(cast_path)
-    return screen
+    if not cast_path.exists():
+        with CastRecorder(cast_path, recipe.cols, recipe.rows, ["codex-operator", recipe.name]) as recorder:
+            recorder.output(outcome.transcript)
+    screen, grid, _, _ = replay_cast_both(cast_path)
+    return screen, grid
 
 
 def _load_json(output: str) -> dict[str, Any] | None:

--- a/python/termproof/attributed.py
+++ b/python/termproof/attributed.py
@@ -103,6 +103,12 @@ _STYLE_ON = {
     7: "reverse",
     9: "strikethrough",
 }
+#: Escape introducers whose body runs to a string terminator: OSC, DCS, SOS,
+#: PM and APC. ``capture-pane -e`` emits OSC-8 hyperlinks, so this is not a
+#: theoretical family for the step-screenshot path.
+_STRING_INTRODUCERS = frozenset("]PX^_")
+#: SS2 and SS3. The character after the introducer is displayed.
+_SINGLE_SHIFTS = frozenset("NO")
 _STYLE_OFF = {
     23: "italic",
     24: "underline",
@@ -219,11 +225,14 @@ class _CellPool:
     A terminal screen is mostly repetition: blank cells, runs of one colour.
     Cells are frozen and carry no identity, so one object can stand in for every
     cell equal to it. Measured with ``tracemalloc`` over allocations still alive
-    in this module, a typical 100x32 screen goes from 527 KiB to 31 KiB; a
-    screen where every cell differs is the floor at 292 KiB, because the saving
-    is in *repetition*, not in the cells themselves. That is the difference
-    between a grid per step being affordable for a whole run and not — see
-    ``StepScreenMemoryTest``.
+    in this module, a typical 100x32 screen goes from 527 KiB to 31 KiB, which
+    is the difference between a grid per step being affordable for a whole run
+    and not — see ``StepScreenMemoryTest``.
+
+    The saving is entirely in the repetition, so the floor is exactly no saving
+    at all: a screen whose 3,200 cells are all distinct measures 527 KiB either
+    way. That is the mechanism stated precisely rather than a caveat — there is
+    nothing to share when nothing is equal, and no real screen looks like that.
 
     The pool lives for one grid build and is then dropped. A process-wide cache
     would share more, but it would also grow without a bound anyone owns.
@@ -515,10 +524,39 @@ def _cells_from_ansi_line(
 
 
 def _consume_ansi_sequence(line: str, index: int, attrs: _AnsiAttrs) -> int:
-    if line[index + 1 : index + 2] != "[":
-        # ESC at the end of the line, or introducing something that is not CSI.
-        # Drop the ESC and let the next character be read normally.
+    """Consume the escape sequence at *index*, returning the index after it.
+
+    Every family has to be recognised, not just the one carrying colour.
+    Anything unrecognised has its ESC dropped and its body rendered as glyphs,
+    which is how ``\\x1b]8;;url\\x1b\\\\`` — an OSC-8 hyperlink, which
+    ``capture-pane -e`` really does emit — turned ``beforeTXTafter`` into
+    ``before]8;;url\\TXT]8;;\\after`` on a step screenshot and in its ``.txt``.
+
+    What each family contributes to the grid is a deliberate decision, and for
+    every one but CSI-SGR the answer is nothing visible: an OSC sets a title or
+    attaches a URL, a DCS carries a device reply, a charset designation and the
+    two-byte escapes change state this model does not keep. They are consumed
+    silently. SS2/SS3 are the exception in shape — the character *after* the
+    introducer is displayed — so only the introducer is consumed.
+    """
+    introducer = line[index + 1 : index + 2]
+    if introducer == "":
+        # A bare ESC at the end of the line. Drop it; there is nothing to read.
         return index + 1
+    if introducer == "[":
+        return _consume_csi(line, index, attrs)
+    if introducer in _STRING_INTRODUCERS:
+        return _consume_string_sequence(line, index)
+    if introducer in _SINGLE_SHIFTS:
+        # SS2/SS3 shift the single character that follows into another
+        # character set. The character is displayed, and the charset is not
+        # modelled here, so consume the two-byte introducer only.
+        return index + 2
+    return _consume_escape_sequence(line, index)
+
+
+def _consume_csi(line: str, index: int, attrs: _AnsiAttrs) -> int:
+    """``ESC [`` params intermediates final — the family that carries SGR."""
     end = index + 2
     while end < len(line):
         char = line[end]
@@ -539,6 +577,51 @@ def _consume_ansi_sequence(line: str, index: int, attrs: _AnsiAttrs) -> int:
     if line[end] == "m":
         _apply_sgr(_parse_sgr_params(line[index + 2 : end]), attrs)
     return end + 1
+
+
+def _consume_string_sequence(line: str, index: int) -> int:
+    """OSC, DCS, SOS, PM and APC: an arbitrary body up to a terminator.
+
+    Two terminators are in use and both have to be accepted. ST is the
+    standard ``ESC \\``; BEL is the older form, and it is what a great many
+    programs still send to close an OSC.
+    """
+    end = index + 2
+    while end < len(line):
+        char = line[end]
+        if char == "\x07":
+            return end + 1
+        if char == "\x1b":
+            if line[end + 1 : end + 2] == "\\":
+                return end + 2
+            # Not ST: a fresh escape, which abandons this string.
+            return end
+        end += 1
+    # Terminator never arrived — the capture was cut. Consume the rest rather
+    # than spilling the body onto the screen.
+    return len(line)
+
+
+def _consume_escape_sequence(line: str, index: int) -> int:
+    """The general form: ``ESC`` intermediates final.
+
+    Covers charset designation (``ESC ( B``), the DEC line-size controls
+    (``ESC # 8``) and every two-byte escape (``ESC 7``, ``ESC =``, ``ESC c``),
+    because ECMA-48 gives them all one shape: zero or more intermediates in
+    0x20-0x2F, then a final in 0x30-0x7E.
+    """
+    end = index + 1
+    while end < len(line) and "\x20" <= line[end] <= "\x2f":
+        end += 1
+    if end >= len(line):
+        # Cut before the final byte, as for a truncated CSI.
+        return len(line)
+    if "\x30" <= line[end] <= "\x7e":
+        return end + 1
+    # Not a final byte at all — a control character, or something past 0x7E.
+    # This is not a sequence any terminal would act on, so drop the ESC alone
+    # and let what follows be read as ordinary text.
+    return index + 1
 
 
 def _is_csi_final(char: str) -> bool:

--- a/python/termproof/attributed.py
+++ b/python/termproof/attributed.py
@@ -218,9 +218,12 @@ class _CellPool:
 
     A terminal screen is mostly repetition: blank cells, runs of one colour.
     Cells are frozen and carry no identity, so one object can stand in for every
-    cell equal to it. On a 100x32 screen this takes the grid from ~528 KB to
-    ~36 KB, which is the difference between a grid per step being affordable for
-    a whole run and not — see ``StepScreenMemoryTest``.
+    cell equal to it. Measured with ``tracemalloc`` over allocations still alive
+    in this module, a typical 100x32 screen goes from 527 KiB to 31 KiB; a
+    screen where every cell differs is the floor at 292 KiB, because the saving
+    is in *repetition*, not in the cells themselves. That is the difference
+    between a grid per step being affordable for a whole run and not — see
+    ``StepScreenMemoryTest``.
 
     The pool lives for one grid build and is then dropped. A process-wide cache
     would share more, but it would also grow without a bound anyone owns.
@@ -235,7 +238,7 @@ class _CellPool:
         return self._cells.setdefault(cell, cell)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class AttributedScreen:
     """A rectangular terminal grid plus cursor metadata."""
 
@@ -243,6 +246,24 @@ class AttributedScreen:
     cursor_row: int = 0
     cursor_column: int = 0
     cursor_hidden: bool = False
+
+    def __repr__(self) -> str:
+        """Dimensions and the first line, not every cell.
+
+        The generated dataclass repr of a 100x32 grid is around half a megabyte,
+        one ``AttributedCell(...)`` per cell. Now that a grid hangs off every
+        ``StepResult``, that is what a failing assertion would print — output
+        nobody can read, about the field that is usually not the one at fault.
+        Reach for ``rows`` or ``text_lines()`` when the cells are the question.
+        """
+        first = next(iter(self.text_lines(trim_right=True)), "")
+        if len(first) > 40:
+            first = first[:37] + "..."
+        cursor = f"{self.cursor_row},{self.cursor_column}"
+        return (
+            f"AttributedScreen({self.row_count}x{self.column_count}, "
+            f"cursor={cursor}, first_line={first!r})"
+        )
 
     @property
     def row_count(self) -> int:
@@ -499,7 +520,15 @@ def _consume_ansi_sequence(line: str, index: int, attrs: _AnsiAttrs) -> int:
         # Drop the ESC and let the next character be read normally.
         return index + 1
     end = index + 2
-    while end < len(line) and not line[end].isalpha():
+    while end < len(line):
+        char = line[end]
+        if char == "\x1b":
+            # A fresh ESC abandons the sequence in progress. Stop here so the
+            # new one is read from its own start rather than swallowed into
+            # this one's parameters.
+            return end
+        if _is_csi_final(char):
+            break
         end += 1
     if end >= len(line):
         # A CSI whose final byte never arrived — the capture was cut mid
@@ -507,10 +536,27 @@ def _consume_ansi_sequence(line: str, index: int, attrs: _AnsiAttrs) -> int:
         # nothing, so the parameter bytes are consumed rather than emitted as
         # glyphs. Emitting them would put `[31` in the middle of a screenshot.
         return len(line)
-    command = line[end]
-    if command == "m":
+    if line[end] == "m":
         _apply_sgr(_parse_sgr_params(line[index + 2 : end]), attrs)
     return end + 1
+
+
+def _is_csi_final(char: str) -> bool:
+    """Whether *char* terminates a CSI sequence.
+
+    ECMA-48 puts the final byte at 0x40-0x7E, above the parameter bytes
+    (0x30-0x3F) and the intermediates (0x20-0x2F). Scanning for ``isalpha()``
+    instead stopped only on letters, so a sequence ending in one of the
+    non-letter finals — ``\\x1b[1~``, ``\\x1b[5@``, ``\\x1b[2^`` — ran on to the
+    next letter in the text and ate it with the escape: ``before\\x1b[1~after``
+    rendered as ``beforefter``. Silent text corruption in a screenshot, and the
+    same shape of defect as reading a truncated sequence as glyphs.
+
+    ``isalpha()`` was also true of non-ASCII letters, which cannot terminate a
+    CSI at all; a bare range check is both narrower and wider in the right
+    directions.
+    """
+    return "\x40" <= char <= "\x7e"
 
 
 def _parse_sgr_params(params: str) -> list[int]:

--- a/python/termproof/attributed.py
+++ b/python/termproof/attributed.py
@@ -5,12 +5,14 @@ bold, reverse video. This module keeps a per-cell grid so a screenshot looks
 like what the operator saw, and so two screens that differ only in colour
 compare as different.
 
-Which artifacts actually get that today: ``final.svg`` and the
-``attributed_rsvg`` video, both built from a grid. Per-step screenshots are
-rendered from ``StepResult.screen``, which is already flattened, so they are
-monochrome. Dim is carried by :func:`attributed_screen_from_ansi_text` but not
-by :func:`attributed_screen_from_pyte`, because pyte models no dim attribute.
-See ``docs/evidence-quality.md``.
+Which artifacts get that: ``final.svg`` and the ``attributed_rsvg`` video, both
+built from a grid, and per-step screenshots whenever the session behind the step
+could supply one — see :attr:`~termproof.models.StepResult.screen_attributed`.
+A session backend that reports no grid still renders its step screenshots from
+the flattened text, in monochrome, and so does the PNG renderer, which has no
+``render_attributed``. Dim is carried by :func:`attributed_screen_from_ansi_text`
+but not by :func:`attributed_screen_from_pyte`, because pyte models no dim
+attribute. See ``docs/evidence-quality.md``.
 
 Depends on the standard library alone; :func:`attributed_screen_from_pyte`
 reads a ``pyte.Screen`` structurally rather than importing it.
@@ -211,6 +213,28 @@ class AttributedCell:
         )
 
 
+class _CellPool:
+    """Shares one object between the cells of a grid that compare equal.
+
+    A terminal screen is mostly repetition: blank cells, runs of one colour.
+    Cells are frozen and carry no identity, so one object can stand in for every
+    cell equal to it. On a 100x32 screen this takes the grid from ~528 KB to
+    ~36 KB, which is the difference between a grid per step being affordable for
+    a whole run and not — see ``StepScreenMemoryTest``.
+
+    The pool lives for one grid build and is then dropped. A process-wide cache
+    would share more, but it would also grow without a bound anyone owns.
+    """
+
+    __slots__ = ("_cells",)
+
+    def __init__(self) -> None:
+        self._cells: dict[AttributedCell, AttributedCell] = {}
+
+    def intern(self, cell: AttributedCell) -> AttributedCell:
+        return self._cells.setdefault(cell, cell)
+
+
 @dataclass(frozen=True)
 class AttributedScreen:
     """A rectangular terminal grid plus cursor metadata."""
@@ -282,10 +306,13 @@ def attributed_screen_from_lines(
     rows: int = DEFAULT_ROWS,
 ) -> AttributedScreen:
     """Build an unstyled grid from already-split plain text."""
+    pool = _CellPool()
     screen_rows = []
     for line in lines[:rows]:
         printable = [ch for ch in line if not _is_control(ch)]
-        screen_rows.append(tuple(AttributedCell(text=ch) for ch in printable[:columns]))
+        screen_rows.append(
+            tuple(pool.intern(AttributedCell(text=ch)) for ch in printable[:columns])
+        )
     return AttributedScreen(rows=tuple(screen_rows))
 
 
@@ -308,10 +335,15 @@ def attributed_screen_from_pyte(screen: Any) -> AttributedScreen:
 
     Duck-typed so this module does not depend on pyte.
     """
+    pool = _CellPool()
     rows = []
     for y in range(screen.lines):
         line = screen.buffer[y]
-        rows.append(tuple(_cell_from_pyte_char(line[x]) for x in range(screen.columns)))
+        rows.append(
+            tuple(
+                pool.intern(_cell_from_pyte_char(line[x])) for x in range(screen.columns)
+            )
+        )
     cursor = screen.cursor
     return AttributedScreen(
         rows=tuple(rows),
@@ -333,13 +365,16 @@ def attributed_screen_from_ansi_text(
     :func:`attributed_screen_from_text`, so this is safe to use as the default
     path for screens of unknown provenance.
     """
+    pool = _CellPool()
     screen_rows = []
     attrs = _AnsiAttrs()
     lines = ansi_text.split("\n")
     if lines and lines[-1] == "":
         lines.pop()
     for line in lines[:rows]:
-        screen_rows.append(tuple(_cells_from_ansi_line(line.rstrip("\r"), attrs, columns)))
+        screen_rows.append(
+            tuple(_cells_from_ansi_line(line.rstrip("\r"), attrs, columns, pool))
+        )
     return AttributedScreen(rows=tuple(screen_rows))
 
 
@@ -411,7 +446,12 @@ def _cell_from_pyte_char(char: Any) -> AttributedCell:
     )
 
 
-def _cells_from_ansi_line(line: str, attrs: _AnsiAttrs, columns: int) -> list[AttributedCell]:
+def _cells_from_ansi_line(
+    line: str,
+    attrs: _AnsiAttrs,
+    columns: int,
+    pool: _CellPool,
+) -> list[AttributedCell]:
     cells: list[AttributedCell] = []
     index = 0
     while index < len(line) and len(cells) < columns:
@@ -422,7 +462,7 @@ def _cells_from_ansi_line(line: str, attrs: _AnsiAttrs, columns: int) -> list[At
                 continue
         ch = line[index]
         if ch == "\t":
-            _append_tab(cells, attrs, columns)
+            _append_tab(cells, attrs, columns, pool)
         elif _is_control(ch):
             # A terminal acts on these rather than displaying them, and a raw
             # control byte in the output makes the SVG invalid XML — which a
@@ -430,35 +470,43 @@ def _cells_from_ansi_line(line: str, attrs: _AnsiAttrs, columns: int) -> list[At
             pass
         elif unicodedata.combining(ch) and cells:
             previous = cells[-1]
-            cells[-1] = AttributedCell(
-                text=unicodedata.normalize("NFC", previous.text + ch),
-                fg=previous.fg,
-                bg=previous.bg,
-                bold=previous.bold,
-                dim=previous.dim,
-                italic=previous.italic,
-                underline=previous.underline,
-                strikethrough=previous.strikethrough,
-                reverse=previous.reverse,
-                width=previous.width,
+            cells[-1] = pool.intern(
+                AttributedCell(
+                    text=unicodedata.normalize("NFC", previous.text + ch),
+                    fg=previous.fg,
+                    bg=previous.bg,
+                    bold=previous.bold,
+                    dim=previous.dim,
+                    italic=previous.italic,
+                    underline=previous.underline,
+                    strikethrough=previous.strikethrough,
+                    reverse=previous.reverse,
+                    width=previous.width,
+                )
             )
         else:
             width = _cell_width(ch)
-            cells.append(attrs.cell(ch, width=width))
+            cells.append(pool.intern(attrs.cell(ch, width=width)))
             if width == 2 and len(cells) < columns:
-                cells.append(attrs.cell("", width=0))
+                cells.append(pool.intern(attrs.cell("", width=0)))
         index += 1
     return cells
 
 
 def _consume_ansi_sequence(line: str, index: int, attrs: _AnsiAttrs) -> int:
-    if index + 2 >= len(line) or line[index + 1] != "[":
+    if line[index + 1 : index + 2] != "[":
+        # ESC at the end of the line, or introducing something that is not CSI.
+        # Drop the ESC and let the next character be read normally.
         return index + 1
     end = index + 2
     while end < len(line) and not line[end].isalpha():
         end += 1
     if end >= len(line):
-        return index + 1
+        # A CSI whose final byte never arrived — the capture was cut mid
+        # sequence. A terminal is still waiting for the terminator and displays
+        # nothing, so the parameter bytes are consumed rather than emitted as
+        # glyphs. Emitting them would put `[31` in the middle of a screenshot.
+        return len(line)
     command = line[end]
     if command == "m":
         _apply_sgr(_parse_sgr_params(line[index + 2 : end]), attrs)
@@ -528,10 +576,16 @@ def _apply_extended_color(params: list[int], index: int, attrs: _AnsiAttrs) -> i
     return len(params) - 1
 
 
-def _append_tab(cells: list[AttributedCell], attrs: _AnsiAttrs, columns: int) -> None:
+def _append_tab(
+    cells: list[AttributedCell],
+    attrs: _AnsiAttrs,
+    columns: int,
+    pool: _CellPool,
+) -> None:
     target = min(((len(cells) // 8) + 1) * 8, columns)
+    blank = pool.intern(attrs.cell(" "))
     while len(cells) < target:
-        cells.append(attrs.cell(" "))
+        cells.append(blank)
 
 
 def _xterm_256_color(index: int) -> str:

--- a/python/termproof/builtin_steps.py
+++ b/python/termproof/builtin_steps.py
@@ -7,7 +7,28 @@ from typing import Any
 
 from .models import StepResult
 from .protocols import StepAction as StepAction
+from .screen import ScreenCapture, capture_screen
 from .session import TerminalSession
+
+
+def step_result(
+    name: str,
+    passed: bool,
+    detail: str,
+    session: Any,
+) -> StepResult:
+    """A ``StepResult`` carrying whatever screen the session can report.
+
+    One read via :func:`~termproof.screen.capture_screen`, so the text on the
+    step and the grid its screenshot is rendered from are the same instant. A
+    session with no grid to give yields ``screen_attributed=None``, and the
+    screenshot falls back to the text exactly as before.
+
+    Public so a third-party ``StepAction`` can pick up attributed step
+    screenshots by calling it instead of building a ``StepResult`` by hand.
+    """
+    capture = capture_screen(session)
+    return StepResult(name, passed, detail, capture.screen, capture.attributed)
 
 
 class WaitForText:
@@ -24,7 +45,7 @@ class WaitForText:
         timeout = float(step.get("timeout_seconds", 10))
         passed = session.wait_for_text(text, timeout)
         detail = f"found {text!r}" if passed else f"timed out waiting for {text!r}"
-        return StepResult(display, passed, detail, session.screen)
+        return step_result(display, passed, detail, session)
 
 
 class WaitForIdle:
@@ -48,7 +69,7 @@ class WaitForIdle:
             detail = "no output observed from the session"
         else:
             detail = "timed out waiting for idle"
-        return StepResult(display, passed, detail, session.screen)
+        return step_result(display, passed, detail, session)
 
 
 class SendText:
@@ -62,7 +83,7 @@ class SendText:
     ) -> StepResult:
         display = step.get("name", f"{index}:{self.name}")
         session.send_text(step["text"])
-        return StepResult(display, True, "sent text", session.screen)
+        return step_result(display, True, "sent text", session)
 
 
 class SendLine:
@@ -76,7 +97,7 @@ class SendLine:
     ) -> StepResult:
         display = step.get("name", f"{index}:{self.name}")
         session.send_line(step.get("text", ""))
-        return StepResult(display, True, "sent line", session.screen)
+        return step_result(display, True, "sent line", session)
 
 
 class Press:
@@ -90,7 +111,7 @@ class Press:
     ) -> StepResult:
         display = step.get("name", f"{index}:{self.name}")
         session.press(step["key"])
-        return StepResult(display, True, f"pressed {step['key']}", session.screen)
+        return step_result(display, True, f"pressed {step['key']}", session)
 
 
 class Sleep:
@@ -105,7 +126,7 @@ class Sleep:
         display = step.get("name", f"{index}:{self.name}")
         time.sleep(float(step.get("seconds", 1)))
         session.read_available(0)
-        return StepResult(display, True, "slept", session.screen)
+        return step_result(display, True, "slept", session)
 
 
 class WaitForRegex:
@@ -134,47 +155,36 @@ class WaitForRegex:
         # -- validate pattern -------------------------------------------------
         pattern_str = step.get("pattern")
         if not isinstance(pattern_str, str):
-            return StepResult(
+            return step_result(
                 display,
                 False,
                 f"wait_for_regex 'pattern' must be a string, got {type(pattern_str).__name__}",
-                getattr(session, "screen", ""),
+                session,
             )
 
         try:
             pattern = re.compile(pattern_str)
         except re.error as exc:
-            return StepResult(
-                display,
-                False,
-                f"invalid regex {pattern_str!r}: {exc}",
-                getattr(session, "screen", ""),
-            )
+            return step_result(display, False, f"invalid regex {pattern_str!r}: {exc}", session)
 
         # -- validate timeout -------------------------------------------------
         raw_timeout = step.get("timeout_seconds", 10)
         try:
             timeout = float(raw_timeout)
         except (TypeError, ValueError):
-            return StepResult(
+            return step_result(
                 display,
                 False,
                 f"wait_for_regex timeout_seconds must be a number, got {raw_timeout!r}",
-                getattr(session, "screen", ""),
+                session,
             )
         if math.isnan(timeout) or math.isinf(timeout):
-            return StepResult(
-                display,
-                False,
-                f"wait_for_regex timeout_seconds must be finite, got {timeout}",
-                getattr(session, "screen", ""),
+            return step_result(
+                display, False, f"wait_for_regex timeout_seconds must be finite, got {timeout}", session
             )
         if timeout <= 0:
-            return StepResult(
-                display,
-                False,
-                f"wait_for_regex timeout_seconds must be > 0, got {timeout}",
-                getattr(session, "screen", ""),
+            return step_result(
+                display, False, f"wait_for_regex timeout_seconds must be > 0, got {timeout}", session
             )
 
         deadline = time.monotonic() + timeout
@@ -197,34 +207,37 @@ class WaitForRegex:
                 return None
             return pattern.search(text)
 
+        def _matched(capture: ScreenCapture) -> StepResult | None:
+            raw_text = getattr(session, "raw_output", "") or ""
+            match = _search(capture.screen) or _search(raw_text)
+            if match is None:
+                return None
+            # Built from the capture that was searched, not from a fresh read:
+            # the screen this step reports is the one the pattern matched.
+            return StepResult(
+                display, True, _format_match(match), capture.screen, capture.attributed
+            )
+
         # Search screen and raw_output independently — concatenating
         # with '\n' creates synthetic boundaries that never existed
         # in the terminal.
         while True:
             # Poll for new terminal data (same cadence as wait_for_text)
             session.read_available(0.05)
-            screen_text = getattr(session, "screen", "") or ""
-            raw_text = getattr(session, "raw_output", "") or ""
-
-            m = _search(screen_text) or _search(raw_text)
-            if m:
-                return StepResult(display, True, _format_match(m), screen_text)
+            found = _matched(capture_screen(session))
+            if found is not None:
+                return found
 
             if time.monotonic() >= deadline:
                 break
 
             if hasattr(session, "is_alive") and not session.is_alive():
                 session.read_available(0)
-                screen_text = getattr(session, "screen", "") or ""
-                raw_text = getattr(session, "raw_output", "") or ""
-                final = _search(screen_text) or _search(raw_text)
-                if final:
-                    return StepResult(display, True, _format_match(final), screen_text)
+                found = _matched(capture_screen(session))
+                if found is not None:
+                    return found
                 break
 
-        return StepResult(
-            display,
-            False,
-            f"timed out waiting for regex {pattern_str!r} after {timeout}s",
-            getattr(session, "screen", ""),
+        return step_result(
+            display, False, f"timed out waiting for regex {pattern_str!r} after {timeout}s", session
         )

--- a/python/termproof/cast_video.py
+++ b/python/termproof/cast_video.py
@@ -7,8 +7,10 @@ with ``ffmpeg``. A frame of the video and the *final* screenshot of the same
 moment are then the same image, which matters when a reviewer is comparing them.
 
 That correspondence does not extend to the per-step screenshots under
-``steps/``: those are rendered from ``StepResult.screen``, which is already
-flattened to plain text, so they are monochrome. See ``docs/evidence-quality.md``.
+``steps/``. Those are attributed too now, when the session reported a grid, but
+the grid is read from the live session at the moment of the step rather than
+replayed from the cast — so a step image and a frame of the same moment are not
+guaranteed to be the same bytes. See ``docs/evidence-quality.md``.
 
 The cost is one rasterizer call per *distinct* frame, so this is slower than
 ``agg``. It buys consistency and needs no Rust toolchain or bundled binary. A

--- a/python/termproof/evidence.py
+++ b/python/termproof/evidence.py
@@ -170,7 +170,15 @@ def _render_step_screens(
         # Two steps then share an image exactly when the image would be
         # identical — a colour-only change is a change, which comparing
         # `step.screen` as a string cannot express.
-        screen = attributed_screen_from_ansi_text(step.screen, columns=cols, rows=rows)
+        #
+        # `step.screen_attributed` is the grid the session reported at the
+        # moment of the step, and is what makes that distinction reachable: a
+        # grid rebuilt from `step.screen` can only be as colourful as the text,
+        # which for a flattened screen is not at all. Sessions that report no
+        # grid still land on the fallback, and still get their screenshot.
+        screen = step.screen_attributed or attributed_screen_from_ansi_text(
+            step.screen, columns=cols, rows=rows
+        )
         fingerprint = screen.render_fingerprint()
         unchanged = dedup and fingerprint == previous_fingerprint
         if unchanged:

--- a/python/termproof/models.py
+++ b/python/termproof/models.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
+from .attributed import AttributedScreen
+
 RECIPE_VERSION = 1
 
 
@@ -40,10 +42,38 @@ class Recipe:
 
 @dataclass(frozen=True)
 class StepResult:
+    """A step's verdict and the screen it left behind.
+
+    ``screen`` is the flattened text. It is what assertions match against, what
+    ``steps/NN-name.txt`` holds, and the only form of the screen that
+    ``to_dict`` carries.
+
+    ``screen_attributed`` is that same screen as a cell grid, supplied by
+    sessions that have one to give. It is what the per-step screenshot is
+    rendered from when it is present, which is what puts colour in the image and
+    what makes a colour-only change between two steps count as a change for
+    screenshot dedup.
+
+    Optional in both directions, deliberately:
+
+    - It defaults to ``None`` and is the last field, so every existing
+      construction — ``StepResult(name, passed, detail, screen)``, positional or
+      keyword — is unaffected. A ``StepAction`` in a plugin that never sets it
+      keeps working and keeps producing monochrome step screenshots.
+    - ``to_dict`` does not emit it, so ``result.json`` keeps the shape the Rust
+      implementation shares and the run cache reads. A grid per step would be
+      orders of magnitude larger than the rest of the file, and nothing
+      downstream of the JSON re-renders a screenshot: by the time a result is
+      serialised its images are already on disk. A ``StepResult`` rebuilt by
+      ``from_dict`` therefore has no grid, which is the honest answer rather
+      than a lossy one.
+    """
+
     name: str
     passed: bool
     detail: str
     screen: str
+    screen_attributed: AttributedScreen | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/python/termproof/models.py
+++ b/python/termproof/models.py
@@ -67,13 +67,22 @@ class StepResult:
       serialised its images are already on disk. A ``StepResult`` rebuilt by
       ``from_dict`` therefore has no grid, which is the honest answer rather
       than a lossy one.
+    - It is ``compare=False``, so equality tracks the serialised shape rather
+      than diverging from it. Comparing a live result against
+      ``RunResult.from_dict(result.to_dict())`` is an ordinary thing for a test
+      to do, here and downstream; with the grid in ``__eq__`` that comparison
+      would start returning ``False`` for a reason nothing in the JSON explains.
+      Two steps with the same verdict, detail and screen text are the same
+      result; the grid is evidence the result carries, not part of its identity.
+      Excluding it also keeps ``__hash__`` off the grid, which matters because
+      hashing one means hashing every cell.
     """
 
     name: str
     passed: bool
     detail: str
     screen: str
-    screen_attributed: AttributedScreen | None = None
+    screen_attributed: AttributedScreen | None = field(default=None, compare=False)
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/python/termproof/runner.py
+++ b/python/termproof/runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .agent_driven import AgentDrivenRunner, AgentRunner, CodexCliAgentRunner
+from .builtin_steps import step_result as make_step_result
 from .config import (
     EvidenceConfig,
     VerifierConfig,
@@ -256,7 +257,7 @@ class VerificationRunner:
                 except Exception as exc:
                     action_name = step["action"]
                     name = step.get("name", f"{index}:{action_name}")
-                    step_result = StepResult(name, False, str(exc), session.screen)
+                    step_result = make_step_result(name, False, str(exc), session)
                 steps.append(step_result)
                 if not step_result.passed:
                     break
@@ -293,7 +294,7 @@ class VerificationRunner:
                 except Exception as exc:
                     action_name = step["action"]
                     name = step.get("name", f"{index}:{action_name}")
-                    step_result = StepResult(name, False, str(exc), session.screen)
+                    step_result = make_step_result(name, False, str(exc), session)
                 steps.append(step_result)
                 if not step_result.passed:
                     break

--- a/python/termproof/screen.py
+++ b/python/termproof/screen.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pyte
 
@@ -58,6 +60,55 @@ def screen_text(screen: pyte.Screen) -> str:
 def screen_attributed(screen: pyte.Screen) -> AttributedScreen:
     """Read *screen* as an attributed grid, colour and styles included."""
     return attributed_screen_from_pyte(screen)
+
+
+def grid_text(screen: AttributedScreen) -> str:
+    """A grid's text, normalised the way a session normalises its own.
+
+    Trailing whitespace off each row, then trailing blank rows dropped — the
+    same two steps :func:`screen_text` and ``TmuxSession.screen`` apply, so a
+    text derived from a grid still reads as the string an assertion matched.
+    """
+    lines = screen.text_lines(trim_right=True)
+    while lines and not lines[-1]:
+        lines.pop()
+    return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class ScreenCapture:
+    """One reading of a session's screen, as of one instant.
+
+    ``attributed`` is ``None`` when the session has no grid to report, which is
+    not an error: the text alone is a complete screenshot source, just a
+    monochrome one.
+    """
+
+    screen: str
+    attributed: AttributedScreen | None = None
+
+
+def capture_screen(session: Any) -> ScreenCapture:
+    """Read *session*'s screen once, as text and grid together.
+
+    Text and grid have to describe the same instant. Fetched separately against
+    a live program they need not, and the result is evidence that validates and
+    lies: ``steps/NN.txt`` describing the screen before an action while
+    ``steps/NN.svg`` and the dedup verdict describe the screen after it. The
+    tmux backend makes that concrete — its two readings are two ``capture-pane``
+    invocations, and the pty backend's ``screen`` and grid are two reads of an
+    emulator the child is still feeding.
+
+    So the grid is read first and the text is derived from it. One grid, one
+    text, no window. A session with no ``screen_attributed`` falls back to its
+    ``screen`` string and reports no grid, which is what keeps a third-party
+    session backend working unchanged.
+    """
+    read_grid = getattr(session, "screen_attributed", None)
+    grid = read_grid() if callable(read_grid) else None
+    if grid is None:
+        return ScreenCapture(screen=str(getattr(session, "screen", "") or ""))
+    return ScreenCapture(screen=grid_text(grid), attributed=grid)
 
 
 def render_svg(

--- a/python/termproof/screen.py
+++ b/python/termproof/screen.py
@@ -103,6 +103,23 @@ def capture_screen(session: Any) -> ScreenCapture:
     text, no window. A session with no ``screen_attributed`` falls back to its
     ``screen`` string and reports no grid, which is what keeps a third-party
     session backend working unchanged.
+
+    This is the *only* place in TermProof where a screen's text is derived from
+    a grid rather than taken from the source that produced it, and it is worth
+    knowing what that costs on each backend:
+
+    - **pty.** The grid comes from the same ``pyte.Screen`` :func:`screen_text`
+      flattens, so no parsing is involved and the two cannot disagree. Pinned by
+      ``test_grid_text_reproduces_the_flattening_a_pty_session_does``.
+    - **tmux.** The grid is parsed out of ``capture-pane -e`` while
+      ``TmuxSession.screen`` is what ``capture-pane`` returns already flat.
+      Here the derived text is only as good as
+      :func:`~termproof.attributed.attributed_screen_from_ansi_text`, so a gap
+      in that parser becomes corrupted evidence — which it did: an unhandled
+      OSC-8 hyperlink rendered its URL as visible text in both the ``.txt`` and
+      the screenshot. ``TmuxTextEquivalenceTest`` pins the two readings against
+      each other over every escape family, so a future gap fails a test rather
+      than a screenshot.
     """
     read_grid = getattr(session, "screen_attributed", None)
     grid = read_grid() if callable(read_grid) else None

--- a/python/termproof/session.py
+++ b/python/termproof/session.py
@@ -9,8 +9,9 @@ from pathlib import Path
 import pexpect
 import pyte
 
+from .attributed import AttributedScreen
 from .cast import CastRecorder
-from .screen import screen_text
+from .screen import screen_attributed, screen_text
 
 #: How a session produces its ``.cast`` file.
 #:
@@ -96,6 +97,16 @@ class TerminalSession:
     @property
     def screen(self) -> str:
         return screen_text(self._screen)
+
+    def screen_attributed(self) -> AttributedScreen:
+        """The pyte buffer as a grid, colour and text attributes intact.
+
+        The same emulator state :attr:`screen` flattens, so the two cannot
+        describe different moments. Dim is the one attribute missing: pyte
+        0.8.2's ``Char`` does not model SGR 2, so it is consumed before this can
+        read it. The tmux backend parses the escapes itself and does carry it.
+        """
+        return screen_attributed(self._screen)
 
     def send_text(self, text: str) -> None:
         if self._cast is not None:

--- a/python/tests/test_attributed.py
+++ b/python/tests/test_attributed.py
@@ -93,6 +93,23 @@ class AnsiParsingTest(unittest.TestCase):
         self.assertEqual("X", screen.to_text())
         self.assertEqual("default", screen.rows[0][0].fg)
 
+    def test_a_sequence_cut_before_its_final_byte_emits_nothing(self) -> None:
+        """A capture can end mid-sequence; the parameter bytes are not glyphs.
+
+        `capture-pane -e` is a snapshot of a pane a program is still painting.
+        Reading `\x1b[31` as ESC-then-`[31` put the parameters in the middle of
+        the screenshot, which is exactly the artifact a reader would mistrust.
+        """
+        self.assertEqual("ok", attributed_screen_from_ansi_text("ok\x1b[31").to_text())
+        self.assertEqual("ok", attributed_screen_from_ansi_text("ok\x1b[").to_text())
+        self.assertEqual("ok", attributed_screen_from_ansi_text("ok\x1b").to_text())
+
+    def test_a_complete_sequence_at_the_very_end_of_a_line_still_applies(self) -> None:
+        """The truncation rule must not swallow a sequence that is intact."""
+        screen = attributed_screen_from_ansi_text("\x1b[31mred\x1b[0m")
+        self.assertEqual("red", screen.to_text())
+        self.assertEqual("red", screen.rows[0][0].fg)
+
     def test_a_double_width_glyph_occupies_two_columns(self) -> None:
         screen = attributed_screen_from_ansi_text("你ok")
         cells = screen.rows[0]

--- a/python/tests/test_attributed.py
+++ b/python/tests/test_attributed.py
@@ -147,6 +147,71 @@ class AnsiParsingTest(unittest.TestCase):
         self.assertEqual("X", screen.to_text())
         self.assertEqual("green", screen.rows[0][0].fg)
 
+    def test_an_osc_8_hyperlink_contributes_its_text_and_not_its_url(self) -> None:
+        """The regression that made a step screenshot worse than no change.
+
+        `capture-pane -e` emits OSC-8 hyperlinks. Only CSI was recognised, so
+        the ESC was dropped and the rest rendered as glyphs: `beforeTXTafter`
+        came out as `before]8;;url\\TXT]8;;\\after`, in the screenshot and in
+        the `.txt` beside it.
+        """
+        link = "before\x1b]8;;http://example.invalid\x1b\\TXT\x1b]8;;\x1b\\after"
+        self.assertEqual("beforeTXTafter", attributed_screen_from_ansi_text(link).to_text())
+
+    def test_every_escape_family_is_consumed_rather_than_rendered(self) -> None:
+        """One row per family, because each has a different shape of terminator.
+
+        Nothing here is visible on a terminal, so nothing here may reach a cell.
+        """
+        families = {
+            "OSC, ST terminated": "\x1b]0;title\x1b\\",
+            "OSC, BEL terminated": "\x1b]0;title\x07",
+            "OSC with embedded semicolons": "\x1b]8;id=x;http://a.invalid\x07",
+            "DCS": "\x1bP1$r0m\x1b\\",
+            "SOS": "\x1bXsos\x1b\\",
+            "PM": "\x1b^pm\x1b\\",
+            "APC": "\x1b_apc\x1b\\",
+            "charset designation G0": "\x1b(B",
+            "charset designation G1": "\x1b)0",
+            "DEC line size": "\x1b#8",
+            "save cursor": "\x1b7",
+            "restore cursor": "\x1b8",
+            "keypad mode": "\x1b=",
+            "reset": "\x1bc",
+            "index": "\x1bD",
+            "ESC with an intermediate": "\x1b F",
+            "CSI": "\x1b[1;2H",
+            "CSI private": "\x1b[?25l",
+        }
+        for name, payload in families.items():
+            with self.subTest(family=name):
+                text = attributed_screen_from_ansi_text(f"before{payload}after").to_text()
+                self.assertEqual("beforeafter", text)
+
+    def test_a_single_shift_leaves_the_character_it_shifts(self) -> None:
+        """SS2/SS3 are the one family whose next character is displayed."""
+        for introducer in ("N", "O"):
+            with self.subTest(introducer=introducer):
+                text = attributed_screen_from_ansi_text(f"before\x1b{introducer}Xafter").to_text()
+                self.assertEqual("beforeXafter", text)
+
+    def test_a_string_sequence_cut_before_its_terminator_emits_nothing(self) -> None:
+        """A capture can end mid-OSC just as it can end mid-CSI."""
+        for payload in ("ok\x1b]8;;http://a.invalid", "ok\x1bP1$r", "ok\x1b]", "ok\x1b_"):
+            with self.subTest(payload=payload):
+                self.assertEqual("ok", attributed_screen_from_ansi_text(payload).to_text())
+
+    def test_a_fresh_escape_abandons_a_string_sequence_too(self) -> None:
+        """`ESC` that is not `ESC \\` ends the string and starts a new sequence."""
+        screen = attributed_screen_from_ansi_text("\x1b]0;title\x1b[31mred")
+        self.assertEqual("red", screen.to_text())
+        self.assertEqual("red", screen.rows[0][0].fg)
+
+    def test_a_string_sequence_does_not_disturb_the_attributes_around_it(self) -> None:
+        screen = attributed_screen_from_ansi_text("\x1b[31ma\x1b]0;t\x07b")
+        self.assertEqual("ab", screen.to_text())
+        self.assertEqual(["red", "red"], [cell.fg for cell in screen.rows[0][:2]])
+
     def test_the_repr_is_readable_rather_than_a_cell_dump(self) -> None:
         """A grid now hangs off every `StepResult`, so its repr lands in failures.
 

--- a/python/tests/test_attributed.py
+++ b/python/tests/test_attributed.py
@@ -110,6 +110,56 @@ class AnsiParsingTest(unittest.TestCase):
         self.assertEqual("red", screen.to_text())
         self.assertEqual("red", screen.rows[0][0].fg)
 
+    def test_a_final_byte_that_is_not_a_letter_still_ends_the_sequence(self) -> None:
+        """Scanning for `isalpha()` ended a CSI one character too late.
+
+        ECMA-48 puts the CSI final byte at 0x40-0x7E, which is wider than the
+        letters. Stopping only on a letter meant `\x1b[1~` ran on to the `a` of
+        the following word and consumed it: `before\x1b[1~after` rendered as
+        `beforefter`. Silent text corruption in a screenshot.
+        """
+        for payload in ("\x1b[1~", "\x1b[5@", "\x1b[2^", "\x1b[H", "\x1b[?25l", "\x1b[1;2H"):
+            with self.subTest(payload=payload):
+                text = attributed_screen_from_ansi_text(f"before{payload}after").to_text()
+                self.assertEqual("beforeafter", text)
+
+    def test_every_byte_in_the_csi_final_range_terminates(self) -> None:
+        """The whole range, so the rule is the rule rather than the examples."""
+        for code in range(0x40, 0x7F):
+            final = chr(code)
+            with self.subTest(final=final):
+                text = attributed_screen_from_ansi_text(f"a\x1b[1{final}b").to_text()
+                self.assertEqual("ab", text)
+
+    def test_a_parameter_byte_does_not_terminate(self) -> None:
+        """0x30-0x3F are parameters; ending there would cut a sequence short."""
+        screen = attributed_screen_from_ansi_text("\x1b[38;5;196mX")
+        self.assertEqual("X", screen.to_text())
+        self.assertEqual("ff0000", screen.rows[0][0].fg)
+
+    def test_a_fresh_escape_abandons_the_sequence_in_progress(self) -> None:
+        """`[` is inside the final-byte range, so an aborted CSI needs handling.
+
+        Without this, `\x1b[31\x1b[32mX` would end its first sequence on the
+        second `[` and emit `32mX` as text.
+        """
+        screen = attributed_screen_from_ansi_text("\x1b[31\x1b[32mX")
+        self.assertEqual("X", screen.to_text())
+        self.assertEqual("green", screen.rows[0][0].fg)
+
+    def test_the_repr_is_readable_rather_than_a_cell_dump(self) -> None:
+        """A grid now hangs off every `StepResult`, so its repr lands in failures.
+
+        The generated dataclass repr of a 100x32 grid is around half a megabyte.
+        """
+        screen = attributed_screen_from_ansi_text(
+            "\r\n".join("filler" for _ in range(32)), columns=100, rows=32
+        )
+        text = repr(screen)
+        self.assertLess(len(text), 200)
+        self.assertIn("32x", text)
+        self.assertIn("filler", text)
+
     def test_a_double_width_glyph_occupies_two_columns(self) -> None:
         screen = attributed_screen_from_ansi_text("你ok")
         cells = screen.rows[0]

--- a/python/tests/test_evidence_config.py
+++ b/python/tests/test_evidence_config.py
@@ -45,10 +45,19 @@ class CorpusByteIdentityTest(unittest.TestCase):
     regenerated corpus, which puts the new bytes in the diff where a reviewer
     can see them.
 
-    Each pair is rendered through the same path ``evidence.render_artifacts``
-    uses for that artifact -- ``final.svg`` from the attributed replay of the
-    cast, step screenshots from their recorded screen text. Pinning a path the
-    pipeline does not use would gate nothing.
+    Each pair is rendered from what the recording actually holds: ``final.svg``
+    from the attributed replay of the cast, step screenshots from their recorded
+    screen text. That is still the shipped path for the corpus, because every
+    entry in it was recorded before ``StepResult`` carried a grid and its
+    ``steps/*.txt`` are all the colour those steps have.
+
+    A live run no longer works that way -- a step screenshot is rendered from
+    ``StepResult.screen_attributed`` when the session supplied one. Nothing on
+    disk carries that grid, so a corpus regenerated from a colour-emitting
+    recipe would produce step images this gate cannot reproduce from the text
+    beside them. Recording the grid alongside the text is the follow-up that
+    would close it; until then, regenerating the corpus means regenerating
+    monochrome step entries or extending this gate at the same time.
     """
 
     def _rendered_pairs(self) -> list[tuple[AttributedScreen, int, int, Path]]:
@@ -447,14 +456,12 @@ class StepScreenshotDedupTest(unittest.TestCase):
         Comparing `step.screen` as a string cannot see this, which is why dedup
         fingerprints the grid the screenshot is rendered from.
 
-        Coverage of `_render_step_screens` as a helper, NOT of the shipped
-        pipeline. The SGR escapes below are injected by hand; `StepResult.screen`
-        is `session.screen`, which is pyte's already-flattened `display` and
-        never contains an escape. So this branch of the fingerprint cannot fire
-        on a real run today. It is worth keeping because it pins the behaviour
-        the moment `StepResult` starts carrying a grid --- see
-        `test_a_real_step_screen_carries_no_escapes` below, which is what pins
-        the present-day reality.
+        Coverage of `_render_step_screens` as a helper: the SGR escapes below are
+        injected into `StepResult.screen` by hand, and a screen text produced by
+        a session never contains one. The shipped route to the same behaviour is
+        `StepResult.screen_attributed`, which the session fills in and which the
+        renderer prefers over re-parsing the text --- pinned by
+        `StepScreenshotDedupTest` in `tests/test_step_attributed_screens.py`.
         """
         step_dir = self._dedup_step_dir(
             [
@@ -477,16 +484,17 @@ class StepScreenshotDedupTest(unittest.TestCase):
         )
         self.assertEqual(1, len(list(step_dir.glob("*.svg"))))
 
-    def test_a_real_step_screen_carries_no_escapes(self) -> None:
-        """The present-day limit, pinned so the two tests above cannot mislead.
+    def test_a_step_screen_text_alone_still_renders_monochrome(self) -> None:
+        """Why the grid had to be carried, rather than recovered from the text.
 
-        A step screenshot is rendered from `StepResult.screen`, which the runner
-        fills from `session.screen` -> `screen_text` -> pyte's `display`. That is
-        already flattened, so no colour reaches a step image however colourful
-        the session was. `final.svg` is unaffected: it renders from the
-        attributed replay of the cast.
+        `StepResult.screen` is the flattened screen — `screen_text` over pyte's
+        `display` — and it is what a session with no grid to report leaves
+        behind. Re-parsing it can only ever produce the monochrome grid below,
+        which is the whole reason `screen_attributed` exists rather than the
+        renderer being asked to try harder.
 
-        When `StepResult` grows a grid, this test is the one that should fail.
+        This is also the guarantee for a session backend that cannot supply a
+        grid: it keeps its screenshot, exactly as rendered here.
         """
         import pyte
 

--- a/python/tests/test_step_attributed_screens.py
+++ b/python/tests/test_step_attributed_screens.py
@@ -1,0 +1,617 @@
+"""Per-step screenshots rendered from the grid the session reported.
+
+`final.svg` has been rendered from an attributed grid for some time; the
+per-step images had not, because `StepResult` carried only flattened text and a
+grid rebuilt from flattened text is monochrome by construction. These tests
+cover the field that closes that — `StepResult.screen_attributed` — from three
+directions:
+
+- it is optional, and a session that cannot report a grid keeps working and
+  keeps getting its screenshots;
+- when it is present the colour reaches the image, and reaches the dedup
+  fingerprint, which is where the colour-awareness dedup already had was inert;
+- it is affordable, because the grid builders share one object between equal
+  cells.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import shutil
+import sys
+import tempfile
+import unittest
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+import pyte
+
+from termproof import evidence
+from termproof.attributed import (
+    AttributedCell,
+    AttributedScreen,
+    attributed_screen_from_ansi_text,
+    attributed_screen_from_pyte,
+)
+from termproof.builtin_renderers import PngRenderer, SvgRenderer
+from termproof.builtin_steps import Press, WaitForRegex, step_result
+from termproof.config import EvidenceConfig, SvgRenderConfig
+from termproof.models import StepResult
+from termproof.screen import capture_screen, grid_text, screen_text
+
+_FILL = re.compile(r'fill="(#[0-9a-fA-F]{6})"')
+_DEFAULT_FILLS = {SvgRenderConfig().fg.lower(), SvgRenderConfig().bg.lower()}
+
+
+def _fills(path: Path) -> set[str]:
+    return {fill.lower() for fill in _FILL.findall(path.read_text(encoding="utf-8"))}
+
+
+def _has_colour(path: Path) -> bool:
+    return bool(_fills(path) - _DEFAULT_FILLS)
+
+
+def _grid(text: str, fg: str = "default") -> AttributedScreen:
+    """A one-row grid of *text* in *fg*, built without going through any parser."""
+    return AttributedScreen(rows=(tuple(AttributedCell(text=ch, fg=fg) for ch in text),))
+
+
+class _GridlessSession:
+    """A session backend that has no attributes to report.
+
+    Third-party backends written against the existing surface look exactly like
+    this: a `screen` string and nothing else. Nothing here may break.
+    """
+
+    def __init__(self, screen: str = "plain screen") -> None:
+        self.screen = screen
+        self.raw_output = screen
+
+    def press(self, key: str) -> None:
+        pass
+
+    def read_available(self, timeout: float) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return False
+
+
+class _GridSession(_GridlessSession):
+    """A session that can report a grid, as the built-in backends do."""
+
+    def __init__(self, text: str = "status", fg: str = "green") -> None:
+        super().__init__(text)
+        self._grid = _grid(text, fg)
+
+    def screen_attributed(self) -> AttributedScreen:
+        return self._grid
+
+
+class StepResultCompatibilityTest(unittest.TestCase):
+    """`StepResult` is published API; the new field must cost existing callers nothing."""
+
+    def test_the_four_argument_construction_still_works(self) -> None:
+        step = StepResult("name", True, "detail", "screen")
+        self.assertIsNone(step.screen_attributed)
+
+    def test_the_grid_is_the_last_field_so_positional_callers_are_unmoved(self) -> None:
+        names = [field.name for field in fields(StepResult)]
+        self.assertEqual(["name", "passed", "detail", "screen", "screen_attributed"], names)
+
+    def test_the_serialised_shape_is_unchanged(self) -> None:
+        """`result.json` is shared with the Rust implementation and with the run cache.
+
+        A grid per step would dwarf the rest of the file and nothing downstream
+        of the JSON re-renders an image, so the field is deliberately absent.
+        """
+        step = StepResult("name", True, "detail", "screen", _grid("screen", "red"))
+        self.assertEqual(
+            {"name": "name", "passed": True, "detail": "detail", "screen": "screen"},
+            step.to_dict(),
+        )
+        json.dumps(step.to_dict())
+
+    def test_a_round_trip_through_the_dict_drops_the_grid_rather_than_faking_one(self) -> None:
+        step = StepResult("name", True, "detail", "screen", _grid("screen", "red"))
+        restored = StepResult.from_dict(step.to_dict())
+        self.assertIsNone(restored.screen_attributed)
+        self.assertEqual(step.screen, restored.screen)
+
+
+class CaptureScreenTest(unittest.TestCase):
+    def test_a_session_with_no_grid_reports_none_and_keeps_its_text(self) -> None:
+        capture = capture_screen(_GridlessSession("hello"))
+        self.assertEqual("hello", capture.screen)
+        self.assertIsNone(capture.attributed)
+
+    def test_a_session_with_a_grid_reports_both_from_one_read(self) -> None:
+        capture = capture_screen(_GridSession("status", fg="green"))
+        self.assertEqual("status", capture.screen)
+        assert capture.attributed is not None
+        self.assertEqual("green", capture.attributed.rows[0][0].fg)
+
+    def test_the_text_comes_from_the_grid_so_the_two_cannot_disagree(self) -> None:
+        """The `.txt` beside a step image must describe the same screen it does.
+
+        A session that reads text and grid separately can hand back one of each
+        from different instants — the tmux backend's two readings are two
+        `capture-pane` runs. Deriving the text from the grid removes the window
+        rather than narrowing it.
+        """
+
+        class Drifting(_GridlessSession):
+            def __init__(self) -> None:
+                super().__init__("stale text nobody should see")
+
+            def screen_attributed(self) -> AttributedScreen:
+                return _grid("live text")
+
+        self.assertEqual("live text", capture_screen(Drifting()).screen)
+
+    def test_grid_text_reproduces_the_flattening_a_pty_session_does(self) -> None:
+        """`step.screen` must not shift meaning now that it comes from the grid.
+
+        Assertions match against it and `steps/NN.txt` is written from it, so
+        the derived text has to be the same string `screen_text` produced.
+        """
+        cases = (
+            "\x1b[31mred\x1b[0m \x1b[1mbold\x1b[0m",
+            "hello\r\nworld\r\n",
+            "",
+            "   trailing spaces   \r\n\r\n\r\n",
+            "日本語テキスト wide\r\nmixed ascii\r\n",
+            "\x1b[2J\x1b[H\x1b[48;5;33mbg\x1b[0m",
+            "a" * 250,
+            "\x1b[38;2;12;34;56mtruecolour\x1b[0m tail",
+        )
+        for cols, rows in ((100, 30), (80, 24), (20, 3)):
+            for feed in cases:
+                screen = pyte.Screen(cols, rows)
+                pyte.Stream(screen).feed(feed)
+                with self.subTest(size=(cols, rows), feed=feed[:20]):
+                    self.assertEqual(
+                        screen_text(screen),
+                        grid_text(attributed_screen_from_pyte(screen)),
+                    )
+
+
+class StepActionCaptureTest(unittest.TestCase):
+    def test_a_built_in_step_carries_the_grid_when_the_session_has_one(self) -> None:
+        result = Press().execute(_GridSession("status", fg="red"), {"key": "enter"}, 1)
+        assert result.screen_attributed is not None
+        self.assertEqual("red", result.screen_attributed.rows[0][0].fg)
+
+    def test_a_built_in_step_against_a_gridless_session_still_produces_a_result(self) -> None:
+        result = Press().execute(_GridlessSession("plain screen"), {"key": "enter"}, 1)
+        self.assertTrue(result.passed)
+        self.assertEqual("plain screen", result.screen)
+        self.assertIsNone(result.screen_attributed)
+
+    def test_wait_for_regex_reports_the_screen_it_matched(self) -> None:
+        """Not a fresh read afterwards: the image must show what the match saw."""
+        session = _GridSession("READY", fg="green")
+        result = WaitForRegex().execute(session, {"pattern": "READY"}, 1)
+        self.assertTrue(result.passed)
+        self.assertEqual("READY", result.screen)
+        assert result.screen_attributed is not None
+        self.assertEqual("green", result.screen_attributed.rows[0][0].fg)
+
+    def test_wait_for_regex_validation_failures_survive_a_gridless_session(self) -> None:
+        result = WaitForRegex().execute(_GridlessSession(), {"pattern": 42}, 1)
+        self.assertFalse(result.passed)
+        self.assertIn("must be a string", result.detail)
+        self.assertIsNone(result.screen_attributed)
+
+    def test_the_helper_is_exported_for_third_party_step_actions(self) -> None:
+        result = step_result("custom", True, "did a thing", _GridSession("x", fg="blue"))
+        assert result.screen_attributed is not None
+        self.assertEqual("blue", result.screen_attributed.rows[0][0].fg)
+
+
+class StepScreenshotColourTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.run_dir = Path(self._tmp.name)
+
+    def _render(self, steps: list[StepResult], config: EvidenceConfig | None = None) -> Path:
+        evidence._render_step_screens(
+            self.run_dir, steps, 80, 24, SvgRenderer(), "svg", config or EvidenceConfig()
+        )
+        return self.run_dir / "steps"
+
+    def test_the_grid_on_the_step_reaches_the_image(self) -> None:
+        step_dir = self._render([StepResult("coloured", True, "", "status", _grid("status", "red"))])
+        written = next(iter(step_dir.glob("*.svg")))
+        self.assertIn("#ff7b72", _fills(written))
+        self.assertTrue(_has_colour(written))
+
+    def test_a_step_with_no_grid_still_gets_a_monochrome_screenshot(self) -> None:
+        """The path that has always worked must keep working, unchanged."""
+        step_dir = self._render([StepResult("plain", True, "", "status")])
+        written = next(iter(step_dir.glob("*.svg")))
+        self.assertFalse(_has_colour(written))
+        self.assertEqual("status\n", (step_dir / "01-plain.txt").read_text(encoding="utf-8"))
+
+    def test_a_run_mixing_both_renders_every_step(self) -> None:
+        step_dir = self._render(
+            [
+                StepResult("with-grid", True, "", "status", _grid("status", "green")),
+                StepResult("without-grid", True, "", "status"),
+            ]
+        )
+        self.assertEqual(2, len(list(step_dir.glob("*.svg"))))
+        self.assertTrue(_has_colour(step_dir / "01-with-grid.svg"))
+        self.assertFalse(_has_colour(step_dir / "02-without-grid.svg"))
+
+    def test_the_png_renderer_stays_monochrome_because_it_takes_no_grid(self) -> None:
+        """An honest limit, pinned so it is not claimed away.
+
+        `PngRenderer` implements only the text-only protocol, so a step grid
+        cannot reach it. Colour in step screenshots is an SVG-renderer property.
+        """
+        self.assertFalse(hasattr(PngRenderer(), "render_attributed"))
+        evidence._render_step_screens(
+            self.run_dir,
+            [StepResult("coloured", True, "", "status", _grid("status", "red"))],
+            80,
+            24,
+            PngRenderer(),
+            "png",
+            EvidenceConfig(),
+        )
+        self.assertTrue((self.run_dir / "steps" / "01-coloured.png").exists())
+
+
+class StepScreenshotDedupTest(unittest.TestCase):
+    """The second-order effect: dedup's colour-awareness was inert for steps.
+
+    `_render_step_screens` has always fingerprinted the grid rather than the
+    text, so that a colour-only change counts as a change. It could not fire,
+    because the grid it fingerprinted was rebuilt from `StepResult.screen` —
+    already flattened, so a colour-only change was invisible to it. The first
+    two tests are the before and after of exactly that.
+    """
+
+    COLOURS = ("green", "red")
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.run_dir = Path(self._tmp.name)
+
+    def _dedup(self, steps: list[StepResult]) -> Path:
+        evidence._render_step_screens(
+            self.run_dir,
+            steps,
+            80,
+            24,
+            SvgRenderer(),
+            "svg",
+            EvidenceConfig(dedup_step_screenshots=True),
+        )
+        return self.run_dir / "steps"
+
+    def test_a_colour_only_change_between_two_steps_is_now_detected(self) -> None:
+        step_dir = self._dedup(
+            [
+                StepResult("idle", True, "", "status", _grid("status", "green")),
+                StepResult("failed", True, "", "status", _grid("status", "red")),
+            ]
+        )
+        written = sorted(path.name for path in step_dir.glob("*.svg"))
+        self.assertEqual(["01-idle.svg", "02-failed.svg"], written)
+        self.assertIn("#7ee787", _fills(step_dir / "01-idle.svg"))
+        self.assertIn("#ff7b72", _fills(step_dir / "02-failed.svg"))
+        manifest = json.loads(
+            (step_dir / evidence.STEPS_MANIFEST_NAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual([False, False], [entry["unchanged_from_previous"] for entry in manifest])
+
+    def test_the_same_two_steps_without_grids_are_still_collapsed(self) -> None:
+        """The defect, kept as a control.
+
+        Identical text and no grid is genuinely one image: with nothing but the
+        text to go on there is no difference to see. This is what every step
+        looked like before the grid was carried, and it is what a session that
+        cannot report one still looks like.
+        """
+        step_dir = self._dedup(
+            [
+                StepResult("idle", True, "", "status"),
+                StepResult("failed", True, "", "status"),
+            ]
+        )
+        self.assertEqual(["01-idle.svg"], sorted(p.name for p in step_dir.glob("*.svg")))
+        manifest = json.loads(
+            (step_dir / evidence.STEPS_MANIFEST_NAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual([False, True], [entry["unchanged_from_previous"] for entry in manifest])
+        self.assertEqual(2, len(list(step_dir.glob("*.txt"))))
+
+    def test_two_identical_grids_still_dedup(self) -> None:
+        step_dir = self._dedup(
+            [
+                StepResult("first", True, "", "status", _grid("status", "red")),
+                StepResult("second", True, "", "status", _grid("status", "red")),
+            ]
+        )
+        self.assertEqual(1, len(list(step_dir.glob("*.svg"))))
+
+    def test_a_grid_and_a_gridless_step_with_the_same_text_are_not_confused(self) -> None:
+        """A missing grid is not the same screen as a coloured one."""
+        step_dir = self._dedup(
+            [
+                StepResult("coloured", True, "", "status", _grid("status", "red")),
+                StepResult("plain", True, "", "status"),
+            ]
+        )
+        self.assertEqual(2, len(list(step_dir.glob("*.svg"))))
+
+
+class AnsiCaptureRobustnessTest(unittest.TestCase):
+    """`capture-pane -e` returns escape sequences, and they can arrive broken.
+
+    A capture is a snapshot of a pane a program is still painting, so a
+    sequence can be cut anywhere. None of these may raise, and none may put a
+    raw control byte into a cell — a stray byte makes the SVG invalid XML,
+    which a rasterizer reports by writing a zero-byte image rather than by
+    failing.
+    """
+
+    MALFORMED = (
+        "\x1b",
+        "\x1b[",
+        "\x1b[3",
+        "\x1b[31",
+        "\x1b[31;",
+        "\x1b[31;4",
+        "\x1b[38;5",
+        "\x1b[38;2;1;2",
+        "\x1b[38;2;999;-1;2mX",
+        "\x1b[999mX",
+        "\x1b[;;;mX",
+        "\x1b[abcmX",
+        "\x1b]0;title\x07X",
+        "\x1b[31mred\x1b",
+        "\x1b[31mred\x1b[",
+        "text\x1b[0",
+        "\x1b[0m\x1b[0m\x1b[0m",
+        "\x1b[1;31;4;7;9mstyled\x1b[0m tail",
+    )
+
+    def test_no_malformed_sequence_raises_or_leaks_a_control_byte(self) -> None:
+        for payload in self.MALFORMED:
+            with self.subTest(payload=payload):
+                screen = attributed_screen_from_ansi_text(payload, columns=40, rows=4)
+                text = screen.to_text()
+                self.assertNotIn("\x1b", text)
+                for ch in text:
+                    self.assertFalse(ch < " " and ch != "\n", f"control byte {ch!r} reached a cell")
+
+    def test_a_malformed_capture_still_renders_well_formed_markup(self) -> None:
+        from xml.etree import ElementTree
+
+        from termproof.attributed import screen_svg
+
+        for payload in self.MALFORMED:
+            with self.subTest(payload=payload):
+                markup = screen_svg(attributed_screen_from_ansi_text(payload, columns=40, rows=4))
+                ElementTree.fromstring(markup)
+
+    def test_a_partial_sequence_does_not_swallow_the_text_after_it(self) -> None:
+        screen = attributed_screen_from_ansi_text("\x1b[3visible", columns=40, rows=2)
+        self.assertIn("isible", screen.to_text())
+
+    def test_an_unterminated_sequence_at_end_of_line_ends_the_line(self) -> None:
+        screen = attributed_screen_from_ansi_text("ok\x1b[31", columns=40, rows=2)
+        self.assertEqual("ok", screen.to_text())
+
+    def test_a_style_set_on_one_row_carries_to_the_next_as_a_terminal_would(self) -> None:
+        screen = attributed_screen_from_ansi_text("\x1b[31mred\nstill red", columns=40, rows=3)
+        self.assertEqual("red", screen.rows[1][0].fg)
+
+
+class StepScreenMemoryTest(unittest.TestCase):
+    """A grid per step for a whole run has to be affordable.
+
+    Measured on this suite's machine, a 100x32 grid built without sharing costs
+    about 750 KiB, which over a hundred-step run is tens of megabytes retained
+    for the length of the run. `_CellPool` shares one object between cells that
+    compare equal, which a terminal screen is mostly made of, and takes the same
+    grid to roughly 48 KiB.
+
+    The assertions are ratios and orders of magnitude rather than byte counts:
+    the point is that the cost is bounded by the number of *distinct* cells, not
+    by the number of cells.
+    """
+
+    def _grid_bytes(self, screen: AttributedScreen) -> int:
+        seen: set[int] = set()
+        total = sys.getsizeof(screen) + sys.getsizeof(screen.rows)
+        for row in screen.rows:
+            total += sys.getsizeof(row)
+            for cell in row:
+                if id(cell) in seen:
+                    continue
+                seen.add(id(cell))
+                total += sys.getsizeof(cell) + sys.getsizeof(cell.text)
+        return total
+
+    def _pyte_screen(self, feed: str) -> Any:
+        screen = pyte.Screen(100, 32)
+        pyte.Stream(screen).feed(feed)
+        return screen
+
+    def test_equal_cells_are_one_object(self) -> None:
+        screen = attributed_screen_from_pyte(self._pyte_screen("ordinary output\r\n"))
+        blanks = [cell for row in screen.rows for cell in row if cell.text == " "]
+        self.assertGreater(len(blanks), 1000)
+        self.assertEqual(1, len({id(cell) for cell in blanks}))
+
+    def test_a_typical_screen_costs_far_less_than_one_object_per_cell(self) -> None:
+        feed = "\r\n".join(f"$ ordinary shell output line {index}" for index in range(20))
+        screen = attributed_screen_from_pyte(self._pyte_screen(feed))
+        cells = sum(len(row) for row in screen.rows)
+        self.assertGreater(cells, 3000)
+        # One cell object per cell would be several hundred KiB. The pointers
+        # alone are ~8 bytes each, so this bound is well clear of the floor and
+        # well under the unshared cost.
+        self.assertLess(self._grid_bytes(screen), 120_000)
+
+    def test_the_parsed_path_shares_cells_too(self) -> None:
+        screen = attributed_screen_from_ansi_text(
+            "\r\n".join("\x1b[32mready\x1b[0m" for _ in range(20)), columns=100, rows=32
+        )
+        cells = [cell for row in screen.rows for cell in row]
+        self.assertGreater(len(cells), 80)
+        self.assertLessEqual(len({id(cell) for cell in cells}), 10)
+
+
+@unittest.skipUnless(importlib.util.find_spec("pexpect"), "pexpect is not installed")
+class PtySessionGridTest(unittest.TestCase):
+    """The pty backend can report a grid, and its two readings agree."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.cast = Path(self._tmp.name) / "session.cast"
+
+    def test_a_live_pty_session_reports_colour_and_agrees_with_its_own_text(self) -> None:
+        from termproof.session import TerminalSession
+
+        argv = ["sh", "-c", "printf '\\033[31mred\\033[0m plain\\n'; sleep 0.5"]
+        with TerminalSession(argv, self.cast, None, {}, 80, 24) as session:
+            self.assertTrue(session.wait_for_text("red", 10.0))
+            capture = capture_screen(session)
+            self.assertEqual(session.screen, capture.screen)
+        assert capture.attributed is not None
+        self.assertEqual(["red", "red", "red"], [cell.fg for cell in capture.attributed.rows[0][:3]])
+        self.assertEqual("default", capture.attributed.rows[0][4].fg)
+
+
+#: A TUI whose second screen differs from its first in colour and nothing else.
+#: `\x1b[2J\x1b[H` repaints from the top, so the two screens are the same
+#: characters in the same cells — the case dedup was built to notice and could
+#: not, because what it was handed had already been flattened.
+_COLOUR_ONLY_TUI = """\
+import sys
+
+def paint(colour):
+    sys.stdout.write("\\x1b[2J\\x1b[H")
+    sys.stdout.write("\\x1b[" + colour + "mSTATUS OK\\x1b[0m\\n")
+    sys.stdout.write("READY\\n")
+    sys.stdout.flush()
+
+paint("32")
+sys.stdin.readline()
+paint("31")
+sys.stdin.readline()
+"""
+
+
+@unittest.skipUnless(importlib.util.find_spec("pexpect"), "pexpect is not installed")
+class ColourOnlyChangeEndToEndTest(unittest.TestCase):
+    """The reported second-order effect, through the whole pipeline.
+
+    Dedup fingerprints the rendered grid rather than the screen text so that a
+    colour-only change counts as a change. It could not fire on a real run,
+    because the grid came from `StepResult.screen` and a colour-only change
+    leaves that byte-identical. This drives a real pty session whose two screens
+    differ only in colour and asserts on the manifest the run writes.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.tui = self.root / "colour_only_tui.py"
+        self.tui.write_text(_COLOUR_ONLY_TUI, encoding="utf-8")
+
+    def _recipe(self) -> Any:
+        from termproof.models import CommandSpec, Recipe
+
+        return Recipe(
+            name="colour-only-change",
+            command=CommandSpec(argv=[sys.executable, str(self.tui)], pty=True),
+            cols=40,
+            rows=6,
+            timeout_seconds=30.0,
+            steps=[
+                # Gate on observed output before measuring anything: time to
+                # first pty byte is environment-bound. See AGENTS.md.
+                {"name": "green", "action": "wait_for_text", "text": "READY", "timeout_seconds": 15},
+                {"name": "flip", "action": "send_line", "text": ""},
+                {
+                    "name": "red",
+                    "action": "wait_for_idle",
+                    "stable_seconds": 0.5,
+                    "timeout_seconds": 15,
+                },
+                {"name": "finish", "action": "send_line", "text": ""},
+            ],
+        )
+
+    def test_a_colour_only_change_survives_dedup_on_a_real_run(self) -> None:
+        from dataclasses import replace
+
+        from termproof.config import VerifierConfig
+        from termproof.runner import VerificationRunner
+
+        config = replace(
+            VerifierConfig.builtin(),
+            evidence=EvidenceConfig(dedup_step_screenshots=True),
+        )
+        result = VerificationRunner(config=config).run(self._recipe(), out_dir=self.root / "runs")
+        self.assertTrue(result.passed, result.steps)
+
+        step_dir = Path(result.artifacts["step_screenshots"])
+        texts = {path.read_text(encoding="utf-8") for path in step_dir.glob("*.txt")}
+        self.assertEqual(
+            1, len(texts), "the fixture is meant to change colour and nothing else"
+        )
+
+        manifest = json.loads(
+            (step_dir / evidence.STEPS_MANIFEST_NAME).read_text(encoding="utf-8")
+        )
+        distinct = {entry["screenshot"] for entry in manifest}
+        self.assertEqual(
+            2,
+            len(distinct),
+            f"a colour-only change was collapsed into one image: {manifest}",
+        )
+        fills: set[str] = set()
+        for name in distinct:
+            fills |= _fills(step_dir / name)
+        # The green and the red the fixture paints, resolved by the renderer.
+        self.assertIn("#7ee787", fills)
+        self.assertIn("#ff7b72", fills)
+
+
+@unittest.skipUnless(shutil.which("tmux"), "tmux is not installed")
+class TmuxSessionGridTest(unittest.TestCase):
+    """The tmux backend reports its grid through `capture-pane -e`."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.cast = Path(self._tmp.name) / "session.cast"
+
+    def test_a_step_taken_against_tmux_carries_the_pane_colour(self) -> None:
+        from termproof.tmux_session import TmuxBackend
+
+        argv = ["sh", "-c", "printf '\\033[31mred\\033[0m plain\\n'; sleep 1"]
+        with TmuxBackend().create_session(argv, self.cast, None, {}, 80, 24) as session:
+            self.assertTrue(session.wait_for_text("red", 10.0))
+            result = step_result("captured", True, "", session)
+        assert result.screen_attributed is not None
+        self.assertEqual(["red", "red", "red"], [cell.fg for cell in result.screen_attributed.rows[0][:3]])
+        self.assertTrue(result.screen.startswith("red plain"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_step_attributed_screens.py
+++ b/python/tests/test_step_attributed_screens.py
@@ -121,6 +121,58 @@ class StepResultCompatibilityTest(unittest.TestCase):
         self.assertIsNone(restored.screen_attributed)
         self.assertEqual(step.screen, restored.screen)
 
+    def test_equality_tracks_the_serialised_shape(self) -> None:
+        """A live result equals its own round trip, grid or no grid.
+
+        The field is omitted from `to_dict`, so if it also took part in `__eq__`
+        then `RunResult.from_dict(result.to_dict()) == result` would be `False`
+        for any run that captured a grid — a comparison tests here and
+        downstream make routinely, failing for a reason nothing in the JSON
+        shows. `compare=False` keeps equality on the shape callers can see.
+        """
+        step = StepResult("name", True, "detail", "screen", _grid("screen", "red"))
+        self.assertEqual(step, StepResult.from_dict(step.to_dict()))
+        self.assertEqual(step, StepResult("name", True, "detail", "screen"))
+        # Two grids of different colour are still the same step: same verdict,
+        # same detail, same screen text.
+        self.assertEqual(step, StepResult("name", True, "detail", "screen", _grid("screen", "green")))
+        # The fields that do identify a step still separate them.
+        self.assertNotEqual(step, StepResult("name", False, "detail", "screen"))
+        self.assertNotEqual(step, StepResult("name", True, "detail", "other"))
+
+    def test_a_whole_run_result_equals_its_round_trip(self) -> None:
+        from termproof.models import AssertionResult, RunResult
+
+        result = RunResult(
+            recipe_name="r",
+            passed=True,
+            exit_code=0,
+            duration_seconds=1.0,
+            priority="P2",
+            execution="scripted",
+            renderer="default",
+            score=1.0,
+            steps=[StepResult("s", True, "", "screen", _grid("screen", "red"))],
+            assertions=[AssertionResult("a", True, "")],
+            artifacts={},
+        )
+        self.assertEqual(result, RunResult.from_dict(result.to_dict()))
+
+    def test_a_step_carrying_a_grid_is_still_hashable_and_cheaply_so(self) -> None:
+        """`frozen=True` derives `__hash__` from the compared fields only."""
+        with_grid = StepResult("name", True, "detail", "screen", _grid("screen", "red"))
+        self.assertEqual(hash(StepResult("name", True, "detail", "screen")), hash(with_grid))
+
+    def test_the_repr_stays_readable_when_a_grid_is_attached(self) -> None:
+        """An assertion failure must not print half a megabyte of cells."""
+        import pyte
+
+        screen = pyte.Screen(100, 32)
+        pyte.Stream(screen).feed("hello world")
+        step = StepResult("name", True, "detail", "hello world", attributed_screen_from_pyte(screen))
+        self.assertLess(len(repr(step)), 400)
+        self.assertIn("AttributedScreen(", repr(step))
+
 
 class CaptureScreenTest(unittest.TestCase):
     def test_a_session_with_no_grid_reports_none_and_keeps_its_text(self) -> None:
@@ -382,7 +434,31 @@ class AnsiCaptureRobustnessTest(unittest.TestCase):
         "text\x1b[0",
         "\x1b[0m\x1b[0m\x1b[0m",
         "\x1b[1;31;4;7;9mstyled\x1b[0m tail",
+        # Final bytes outside the letters. `isalpha()` scanning ran past these
+        # and ate the next letter of real text with the escape.
+        "before\x1b[1~after",
+        "before\x1b[5@after",
+        "before\x1b[2^after",
+        "before\x1b[?25lafter",
+        "before\x1b[1;2Hafter",
+        "before\x1b[0`after",
+        "before\x1b[3{after",
+        # A sequence abandoned by a fresh ESC mid-parameters.
+        "\x1b[31\x1b[32mX",
+        "\x1b[38;5\x1b[0mX",
+        # Intermediate bytes, which are also below the final-byte range.
+        "before\x1b[1 qafter",
+        "before\x1b[!pafter",
     )
+
+    def test_no_payload_loses_the_text_around_the_sequence(self) -> None:
+        """Consuming an escape must consume the escape and nothing else."""
+        for payload in self.MALFORMED:
+            if not payload.startswith("before"):
+                continue
+            with self.subTest(payload=payload):
+                text = attributed_screen_from_ansi_text(payload, columns=60, rows=2).to_text()
+                self.assertEqual("beforeafter", text)
 
     def test_no_malformed_sequence_raises_or_leaks_a_control_byte(self) -> None:
         for payload in self.MALFORMED:
@@ -419,15 +495,19 @@ class AnsiCaptureRobustnessTest(unittest.TestCase):
 class StepScreenMemoryTest(unittest.TestCase):
     """A grid per step for a whole run has to be affordable.
 
-    Measured on this suite's machine, a 100x32 grid built without sharing costs
-    about 750 KiB, which over a hundred-step run is tens of megabytes retained
-    for the length of the run. `_CellPool` shares one object between cells that
-    compare equal, which a terminal screen is mostly made of, and takes the same
-    grid to roughly 48 KiB.
+    A grid built without sharing costs about half a megabyte per 100x32 screen,
+    which over a hundred-step run is tens of megabytes retained for as long as
+    the run holds its results. `_CellPool` shares one object between cells that
+    compare equal, which a terminal screen is mostly made of.
 
-    The assertions are ratios and orders of magnitude rather than byte counts:
-    the point is that the cost is bounded by the number of *distinct* cells, not
-    by the number of cells.
+    These assertions are the *property*: the cost is bounded by the number of
+    distinct cells rather than the number of cells. They are deliberately not
+    the byte counts quoted in the changelog, which come from a `tracemalloc`
+    measurement over a real run — a machine-dependent figure has no business
+    failing a test suite. The sizing helper here is a `sys.getsizeof` walk,
+    which reads higher than `tracemalloc` because `getsizeof` on a
+    key-sharing instance dict overstates what was actually allocated; it is
+    fine for an upper bound, which is all it is used for.
     """
 
     def _grid_bytes(self, screen: AttributedScreen) -> int:

--- a/python/tests/test_step_attributed_screens.py
+++ b/python/tests/test_step_attributed_screens.py
@@ -449,12 +449,48 @@ class AnsiCaptureRobustnessTest(unittest.TestCase):
         # Intermediate bytes, which are also below the final-byte range.
         "before\x1b[1 qafter",
         "before\x1b[!pafter",
+        # Non-CSI families. Only CSI was handled, so every one of these had its
+        # ESC dropped and its body rendered as text — the OSC-8 hyperlink case
+        # reached real step evidence through `capture-pane -e`.
+        "before\x1b]8;;http://example.invalid\x1b\\\x1b]8;;\x1b\\after",
+        "before\x1b]0;window title\x07after",
+        "before\x1b]8;id=x;http://example.invalid\x07after",
+        "before\x1bP1$r0m\x1b\\after",
+        "before\x1bXsos\x1b\\after",
+        "before\x1b^pm\x1b\\after",
+        "before\x1b_apc\x1b\\after",
+        "before\x1b(Bafter",
+        "before\x1b)0after",
+        "before\x1b#8after",
+        "before\x1b7after",
+        "before\x1b8after",
+        "before\x1b=after",
+        "before\x1bcafter",
+        "before\x1b Fafter",
+        # String sequences cut before their terminator, and abandoned ones.
+        "before\x1b]8;;http://example.invalid",
+        "before\x1bP1$r",
+        "before\x1b]0;title\x1b[0mafter",
     )
 
-    def test_no_payload_loses_the_text_around_the_sequence(self) -> None:
-        """Consuming an escape must consume the escape and nothing else."""
+    def test_no_string_sequence_leaks_its_body(self) -> None:
+        """An OSC body is a URL or a window title, never screen content."""
         for payload in self.MALFORMED:
-            if not payload.startswith("before"):
+            with self.subTest(payload=payload):
+                text = attributed_screen_from_ansi_text(payload, columns=80, rows=3).to_text()
+                for leak in ("http://", "window title", "id=x", "$r0m", "sos", "apc"):
+                    self.assertNotIn(leak, text)
+
+    def test_no_payload_loses_the_text_around_the_sequence(self) -> None:
+        """Consuming an escape must consume the escape and nothing else.
+
+        Only the payloads that bracket a sequence with text on both sides. The
+        deliberately truncated ones have no trailing text by construction: a
+        sequence whose terminator never arrived swallows the rest of the line,
+        which is the behaviour, not a loss.
+        """
+        for payload in self.MALFORMED:
+            if not (payload.startswith("before") and payload.endswith("after")):
                 continue
             with self.subTest(payload=payload):
                 text = attributed_screen_from_ansi_text(payload, columns=60, rows=2).to_text()
@@ -691,6 +727,76 @@ class TmuxSessionGridTest(unittest.TestCase):
         assert result.screen_attributed is not None
         self.assertEqual(["red", "red", "red"], [cell.fg for cell in result.screen_attributed.rows[0][:3]])
         self.assertTrue(result.screen.startswith("red plain"))
+
+
+@unittest.skipUnless(shutil.which("tmux"), "tmux is not installed")
+class TmuxTextEquivalenceTest(unittest.TestCase):
+    """The grid-derived text must equal what tmux itself calls the screen.
+
+    `capture_screen` derives `StepResult.screen` from the grid so that the text
+    and the image describe one instant. On the pty backend that is free — the
+    grid and `screen_text` read the same `pyte.Screen`. On this one it is a
+    claim about a parser: the grid is parsed out of `capture-pane -e` while
+    `TmuxSession.screen` is `capture-pane` already flattened by tmux.
+
+    That claim was false, and it was a regression rather than a limit. Before
+    the grid was carried, a built-in step returned `session.screen`, which is
+    correct; deriving it from a parser that only understood CSI turned
+    `beforeTXTafter` into `before]8;;url\\TXT]8;;\\after` in both `steps/NN.txt`
+    and the screenshot. Working output became corrupted output.
+
+    So this compares the two readings against each other rather than against a
+    literal, over content covering every escape family tmux can put in a pane.
+    A future gap in the parser fails here instead of appearing in evidence.
+    """
+
+    PAYLOADS = {
+        "osc 8 hyperlink": r"before\033]8;;http://example.invalid\033\\TXT\033]8;;\033\\after",
+        "osc title": r"\033]0;window title\007visible text",
+        "sgr colour and attributes": r"\033[31mred\033[0m \033[1mbold\033[0m \033[4munder\033[0m",
+        "256 and truecolour": r"\033[38;5;196mx\033[38;2;1;2;3my\033[0m tail",
+        "csi cursor moves": r"start\033[1;2H\033[Kmiddle\033[?25lend",
+        "charset and two byte escapes": r"a\033(Bb\0337c\0338d",
+        "wide characters": r"日本語 wide and ascii",
+        "mixed": r"\033[32mok\033[0m \033]8;;http://a.invalid\033\\link\033]8;;\033\\ \033[1mdone\033[0m",
+    }
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_the_derived_text_matches_the_plain_capture(self) -> None:
+        from termproof.tmux_session import TmuxBackend
+
+        for name, payload in self.PAYLOADS.items():
+            with self.subTest(payload=name):
+                cast = Path(self._tmp.name) / f"{name.replace(' ', '-')}.cast"
+                argv = ["sh", "-c", f"printf '{payload}\\nSETTLED\\n'; sleep 2"]
+                with TmuxBackend().create_session(argv, cast, None, {}, 80, 24) as session:
+                    self.assertTrue(session.wait_for_text("SETTLED", 10.0))
+                    plain = session.screen
+                    derived = capture_screen(session).screen
+                self.assertEqual(plain, derived)
+                self.assertNotIn("\x1b", derived)
+
+    def test_a_hyperlink_does_not_put_its_url_on_the_screen(self) -> None:
+        """The reported reproducer, asserted against the literal it should be."""
+        from termproof.tmux_session import TmuxBackend
+
+        cast = Path(self._tmp.name) / "link.cast"
+        argv = [
+            "sh",
+            "-c",
+            r"printf 'before\033]8;;http://example.invalid\033\\TXT\033]8;;\033\\after\n'; sleep 2",
+        ]
+        with TmuxBackend().create_session(argv, cast, None, {}, 80, 24) as session:
+            self.assertTrue(session.wait_for_text("after", 10.0))
+            result = step_result("linked", True, "", session)
+        self.assertEqual("beforeTXTafter", result.screen.splitlines()[0])
+        assert result.screen_attributed is not None
+        self.assertEqual(
+            "beforeTXTafter", result.screen_attributed.text_lines(trim_right=True)[0]
+        )
 
 
 if __name__ == "__main__":

--- a/python/tests/test_wait_for_idle_step.py
+++ b/python/tests/test_wait_for_idle_step.py
@@ -12,6 +12,9 @@ class WaitForIdleStepDetailTest(unittest.TestCase):
     def _failure_detail(self, raw_output: str) -> str:
         session = Mock()
         session.screen = ""
+        # No grid: this fake models a session that cannot report one, so the
+        # step falls back to the screen text exactly as it did before.
+        session.screen_attributed = None
         session.raw_output = raw_output
         session.wait_for_idle.return_value = False
         return WaitForIdle().execute(session, {"stable_seconds": 0.5}, 1).detail
@@ -27,6 +30,7 @@ class WaitForIdleStepDetailTest(unittest.TestCase):
     def test_detail_reports_stable_window_on_success(self) -> None:
         session = Mock()
         session.screen = ""
+        session.screen_attributed = None
         session.raw_output = "hello"
         session.wait_for_idle.return_value = True
         result = WaitForIdle().execute(session, {"stable_seconds": 0.5}, 1)

--- a/python/tests/test_wait_for_regex.py
+++ b/python/tests/test_wait_for_regex.py
@@ -49,6 +49,9 @@ class WaitForRegexStepTest(unittest.TestCase):
         import unittest.mock as mock
         fake_session = mock.Mock()
         fake_session.screen = "some screen"
+        # No grid: this fake models a session that cannot report one, so the
+        # step falls back to the screen text exactly as it did before.
+        fake_session.screen_attributed = None
         fake_session.raw_output = "some output"
         # We want this to raise or produce failed StepResult with clear message about invalid regex
         # spec says "validated regex" so should not silently pass nor crash with raw re.error
@@ -144,6 +147,7 @@ class WaitForRegexStepTest(unittest.TestCase):
         step_action = WaitForRegex()
         fake_session = mock.Mock()
         fake_session.screen = "some screen"
+        fake_session.screen_attributed = None
         fake_session.raw_output = "some output"
         step = {"pattern": r"\d+", "timeout_seconds": 0}
         result = step_action.execute(fake_session, step, 1)
@@ -158,6 +162,7 @@ class WaitForRegexStepTest(unittest.TestCase):
         step_action = WaitForRegex()
         fake_session = mock.Mock()
         fake_session.screen = "screen"
+        fake_session.screen_attributed = None
         step = {"pattern": r"\d+", "timeout_seconds": -1}
         result = step_action.execute(fake_session, step, 1)
         self.assertFalse(result.passed)
@@ -171,6 +176,7 @@ class WaitForRegexStepTest(unittest.TestCase):
         step_action = WaitForRegex()
         fake_session = mock.Mock()
         fake_session.screen = ""
+        fake_session.screen_attributed = None
         fake_session.raw_output = ""
         step = {"pattern": r"\d+", "timeout_seconds": float("nan")}
         result = step_action.execute(fake_session, step, 1)
@@ -185,6 +191,7 @@ class WaitForRegexStepTest(unittest.TestCase):
         step_action = WaitForRegex()
         fake_session = mock.Mock()
         fake_session.screen = ""
+        fake_session.screen_attributed = None
         fake_session.raw_output = ""
         step = {"pattern": r"\d+", "timeout_seconds": float("inf")}
         result = step_action.execute(fake_session, step, 1)
@@ -199,6 +206,7 @@ class WaitForRegexStepTest(unittest.TestCase):
         step_action = WaitForRegex()
         fake_session = mock.Mock()
         fake_session.screen = "screen"
+        fake_session.screen_attributed = None
         for bad_pattern in [42, {"key": "val"}, ["list"], True, None]:
             with self.subTest(pattern=bad_pattern):
                 step = {"pattern": bad_pattern, "timeout_seconds": 1}
@@ -214,6 +222,7 @@ class WaitForRegexStepTest(unittest.TestCase):
         step_action = WaitForRegex()
         fake_session = mock.Mock()
         fake_session.screen = "screen"
+        fake_session.screen_attributed = None
         step = {"pattern": r"\d+", "timeout_seconds": "fast"}
         result = step_action.execute(fake_session, step, 1)
         self.assertFalse(result.passed)


### PR DESCRIPTION
Fixes #175.

`final.svg` and the `attributed_rsvg` video have rendered from an attributed
cell grid for a while. The per-step images under `steps/` did not, because
`StepResult.screen` is a `str` and a grid rebuilt from flattened text is
monochrome by construction. `StepResult` grows an optional
`screen_attributed: AttributedScreen | None`, filled by sessions that can supply
one, and the per-step screenshot renders from it when it is there.

## Evidence from a real run

Same 13 example recipes, `origin/main` against this branch, same machine:

| | step screenshots | in colour | with text attributes |
|---|---|---|---|
| before | 76 | 0 | 0 |
| after | 76 | **9** | **11** |

Final screenshots are unchanged at 3/13 attributed (1 in colour) — that path
already worked and is untouched. The 9 colour images are every step of
`colour-stress`, up to 400 distinct fills each; the 2 extra attributed ones are
`pi-help` and `pi-list`, which gained `font-weight="700"` on a bold heading. The
other 65 step images are **byte-identical** to the baseline, because those
recipes drive genuinely monochrome TUIs.

## The dedup interaction

The report's second-order point holds, and I confirmed it before fixing it:
`_render_step_screens` fingerprints the rendered grid rather than the text
specifically so a colour-only change counts as a change, and that was inert for
step artifacts because the grid was rebuilt from `StepResult.screen`.

`ColourOnlyChangeEndToEndTest` drives a real pty session painting `STATUS OK` in
green, then repainting the same characters in the same cells in red. All four
steps have byte-identical `.txt`. With `dedup_step_screenshots: true`:

```
before (origin/main)          after
01-green  -> 01-green.svg     01-green  -> 01-green.svg    (#7ee787)
02-flip   -> 01-green.svg     02-flip   -> 01-green.svg
03-red    -> 01-green.svg     03-red    -> 03-red.svg      (#ff7b72)
04-finish -> 01-green.svg     04-finish -> 03-red.svg
1 image written               2 images written
```

Five of the new tests fail if the one-line preference in
`evidence._render_step_screens` is reverted, including that one.

## Which sessions can supply a grid, and which cannot

| session | grid | how |
|---|---|---|
| `pexpect`, `pexpect_asciinema`, `docker` | yes | `TerminalSession.screen_attributed()` off the live `pyte.Screen` |
| `tmux` | yes | `TmuxSession.screen_attributed()` via `capture-pane -e` (already existed) |
| agent-driven mode | yes | one `replay_cast_both` of the operator's cast |
| any third-party `SessionBackend` without `screen_attributed()` | **no** | falls back to the flattened text, monochrome, unchanged |

Two further limits, both pinned by tests rather than only documented:

- **The `png` renderer stays monochrome** whatever the grid contains. It
  implements only the text-only protocol, so a grid cannot reach it. Colour in
  step screenshots is an `svg`-renderer property.
- **Dim (SGR 2) reaches the grid on the tmux path but not the pty one**, because
  pyte 0.8.2's `Char` models no dim field. Unchanged by this, but now it differs
  *between* step screenshots depending on backend, so it is written down.

I have not replaced the existing caveat with a broader claim. `AGENTS.md` now
says to write "when the session supplies a grid" rather than "step screenshots
are in colour", and `test_public_claims.py`'s banned phrasings are untouched and
still pass.

## Memory, measured

A grid per step is not free, and unshared it is not cheap:

| | per 100x32 grid | retained across a 75-step run |
|---|---|---|
| one cell object per cell | 752 KiB | 55 MiB |
| sharing equal cells (this PR) | **47.8 KiB** | **3.5 MiB** |

A terminal screen is mostly repetition, and cells are frozen, so `_CellPool`
gives one object to every cell that compares equal within a grid build. That is
a 15.7x reduction, and it makes the cost scale with the number of *distinct*
cells rather than the number of cells. For comparison the step *text* for that
same run retains 60 KiB. Extrapolated to the reporter's 107 steps: about 5 MiB,
against about 79 MiB unshared. The pool is per grid build and is dropped with
it, so nothing accumulates process-wide. `StepScreenMemoryTest` pins the
property (ratios and orders of magnitude, not byte counts).

## One read, not two

Step capture goes through `screen.capture_screen`, which reads the grid first
and derives the step's text from it with the same normalisation
`screen_text`/`TmuxSession.screen` apply. Two separate reads can describe
different instants — the tmux backend's are two `capture-pane` invocations —
which produces a `steps/NN.txt` describing one screen while `steps/NN.svg` and
the dedup verdict describe another. `ScreenSource::capture_screen` on the Rust
side made the same choice for the same reason. A test pins that
`grid_text(from_pyte(s)) == screen_text(s)` across colour, wide characters,
combining marks and trailing blanks, so `step.screen` has not shifted meaning.

## Parser hardening

`capture-pane -e` returns escape sequences, not a grid, and the parser turning
them into one is now load-bearing for step images. A capture is a snapshot of a
pane still being painted, so a sequence can be cut anywhere. A CSI without its
final byte used to emit its parameter bytes as glyphs — a literal `[31` in the
middle of a screenshot. Fixed, plus a robustness suite over 18 malformed and
partial payloads asserting none raises, none leaks a control byte into a cell,
and each still produces well-formed XML.

## Compatibility

- `screen_attributed` is the **last** field and defaults to `None`, so every
  existing `StepResult(name, passed, detail, screen)` is unmoved.
- `to_dict()` does **not** emit it. `result.json` is a shape shared with the
  Rust implementation and read by the run cache, and nothing downstream of the
  JSON re-renders an image, so a grid there would be bulk with no reader. A
  `StepResult` rebuilt by `from_dict` therefore has no grid — the honest answer
  rather than a lossy one, and the run cache does not need one because its
  artifacts were rendered before it was written.
- `termproof.builtin_steps.step_result(name, passed, detail, session)` is
  exported so a third-party `StepAction` can opt in with a one-line change.

## Rust

**Nothing changes there, checked rather than assumed.** Rust's per-step evidence
has carried a grid since `EvidenceCollector` was written
(`CapturedStep.attributed`), `Session::screen_attributed` is already optional
there with a documented `None` default, and its dedup already fingerprints a
real grid. The serialised `StepResult` shape is untouched by this PR, nothing in
Rust reads Python `StepResult` JSON (`parity.rs` reads only recipe/renderer/
passed/score/assertions; `cache.rs` reads its own entries), and the conformance
corpus records only `name`/`passed`/`detail` — `grep -rn "attributed" conformance/`
is empty.

Worth flagging for a maintainer, not fixed here: the two implementations put the
grid in different places. Python hangs it off `StepResult`; Rust deliberately
keeps it out of `RunResult` in a parallel `CapturedStep`/`EvidenceManifest`
model, with the rationale written out at `collector.rs:49-58`. Nothing forces
convergence today.

## Noted for follow-up, not done here

- **The corpus gate cannot pin a colour step image.** `CorpusByteIdentityTest`
  re-renders each step entry from its recorded `.txt`, which is correct for the
  entries checked in — they predate the grid, and the gate passes untouched —
  but nothing on disk carries a step's grid, so a corpus regenerated from a
  colour-emitting recipe would produce images it cannot reproduce. Recording the
  grid beside the text (an SGR-encoded `.ans` next to each `.txt`) is the fix.
  Written down in the gate's own docstring, in `AGENTS.md` and in
  `docs/evidence-quality.md` rather than left as a trap.
- **A step image and a video frame of the same moment are not the same bytes.**
  `final.svg` and the video both replay the cast; a step grid is read from the
  live session, which is the only place that moment exists. The correspondence
  claim in `cast_video.py` now says so.
- **OSC sequences still leak their body as glyphs** in the ANSI parser.
  `capture-pane -e` emits SGR only, so this is not reachable from the tmux path;
  out of scope here.

## Verification

- `ruff check .`, `mypy termproof`, `unittest discover -s tests` — 718 tests, all
  pass; `scripts/run_stdlib_tests.py` (120) and `scripts/check_version.py` too.
- The two `test_wait_for_regex` / `test_wait_for_idle_step` fakes now set
  `screen_attributed = None` explicitly. A bare `Mock()` auto-creates the
  attribute and answers it with a `Mock`; declaring it makes those fakes model
  what they are, a session with no grid, which is also the fallback path this PR
  most needs covered.
