### PR TITLE
api: re-export the dependencies that reach the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,31 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ## [Unreleased]
 
+### Rust — Added
+
+- **`fancy_regex`, `jsonschema` and `vt100` are re-exported at the crate root.**
+  All three reach the public API — `pyregex::compile` returns a
+  `fancy_regex::Regex`, `pyschema::compile` a `jsonschema::Validator`, and
+  `terminal::attributed::from_vt100` takes a `vt100::Screen` — and a
+  third-party type in a signature is only interchangeable with the consumer's
+  own when cargo hands both sides the same copy. Naming
+  `termproof::fancy_regex::Regex` instead of your own makes that true by
+  construction. Purely additive; nothing that compiled before stops.
+  ([#177](https://github.com/md-mt/termproof/issues/177))
+
+### Rust — Docs
+
+- **The crate docs no longer claim `schemars` is the only dependency reaching
+  the public API.** Three others do, and the claim is why that went unnoticed.
+  A new *Dependencies in the public API* section names all four, says why a
+  bound on them is a source-compatibility surface and not just a duplicate
+  count, and records the resolver behaviour behind it: cargo takes the **top**
+  of a requirement's range, so the window of versions a consumer can unify with
+  is one version wide however the range is written — widening moves the window
+  rather than enlarging it. `schemars` stays the one with no escape hatch,
+  because its derives are on the published types rather than in a signature.
+  ([#177](https://github.com/md-mt/termproof/issues/177))
+
 ### Docs
 
 - **The distribution claims now say what 0.3.4 actually shipped.** Both

--- a/rust/crates/termproof/src/lib.rs
+++ b/rust/crates/termproof/src/lib.rs
@@ -52,13 +52,67 @@
 //!   validates against comes from.
 //! - **`schema`** — the [`schema`] module and the `JsonSchema` impls derived on
 //!   [`Recipe`], [`config::VerifierConfig`] and the types they contain. Off,
-//!   the crate does not compile `schemars`. This is the one dependency that
-//!   reaches the public API, so it is the one a consumer cannot deduplicate by
-//!   pinning; turning it off is how a consumer on a different `schemars` major
-//!   stops carrying two.
+//!   the crate does not compile `schemars`. Of the dependencies that reach the
+//!   public API (below) it is the one a consumer cannot route around, because
+//!   the derives put `JsonSchema` on the published types themselves rather than
+//!   in a signature there is a re-export for; turning it off is how a consumer
+//!   on a different `schemars` major stops carrying two.
 //!
 //! [`terminal`] has no feature of its own: the crate root is built on it, and
 //! every build drives a terminal, so there is nothing to save.
+//!
+//! # Dependencies in the public API
+//!
+//! Four dependencies are reachable from this crate's public surface, and that
+//! makes each one's version requirement a *source-compatibility* surface and
+//! not just a question of how many copies the graph carries. Two copies of a
+//! crate are two unrelated types, so a consumer that names one of these in its
+//! own code compiles only when its copy is the copy cargo handed us.
+//!
+//! Cargo resolves a requirement to the **top** of its range, so the window of
+//! versions a consumer can unify with is one version wide however the
+//! requirement is written. Widening a range moves that window upward; it does
+//! not enlarge it. Measured, and the reason the `fancy-regex` requirement is
+//! what it is — see the note on it in the workspace manifest (#177).
+//!
+//! | Dependency | Where it surfaces | Re-exported here as |
+//! |---|---|---|
+//! | `fancy-regex` | [`pyregex::compile`] | [`fancy_regex`] |
+//! | `jsonschema` | [`pyschema::compile`], [`pyschema::validate`] | [`jsonschema`] |
+//! | `vt100` | [`terminal::attributed::from_vt100`] | [`vt100`] |
+//! | `schemars` | the `JsonSchema` derives on [`Recipe`] and the types it holds | — |
+//!
+//! The first three are re-exported at the crate root so a consumer can name
+//! *our* copy — `termproof::fancy_regex::Regex` rather than its own
+//! `fancy_regex::Regex` — and stop depending on the two resolving to the same
+//! version. Naming the re-export is the supported way to interoperate with
+//! these signatures; naming your own is a bet on the resolver.
+//!
+//! `serde`, `serde_json` and `serde_yaml` are in public signatures too and are
+//! deliberately absent from that table: they are 1.x, so cargo unifies every
+//! consumer onto one copy and the hazard cannot arise.
+
+// The dependencies that reach the public API, re-exported so a consumer can
+// name the copy this crate was built against instead of resolving its own and
+// hoping the two unify. See "Dependencies in the public API" above.
+//
+// Re-exporting is deliberate and has a cost worth stating: it puts each of
+// these crates' own surfaces inside ours, so a major bump of one becomes
+// visible to anyone who named it through here. That is the trade — an explicit,
+// versioned escape hatch instead of an implicit dependence on the resolver
+// handing two crates the same copy (#177).
+
+/// The regex engine behind [`pyregex`], re-exported so its types can be named
+/// against the copy this crate was built against.
+pub use fancy_regex;
+/// The JSON Schema validator behind [`pyschema`] and [`validation`],
+/// re-exported so its types can be named against the copy this crate was built
+/// against.
+#[cfg(feature = "json-schema")]
+pub use jsonschema;
+/// The terminal emulator behind [`terminal`], re-exported so its types can be
+/// named against the copy this crate was built against.
+pub use vt100;
 
 #[cfg(feature = "evidence")]
 pub mod evidence;

--- a/rust/crates/termproof/src/pyregex.rs
+++ b/rust/crates/termproof/src/pyregex.rs
@@ -29,6 +29,24 @@ use fancy_regex::Regex;
 ///
 /// The wording is TermProof's own. Byte-parity with CPython's `re.error` text
 /// is a separate question, open as 001-OQ-001 / 002-OQ-002 / 003-OQ-010.
+///
+/// # Naming the returned type
+///
+/// This returns a [`fancy_regex::Regex`], which is a *third-party* type, so it
+/// is only interchangeable with a `Regex` your own crate names if cargo gave
+/// you both from the same copy of `fancy-regex`. Name it through the
+/// re-export — [`crate::fancy_regex`] — rather than through your own
+/// dependency, and that is true by construction:
+///
+/// ```no_run
+/// let re: termproof::fancy_regex::Regex = termproof::pyregex::compile(r"\d+").unwrap();
+/// assert!(re.is_match("42").unwrap());
+/// ```
+///
+/// Calling methods on the value without naming its type works either way; it is
+/// annotating it, or passing it into a signature of your own, that needs the
+/// copies to agree. See "Dependencies in the public API" in the crate docs
+/// (#177).
 pub fn compile(pattern: &str) -> Result<Regex, String> {
     let translated = translate(pattern)?;
     Regex::new(&translated).map_err(|e| one_line(&e.to_string()))

--- a/rust/crates/termproof/src/pyschema.rs
+++ b/rust/crates/termproof/src/pyschema.rs
@@ -31,6 +31,14 @@ use crate::pyrepr::repr_json;
 /// Compile a schema, or describe why it is not a schema.
 ///
 /// The `Err` is the clause that goes after FR-016's `invalid schema: ` prefix.
+///
+/// # Naming the returned type
+///
+/// This returns a [`jsonschema::Validator`], a *third-party* type, so it is
+/// only the same type as a `Validator` your own crate names when cargo gave you
+/// both from the same copy of `jsonschema`. Name it through the re-export —
+/// [`crate::jsonschema`] — and that holds by construction. See "Dependencies in
+/// the public API" in the crate docs (#177).
 pub fn compile(schema: &JsonValue) -> Result<Validator, String> {
     jsonschema::validator_for(schema).map_err(|error| describe(&error))
 }
@@ -38,6 +46,9 @@ pub fn compile(schema: &JsonValue) -> Result<Validator, String> {
 /// Validate `instance`, returning the clause for FR-016's
 /// `schema validation failed` detail plus the dotted instance path FR-017 asks
 /// for, or `None` when the instance is valid.
+///
+/// Takes the [`jsonschema::Validator`] [`compile`] returns, with the same
+/// caveat about which copy of `jsonschema` names the type.
 pub fn validate(validator: &Validator, instance: &JsonValue) -> Option<(String, String)> {
     let errors: Vec<ValidationError<'_>> = validator.iter_errors(instance).collect();
     let best = best_match(&errors)?;

--- a/rust/crates/termproof/src/terminal/attributed.rs
+++ b/rust/crates/termproof/src/terminal/attributed.rs
@@ -426,6 +426,16 @@ pub fn attributed_screen_from_ansi_text(
 ///
 /// The usual path: a session feeds bytes to `vt100`, and this reads the grid
 /// back out with attributes intact.
+///
+/// # Naming the argument type
+///
+/// [`vt100::Screen`] is a *third-party* type, so a `Screen` from your own
+/// `vt100` dependency is only accepted here when cargo gave us both from the
+/// same copy. Build it through the re-export — [`crate::vt100`] — and that is
+/// true by construction. If you have text rather than a live parser, the
+/// sibling constructors [`attributed_screen_from_text`] and
+/// [`attributed_screen_from_ansi_text`] take `&str` and raise no such question.
+/// See "Dependencies in the public API" in the crate docs (#177).
 pub fn from_vt100(screen: &vt100::Screen) -> AttributedScreen {
     let (rows, cols) = screen.size();
     let grid = (0..rows)


### PR DESCRIPTION
Diff 1 of 3 for #177. Additive only — **this one can land on its own** and is worth landing first even if the rest slips.

## Why

Three dependencies reach this crate's public API, and nobody knew:

| Public item | Third-party type | Bound |
|---|---|---|
| `pyregex::compile` → | `fancy_regex::Regex` | `>=0.16, <0.20` |
| `pyschema::compile` → / `validate` ← | `jsonschema::Validator` | `>=0.32, <0.34` |
| `terminal::attributed::from_vt100` ← | `vt100::Screen` | `0.16` |
| derives on `Recipe` etc. | `schemars::JsonSchema` | `0.8` |

A third-party type in a public signature is only interchangeable with the consumer's own when cargo hands both sides the *same copy*. So each of those bounds is a **source-compatibility** surface, not just a duplicate count.

`lib.rs` said the opposite in as many words — `schemars` "is the one dependency that reaches the public API" — and that sentence is why this went unnoticed through the review of #179.

## What this does

**Re-exports `fancy_regex`, `jsonschema` and `vt100` at the crate root.** A consumer that writes `termproof::fancy_regex::Regex` instead of its own stops depending on the resolver handing two crates one copy.

Verified against a consumer carrying its own `fancy-regex 0.19.0` and `vt100 0.15.2` *beside* ours — it compiles, naming both:

```rust
let re: termproof::fancy_regex::Regex = termproof::pyregex::compile(r"\d+").unwrap();
let v: termproof::jsonschema::Validator = termproof::pyschema::compile(&s).unwrap();
let mut p = termproof::vt100::Parser::new(3, 10, 0);
let _ = termproof::terminal::attributed::from_vt100(p.screen());

let mine = fancy_regex::Regex::new("y").unwrap();   // consumer's own 0.19.0
let _mine_vt = vt100::Parser::new(3, 10, 0);        // consumer's own 0.15.2
```

**Corrects the false claim** and replaces it with a *Dependencies in the public API* section naming all four, plus the resolver fact underneath the whole issue: cargo resolves a requirement to the **top** of its range, so the window of versions a consumer can unify with is one version wide however the range is written. Widening moves the window; it does not enlarge it.

**Documents the hazard at each leaking item.** `from_vt100` also points at the `&str` constructors beside it for callers who have text rather than a live parser.

## The trade, stated in the source

Re-exporting puts those crates' surfaces inside ours, so a major bump of one becomes visible to whoever named it through here. That is the point: an explicit, versioned escape hatch instead of an implicit bet on resolution.

`schemars` gets no re-export and keeps no escape — its derives are on the published types themselves rather than in a signature. That is what the `schema` feature is for, and the docs now say so accurately.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check --all` | pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --workspace` | pass, 0 failed |
| All 16 feature combinations | 16/16 pass |
| `cargo doc --all-features` | no new warnings (6 pre-existing, none in touched lines) |
| `python/scripts/check_version.py` | pass |
| Consumer escape-hatch repro above | compiles |

No signature changes; nothing that compiled before stops.

## Stack

1. **this PR** — re-exports + docs (additive)
2. wrap the leaked types + bump to 0.4.0 (breaking)
3. #179 — narrow `fancy-regex` to `^0.16`, rebased onto 2
