### PR TITLE
docs: correct the last stale 'not vendored' claim about the canonical schema

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -86,8 +86,9 @@ jobs:
       # The binary built below embeds the canonical recipe schema, so the copy
       # it embeds has to be the one the Python package ships (#174). Cheap
       # enough to repeat per target, and a release tag can be pushed by hand
-      # from a commit that never went through CI (Python), which is the only
-      # other place this runs on a non-release path.
+      # from a commit that went through neither of the workflows that run this
+      # on a pull request — CI (Python), and the `gate` job in Publish crates
+      # (Rust), which is a `pull_request` trigger on `rust/**`.
       - name: Canonical recipe schema drift across all copies
         run: python3 python/scripts/check_schema_copies.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   paths.
 - Add new entries under `[Unreleased]`, in the same PR as the change, under
   the implementation they affect.
+- **Write entries in the past tense, about the release they sit under.** A
+  released section is a record of what that version did, and it is never
+  rewritten to match the present — that would destroy the one job it has,
+  telling someone on an old version what changed and when. But this file is
+  also read for current behaviour, so a present-tense entry ("the crate does
+  not vendor the schema") goes on reading as a claim about now long after a
+  later release made it false. Past tense keeps the record intact and stops it
+  being mistaken for a statement about the current tree. Three entries under
+  `[0.3.4]` had to be re-tensed for exactly this reason (#174).
 - **Below 0.3.3 the two counts were independent**, so those headings can carry
   two release dates for one number. From 0.3.3 the counts are the same.
 
@@ -299,9 +308,10 @@ assuming a release this size moved both.
   `md-mt/termproof`. They named the Rust-only repository, which no longer holds
   the source, so the links on crates.io and docs.rs pointed at the wrong place.
   This is the substantive reason to publish the crate again.
-- **cargo:** `tests/canonical_schema.rs` is excluded from the package. It reads
-  `python/docs/recipe-schema-v1.json`, which sits outside the crate, so
-  shipping it would put a test in the tarball that cannot pass from there.
+- **cargo:** `tests/canonical_schema.rs` was excluded from the package. It read
+  `python/docs/recipe-schema-v1.json`, which sat outside the crate, so
+  shipping it would have put a test in the tarball that could not pass from
+  there.
 
 ### Rust — Fixed
 
@@ -310,8 +320,8 @@ assuming a release this size moved both.
   manifest and changelog were left behind and whose own drift check failed.
   `version-bump.py` now moves `python/pyproject.toml` and this file too, and
   the workflow verifies the train before it tags.
-- **schema:** `load_canonical_schema` reaches
-  `python/docs/recipe-schema-v1.json`. Its candidate paths described
+- **schema:** `load_canonical_schema` was made to reach
+  `python/docs/recipe-schema-v1.json`. Its candidate paths had described
   side-by-side checkouts from before the two implementations shared a
   repository, so it returned `None` everywhere.
 
@@ -320,9 +330,10 @@ assuming a release this size moved both.
   old candidates was `docs/recipe-schema-v1.json` relative to the working
   directory, so the function could read whatever file of that name happened to
   sit in a consumer's tree and hand it back as TermProof's canonical schema.
-  The crate does not vendor the schema, so `None` is the correct answer from a
-  registry checkout, and `None` is what it returns. `load_canonical_schema_from_dir`
-  is new and doc-hidden; it exists so a test can prove the packaged case.
+  The crate did not vendor the schema at this release, so `None` was the
+  correct answer from a registry checkout, and `None` is what it returned.
+  `load_canonical_schema_from_dir` was new and doc-hidden; it existed so a test
+  could prove the packaged case.
 
 ## [0.3.3] — 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,8 +148,9 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   answers a different question (#174).
 - CI holds every copy of the canonical schema byte-identical against the
   package resource (`python/scripts/check_schema_copies.py`). It runs in `CI
-  (Python)` and in the `gate` job of `Publish crates (Rust)`, which between
-  them cover every pull request, and in all four release paths — Python
+  (Python)`, whose path filter covers all three copies, so a pull request that
+  can change one runs it; in the `gate` job of `Publish crates (Rust)`, which
+  runs on every `rust/**` pull request; and in all four release paths — Python
   release, Rust release, Rust publish and Rust auto-release — because a tag can
   be cut from a commit that went through none of them, and a mismatch there is
   two published artifacts disagreeing about what a recipe is (#174).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,10 +148,11 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   answers a different question (#174).
 - CI holds every copy of the canonical schema byte-identical against the
   package resource (`python/scripts/check_schema_copies.py`). It runs in `CI
-  (Python)` and in all four release paths — Python release, Rust release, Rust
-  publish and Rust auto-release — because a tag can be cut from a commit that
-  passed neither pull-request nor `main` CI, and a mismatch there is two
-  published artifacts disagreeing about what a recipe is (#174).
+  (Python)` and in the `gate` job of `Publish crates (Rust)`, which between
+  them cover every pull request, and in all four release paths — Python
+  release, Rust release, Rust publish and Rust auto-release — because a tag can
+  be cut from a commit that went through none of them, and a mismatch there is
+  two published artifacts disagreeing about what a recipe is (#174).
 
 ### Python — Added
 

--- a/python/docs-site/api/index.md
+++ b/python/docs-site/api/index.md
@@ -10,7 +10,7 @@ TermProof stabilizes the recipe format and plugin protocols as public integratio
 - `assertions` evaluate output, screen text, exit code, files, or JSON Schema.
 - `renderers` fan one recipe out across multiple frontend implementations.
 
-See `docs/recipe-format-v1.md` and `docs/recipe-schema-v1.json` in the repository for the complete schema and migration policy. The installed package validates against `termproof/_resources/recipe-schema-v1.json`, a byte-identical copy inside the package.
+See `docs/recipe-format-v1.md` and `docs/recipe-schema-v1.json` in the repository for the complete schema and migration policy. The schema the installed package validates against is `termproof/_resources/recipe-schema-v1.json`, inside the package; the `docs/` file is a byte-identical copy of it, kept so the published path it has always been at does not move.
 
 ## Plugin Protocols
 

--- a/python/tests/test_public_claims.py
+++ b/python/tests/test_public_claims.py
@@ -182,6 +182,37 @@ BANNED = (
 )
 
 
+#: The changelog's released sections are excluded from the sweep, and this is
+#: the boundary rather than a hole.
+#:
+#: A released entry is a record of what that version did. It is never rewritten
+#: to match the present — that would destroy the one job it has, telling someone
+#: on an old version what changed and when — so it will always contain
+#: statements that are false of the current tree. That is not a defect in the
+#: entry; it is what a changelog is. Sweeping it can only produce false
+#: positives, and a guard that cries wolf stops being read.
+#:
+#: The compensating control is the past-tense rule recorded in the file's own
+#: "How to read this file" section. A released entry written in the past tense
+#: cannot be misread as a claim about now, so there is nothing here for a
+#: pattern to catch. Three entries under [0.3.4] were re-tensed when this was
+#: introduced, including one that said "the crate does not vendor the schema" —
+#: true at 0.3.4, false after #174 vendored it, and read by six review rounds
+#: as a live claim (#174).
+#:
+#: Everything above the first released heading — the preamble and
+#: `[Unreleased]` — describes the current tree and stays swept.
+_FIRST_RELEASED_SECTION = re.compile(r"^## \[\d", re.M)
+
+
+def _sweepable_text(path: Path, text: str) -> str:
+    """`text`, minus any part of it that is an immutable historical record."""
+    if path.name != "CHANGELOG.md":
+        return text
+    match = _FIRST_RELEASED_SECTION.search(text)
+    return text if match is None else text[: match.start()]
+
+
 class PublicClaimsTest(unittest.TestCase):
     def test_the_enumeration_is_not_vacuous(self) -> None:
         """Guard the guard: a broken glob would silently check nothing."""
@@ -252,7 +283,7 @@ class PublicClaimsTest(unittest.TestCase):
         offenders = []
         for path in _tracked_surfaces():
             relative = path.relative_to(REPO_ROOT).as_posix()
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = _sweepable_text(path, path.read_text(encoding="utf-8", errors="replace"))
             for pattern, why, scope in BANNED:
                 if scope is not None and not relative.startswith(scope):
                     continue
@@ -263,6 +294,24 @@ class PublicClaimsTest(unittest.TestCase):
                         f"{match.group(0)!r} — {why}"
                     )
         self.assertEqual([], sorted(offenders), "\n" + "\n".join(sorted(offenders)))
+
+    def test_the_changelog_exclusion_keeps_the_live_section(self) -> None:
+        """Guard the guard: the exclusion must not swallow the whole file.
+
+        `_sweepable_text` drops the changelog's released sections. A regex that
+        stopped matching the heading, or matched the wrong one, would silently
+        exclude everything — including `[Unreleased]`, which describes the
+        current tree and is exactly what the sweep is for.
+        """
+        path = REPO_ROOT / "CHANGELOG.md"
+        text = path.read_text(encoding="utf-8")
+        swept = _sweepable_text(path, text)
+
+        self.assertIn("## [Unreleased]", swept, "the live section stopped being swept")
+        self.assertLess(len(swept), len(text), "nothing was excluded; the heading regex stopped matching")
+        released = _FIRST_RELEASED_SECTION.search(text)
+        self.assertIsNotNone(released, "no released section found; the heading format changed")
+        self.assertNotIn(text[released.start() : released.end()], swept)
 
     def test_module_docstrings_are_covered_too(self) -> None:
         """Docstrings were the first surface a sweep missed.

--- a/python/tests/test_public_claims.py
+++ b/python/tests/test_public_claims.py
@@ -158,6 +158,27 @@ BANNED = (
         # accurate and must not be "corrected" into a false one.
         "python/",
     ),
+    (
+        # #174 vendored the canonical recipe schema into the crate
+        # (`crates/termproof/resources/`, embedded with `include_str!`). The
+        # `schemars` rationale in `rust/Cargo.toml` went on saying the schema
+        # "lives in the Python tree and is deliberately not vendored here",
+        # and used that as the reason no generated-vs-canonical drift test
+        # exists. That surface was already swept — `rust/Cargo.toml` is
+        # asserted into the enumeration below — so what was missing was this
+        # pattern, not coverage.
+        #
+        # Scoped to the schema deliberately. A bare `not vendored` would flag
+        # `rust/docs/architecture.md` and `crates/termproof/README.md`, which
+        # say the *conformance corpus* is not vendored — still true, and a
+        # pattern with false positives teaches people to add exemptions
+        # rather than to read it.
+        re.compile(r"canonical (?:recipe )?schema[^.]{0,120}not vendored", re.I),
+        "the crate vendors the canonical schema at "
+        "crates/termproof/resources/recipe-schema-v1.json; what is still "
+        "missing is a generated-vs-canonical comparison, not reach",
+        None,
+    ),
 )
 
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -98,8 +98,9 @@ serde_yaml = "0.9"
 # the fourth, added by #174, asserts on the *canonical* embedded schema, which
 # a redraw of the generated one does not touch. A change of that shape passing
 # green is the argument for a real drift test. The `termproof` crate vendors
-# the canonical schema now (`crates/termproof/resources/`, embedded by
-# `schema::load_canonical_schema`), so reaching it is no longer what is
+# the canonical schema now — `crates/termproof/resources/`, embedded with
+# `include_str!` as `schema::CANONICAL_SCHEMA_JSON` and parsed by
+# `schema::load_canonical_schema` — so reaching it is no longer what is
 # missing — comparing it against the generated schema is, and that remains
 # parity-gate work and is not done. `crates/termproof/tests/schema_snapshot.rs`
 # pins the generated schema to itself in the meantime, which is what would have

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -93,15 +93,17 @@ serde_yaml = "0.9"
 # The bump also silently redraws the generated recipe schema: `definitions`
 # becomes `$defs` with every `$ref` retargeted, `"minimum": 0.0` becomes
 # `"minimum": 0`, and key order and the `required` array go from sorted to
-# declaration order. The three tests in `schema.rs` catch none of it — they
-# check `$schema`, two `required` entries and one const. A change of that shape
-# passing green is the argument for a real drift test. The `termproof` crate
-# vendors the canonical schema now (`crates/termproof/resources/`, embedded by
+# declaration order. The unit tests in `crates/termproof/src/schema.rs` catch
+# none of it — they check `$schema`, two `required` entries and one const, and
+# the fourth, added by #174, asserts on the *canonical* embedded schema, which
+# a redraw of the generated one does not touch. A change of that shape passing
+# green is the argument for a real drift test. The `termproof` crate vendors
+# the canonical schema now (`crates/termproof/resources/`, embedded by
 # `schema::load_canonical_schema`), so reaching it is no longer what is
 # missing — comparing it against the generated schema is, and that remains
-# parity-gate work and is not done. `tests/schema_snapshot.rs` pins the
-# generated schema to itself in the meantime, which is what would have caught
-# the redraw above.
+# parity-gate work and is not done. `crates/termproof/tests/schema_snapshot.rs`
+# pins the generated schema to itself in the meantime, which is what would have
+# caught the redraw above.
 #
 # What #28 shipped instead is the `schema` feature on the `termproof` crate: a
 # consumer that does not need generation stops compiling `schemars` at all,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -95,9 +95,13 @@ serde_yaml = "0.9"
 # `"minimum": 0`, and key order and the `required` array go from sorted to
 # declaration order. The three tests in `schema.rs` catch none of it — they
 # check `$schema`, two `required` entries and one const. A change of that shape
-# passing green is the argument for a real drift test; the canonical schema
-# lives in the Python tree and is deliberately not vendored here, so building
-# one is parity-gate work and is not done.
+# passing green is the argument for a real drift test. The `termproof` crate
+# vendors the canonical schema now (`crates/termproof/resources/`, embedded by
+# `schema::load_canonical_schema`), so reaching it is no longer what is
+# missing — comparing it against the generated schema is, and that remains
+# parity-gate work and is not done. `tests/schema_snapshot.rs` pins the
+# generated schema to itself in the meantime, which is what would have caught
+# the redraw above.
 #
 # What #28 shipped instead is the `schema` feature on the `termproof` crate: a
 # consumer that does not need generation stops compiling `schemars` at all,

--- a/rust/crates/termproof/tests/schema_snapshot.rs
+++ b/rust/crates/termproof/tests/schema_snapshot.rs
@@ -1,11 +1,12 @@
 //! Snapshot guard for [`termproof::schema::generate_recipe_schema`] (#33).
 //!
-//! The unit tests next to `generate_recipe_schema` assert only `$schema`, two
-//! `required` entries and the `recipe_version` const, so the generated schema
-//! can be rewritten structurally — `definitions` to `$defs` with every `$ref`
-//! retargeted, `minimum: 0.0` to `minimum: 0`, key and `required` ordering —
-//! while those tests stay green. That is exactly what a `schemars` major bump
-//! did, and nothing noticed.
+//! The unit tests next to `generate_recipe_schema` check `$schema`, two
+//! `required` entries and one const, and the fourth — added by #174 — asserts
+//! on the *canonical* embedded schema, which a redraw of the generated one
+//! leaves untouched. None of them catches a structural rewrite: `definitions`
+//! to `$defs` with every `$ref` retargeted, `minimum: 0.0` to `minimum: 0`,
+//! key and `required` ordering can all move while those tests stay green.
+//! That is exactly what a `schemars` major bump did, and nothing noticed.
 //!
 //! This test pins the crate's own generated schema to a checked-in snapshot
 //! (`tests/snapshots/recipe_schema_v1.json`). Both sides are parsed and

--- a/rust/docs/architecture.md
+++ b/rust/docs/architecture.md
@@ -56,7 +56,8 @@ shared rather than remote.
 - **The recipe schema and the example corpus are owned by the Python
   implementation.** They are the contract both implementations answer to. The
   schema is vendored into the crate at `resources/recipe-schema-v1.json` and
-  embedded by `load_canonical_schema` with `include_str!`, held byte-identical
+  embedded with `include_str!` as `schema::CANONICAL_SCHEMA_JSON` and parsed by
+  `load_canonical_schema`, held byte-identical
   to `python/termproof/_resources/recipe-schema-v1.json` by
   `python/scripts/check_schema_copies.py`; the corpus is the shared
   `conformance/` tree at the repository root and is not vendored. What the crate

--- a/rust/docs/architecture.md
+++ b/rust/docs/architecture.md
@@ -57,8 +57,8 @@ shared rather than remote.
   implementation.** They are the contract both implementations answer to. The
   schema is vendored into the crate at `resources/recipe-schema-v1.json` and
   embedded with `include_str!` as `schema::CANONICAL_SCHEMA_JSON` and parsed by
-  `load_canonical_schema`, held byte-identical
-  to `python/termproof/_resources/recipe-schema-v1.json` by
+  `load_canonical_schema`, held byte-identical to
+  `python/termproof/_resources/recipe-schema-v1.json` by
   `python/scripts/check_schema_copies.py`; the corpus is the shared
   `conformance/` tree at the repository root and is not vendored. What the crate
   does pin is its *own* generated schema, to a checked-in snapshot

--- a/rust/docs/engineering-baseline.md
+++ b/rust/docs/engineering-baseline.md
@@ -253,14 +253,13 @@ workspace README in the same change.
 - The generated recipe schema is pinned by a checked-in snapshot
   (`crates/termproof/tests/schema_snapshot.rs` plus
   `crates/termproof/tests/snapshots/recipe_schema_v1.json`). The guard exists
-  because no schema unit test asserts on the generated schema's structure —
-  they check `$schema`, two `required` entries and the `recipe_version` const,
-  and the fourth, added by #174, asserts on the *canonical* embedded schema,
-  which a redraw of the generated one leaves untouched. So a structural
-  rewrite (`definitions` to
-  `$defs` with every `$ref` retargeted, `minimum: 0.0` to `minimum: 0`, key
-  and `required` ordering) can slip through with the suite green — exactly
-  what a `schemars` major bump did (#33).
+  because the schema unit tests catch none of the shapes a structural rewrite
+  takes: they check `$schema`, two `required` entries and one const, and the
+  fourth, added by #174, asserts on the *canonical* embedded schema, which a
+  redraw of the generated one leaves untouched. So `definitions` becoming
+  `$defs` with every `$ref` retargeted, `minimum: 0.0` becoming `minimum: 0`,
+  or key and `required` ordering changing can all slip through with the suite
+  green — exactly what a `schemars` major bump did (#33).
 - The snapshot is compared as parsed `serde_json::Value` trees, not as text:
   object key order in the file is ignored (semantically irrelevant), but every
   structural difference — keywords, numbers, array order, `$ref` targets —

--- a/rust/docs/engineering-baseline.md
+++ b/rust/docs/engineering-baseline.md
@@ -275,8 +275,9 @@ workspace README in the same change.
   changes to this crate's generated schema; it does **not** establish
   agreement with the canonical schema. That schema is owned by the Python
   implementation and is vendored into this crate at
-  `resources/recipe-schema-v1.json`, embedded by
-  `schema::load_canonical_schema` with `include_str!` and held byte-identical
+  `resources/recipe-schema-v1.json`, embedded with `include_str!` as
+  `schema::CANONICAL_SCHEMA_JSON`, parsed by `schema::load_canonical_schema`
+  and held byte-identical
   to `python/termproof/_resources/recipe-schema-v1.json` by
   `python/scripts/check_schema_copies.py` in CI. The seam therefore answers
   the same from a published tarball as it does here, and reads no path outside
@@ -322,10 +323,15 @@ workspace README in the same change.
   change the convention would call a minor bump; it is caught here before a
   release, not by the first consumer who fails to compile.
 - **Package verification.** PR CI runs `cargo package -p termproof` and
-  `.github/scripts/rust/verify-package-contents.sh`, which asserts the tarball
-  carries the snapshot test and its fixture (issue #33's promise) and does
-  not carry the differential tests or `conformance/` (which cannot run without
-  the repository).
+  `.github/scripts/rust/verify-package-contents.sh`. The rule it encodes,
+  rather than the lists it holds: a test ships if a consumer can run it from
+  the tarball alone, and does not if it needs the repository around it. So the
+  snapshot and canonical-schema tests and the files they read are required, and
+  the differential tests and `conformance/` — which replay a corpus that lives
+  at the repository root and is not packaged — are forbidden. Read the script
+  for the current lists; #174 moved `tests/canonical_schema.rs` across that
+  line, from forbidden to required, by making it read the embedded schema
+  instead of a path outside the crate.
 - **Release archives.** `release-rust.yml` smoke-tests every archive before
   upload: `.github/scripts/rust/verify-release-archive.sh` verifies the sha256,
   extracts the tarball, and asserts `termproof --version` reports exactly the

--- a/rust/docs/engineering-baseline.md
+++ b/rust/docs/engineering-baseline.md
@@ -253,8 +253,11 @@ workspace README in the same change.
 - The generated recipe schema is pinned by a checked-in snapshot
   (`crates/termproof/tests/schema_snapshot.rs` plus
   `crates/termproof/tests/snapshots/recipe_schema_v1.json`). The guard exists
-  because the schema unit tests assert only `$schema`, two `required` entries
-  and the `recipe_version` const, so a structural rewrite (`definitions` to
+  because no schema unit test asserts on the generated schema's structure —
+  they check `$schema`, two `required` entries and the `recipe_version` const,
+  and the fourth, added by #174, asserts on the *canonical* embedded schema,
+  which a redraw of the generated one leaves untouched. So a structural
+  rewrite (`definitions` to
   `$defs` with every `$ref` retargeted, `minimum: 0.0` to `minimum: 0`, key
   and `required` ordering) can slip through with the suite green — exactly
   what a `schemars` major bump did (#33).

--- a/rust/docs/engineering-baseline.md
+++ b/rust/docs/engineering-baseline.md
@@ -276,10 +276,9 @@ workspace README in the same change.
   agreement with the canonical schema. That schema is owned by the Python
   implementation and is vendored into this crate at
   `resources/recipe-schema-v1.json`, embedded with `include_str!` as
-  `schema::CANONICAL_SCHEMA_JSON`, parsed by `schema::load_canonical_schema`
-  and held byte-identical
-  to `python/termproof/_resources/recipe-schema-v1.json` by
-  `python/scripts/check_schema_copies.py` in CI. The seam therefore answers
+  `schema::CANONICAL_SCHEMA_JSON`, parsed by `schema::load_canonical_schema`,
+  and held byte-identical to `python/termproof/_resources/recipe-schema-v1.json`
+  by `python/scripts/check_schema_copies.py` in CI. The seam therefore answers
   the same from a published tarball as it does here, and reads no path outside
   the crate; `tests/canonical_schema.rs` ships and proves both, including that
   a decoy file in the working directory cannot displace it. Comparing the two


### PR DESCRIPTION
Follow-up to #180 / #174. One comment fix, and the sweep that found it.

## First, a correction to the premise I was given

**The round-4 fix did land.** `python/docs/recipe-format-v1.md` on `main` at `3d2367e` is byte-identical to the corrected file — both `sha256 0456aa8c…8d4a` — and reads "outside the Python package and outside the Rust crate", not "inside neither published artifact". The phrase is absent from:

- every tracked file (`git grep`);
- every file on disk including untracked and gitignored ones, so the regenerated `python/_site/` copy too;
- `main`'s history (`git log -S"neither published artifact"` on `origin/main` returns nothing — the PR was squash-merged carrying the final state, so the phrase never reached `main` at all);
- the squash commit message, which does not contain the string at all — it contains the word `neither`, once, in the unrelated "passed neither pull-request nor `main` CI";
- the merged #180 body, which contains the string exactly once, inside my own sweep documentation quoting the grep pattern. Not a claim. (The round-2 correction section quotes a *different* withdrawn phrase, `"in no artifact"`.)

`python/_site/` was never a checked-in generated copy either — it is gitignored and untracked at `3d2367e` and at every ancestor. It was a local artifact left by my own `test_docs_pages.py` run. I deleted it and re-ran the builder anyway; it regenerates from `python/docs/` and now carries the corrected wording.

So there was nothing left of *that* phrase to land. But the instruction to sweep the whole repo for it **and its near neighbours** was the right one, and it found something.

## What the sweep found

`rust/Cargo.toml`, in the `schemars` dependency-rationale comment:

> the canonical schema lives in the Python tree and is deliberately not vendored here, so building one is parity-gate work and is not done

#180 vendored it — `crates/termproof/resources/recipe-schema-v1.json`, embedded with `include_str!` as `schema::CANONICAL_SCHEMA_JSON` and parsed by `schema::load_canonical_schema`. The comment is stale, and it uses the stale half as the reason a generated-vs-canonical drift test does not exist.

The conclusion survives; the reason does not. Reaching the schema is no longer what is missing — comparing it against the generated schema is, and that is still parity-gate work. The comment now says that, and points at `crates/termproof/tests/schema_snapshot.rs`, which is the guard the paragraph immediately above it argues for and which does exist.

This is the same overclaim family that #180's review corrected in four other places over three rounds.

**Why it survived — corrected.** My first draft said "it is a dependency-rationale comment in a workspace manifest, nobody looked there". That is wrong, and the wrong diagnosis is what led to the omission fixed in the second commit. `rust/Cargo.toml` was never unswept: it is matched by `SURFACE_GLOBS`' `*.toml` and is named explicitly in `test_public_claims.py`'s "a prefix that stops matching must fail rather than quietly shrink the sweep" block. **The surface was covered; the pattern was missing.**

## How I swept

Not by fixing the files I was pointed at. Four passes:

1. **Literal phrasings**, `git grep -iE` over the tracked tree: `neither published artifact|inside neither|in neither|in no artifact|no artifact at all|inside no artifact|not in either artifact|neither artifact|outside both|not inside either|neither distributable`.
2. **The same patterns with plain `grep -rn`**, so untracked and gitignored files were included. This is the only pass that reads `python/_site/`, and it is how I established that file's actual status rather than assuming it.
3. **The claim family, not the phrase** — every line matching `never packaged|not shipped|does not ship|is not in the (wheel|sdist|package|crate|tarball)|excluded from the package|not vendored|in no wheel|ships? (in|inside)`, and separately every line pairing `docs/` with `artifact|ship|carry|distribut`. Pass 3 is what caught `rust/Cargo.toml`; passes 1 and 2 do not match it.
4. **Surfaces `git grep` cannot read** — the commit message and the PR body, checked with `gh pr view --json body`.

Passes 1 and 2 now return nothing, on tracked and untracked files alike.

## Review round 1 — what it changed

An adversarial review returned `merge-with-follow-ups`, 0 blocking, 3 non-blocking. All three were right and all three are fixed in `74c6c86`:

1. **The guard was not extended.** `python/tests/test_public_claims.py` is the repo's regression net for precisely this defect class, and its docstring states the protocol: "a new one is added when a new one is found". I found one, corrected it, and added no pattern — leaving the correction unprotected against reintroduction, which is the outcome that file was written to prevent. Now added, scoped to the schema (`canonical (?:recipe )?schema[^.]{0,120}not vendored`) so it does not collide with the two legitimate "the *conformance corpus* is not vendored" statements. Proven both ways: matches the withdrawn text at `3d2367e`, does not match the corrected text, false-positives on no tracked file.
2. **Two inaccuracies in the section above**, both corrected in place — the squash commit message does not contain the string at all, and #180's body contains it once rather than twice.
3. **A stale count two lines from my own hunk.** `rust/Cargo.toml` said "The three tests in `schema.rs`"; #174 made it four. Same stale-claim family, made stale by the very PR this comment was being updated for, and my sweep missed it because it searched for shipping claims and not for counts. Rewritten to state why the conclusion survives rather than to carry a number that goes stale again. The reviewer also caught `tests/schema_snapshot.rs` and `crates/termproof/resources/` written with different path roots one sentence apart (`rust/tests/` does not exist); both are workspace-relative now.

## Review round 2 — what it changed

Second adversarial pass on `74c6c86`: **all three round-1 follow-ups confirmed fixed**, 0 blocking. It verified the new guard entry the hard way — restoring the withdrawn text and watching the test fail — rather than taking the pattern on trust. Four new items, three fixed in `3088101` and this body:

- **`rust/docs/engineering-baseline.md` carried the same incomplete enumeration**, one file over from the one I had just fixed: "the schema unit tests assert only `$schema`, two `required` entries and the `recipe_version` const". #174 added a fourth. Fixed the same way — state why the conclusion survives instead of enumerating a set that goes stale on the next test. A fair hit on a PR whose whole subject is that a sweep should not stop at the file it was pointed at.
- Two body slips, corrected above: it said the comment "points at `tests/schema_snapshot.rs`" — the exact unrooted form round 1 had flagged — two paragraphs after claiming the roots were fixed; and it quoted the regex as `(recipe )?` where the code has `(?:recipe )?`.

**Found and deliberately not fixed:** `rust/docs/engineering-baseline.md:5` says "all five crates"; the workspace has three (`cargo metadata`, and `architecture.md:10` / `publishing.md:191` both say three). It went stale at the consolidation (`808c92d`), not at #174 — a different claim about a different thing — so it belongs in its own change rather than smuggled into a schema-claims sweep. Happy to file it.

## Review round 3 — what it changed

Third pass, on `3088101`: 0 blocking, round-2 items A/B/C confirmed fixed and D confirmed correctly deferred. Two real findings, both fixed in `4e6d853`:

- **A third copy of the enumeration**, verbatim, in `crates/termproof/tests/schema_snapshot.rs:3-4` — the module docstring of the very file the two corrected sentences cite as the guard. All three sites were the same vintage; #180 edited lines 17-23 of that file and left 3-4 alone.

  The useful part is *how* it was found. Twice I fixed the file a reviewer named and a copy survived one file over. Grepping the **sentence** instead of the file is the check I should have run at the start. `git grep -nE 'redraw of the generated'` returns all three sites, and all three now agree and are true.

  See round 4 below for why the recipe originally quoted here was the wrong one — and for the more useful version of this lesson.

- **I introduced a false claim while fixing the stale one.** My rewrite said "no schema unit test asserts on the generated schema's structure". That is wrong: `schema_has_required_fields` asserts on `schema["required"]`, and `schema_recipe_version_is_const_one` on `schema["properties"]["recipe_version"]["const"]` — both structural assertions on the generated document. The accurate framing was already in `rust/Cargo.toml` (the tests catch none of the three *redraw shapes*) and I failed to reuse it. All three sites now use it. Fixing a stale claim by writing a false one is worse than leaving it alone.

  Note the guard added in `74c6c86` could not have caught this: it is a regression net for phrasings that shipped, and this one was caught in review before it shipped.

Also corrected in this body: it cited `publishing.md:33` as saying the workspace has three crates. Line 33 says the three *merged-away* crates were unpublished — a different fact. The correct citation is `publishing.md:191`.

## Review round 4 — what it changed

Fourth pass, on `4e6d853`: **0 blocking, all round-3 items fixed.** It verified the corrected framing by *mutation* rather than by reading — patching `generate_recipe_schema` to apply all three redraw shapes at once, then confirming all four unit tests still pass while `generated_schema_matches_checked_in_snapshot` fails on `/$defs`. That is a stronger proof than I gave, and it settles that the replacement wording is true.

**The finding, and it is the sharpest one in this PR: my own commit blinded the grep I was using as evidence.** The body claimed `git grep -nE 'two .?required.? entries|assert only'` "finds all of them at once". At `3088101` it returned 3 sites; at that commit's successor it returned **2**. I read the 3→2 drop as the fix landing. It was the instrument going blind, and had a site still been stale it would have looked fixed.

  *(Cause, corrected in round 5: the rewrap did **not** split `two` from `` `required` entries `` — they were already on separate lines at `3088101`, so that alternate never matched `schema_snapshot.rs` at all. Deleting `assert only` was the sole cause. I inherited the split-pattern explanation from the round-4 report and repeated it without checking it, which is the same mistake the paragraph is about.)*

Corrected above to `git grep -nE 'redraw of the generated'`, which returns exactly 3 with no false positives. But swapping one fragment for another is not the lesson. **A line-oriented grep over wrapped prose is inherently fragile: any rewrap can split the pattern, and a sweep that reports fewer hits after an edit cannot distinguish "fixed" from "no longer matching".** The rule that follows is to confirm the recipe still returns the known site count *before* reading any change in it as progress. I did not, and it took a fourth reviewer to notice.

**Found, verified, and deliberately not fixed here** — four more stale claims, all `808c92d` (consolidation) vintage, none touched by #174/#180/#185, listed so they are not lost:

| Claim | Reality |
| --- | --- |
| `engineering-baseline.md:5` "all five crates" | three (`cargo metadata`; `architecture.md:10`, `publishing.md:191`) |
| `engineering-baseline.md:304` Dependabot "capped at five per ecosystem" | `github-actions` is 1, and the config says so |
| `engineering-baseline.md:334` cites `release-rust.yml` | it is `rust-release.yml`; pre-consolidation names survive on **17 lines across 4 files** (`rust-auto-release.yml` ×13, `rust-release.yml` ×2, `verify-release-archive.sh`, `engineering-baseline.md`), including a user-facing `::error::` at `rust-auto-release.yml:176` |
| `check_version.py:5-6` claims `action.yml` and `Formula/termproof.rb` are checked | `check_action` is `return True`; `FORMULA` is never read |
| `specs/` (plural) cited | the directory is `spec/`. 17 hits across 9 files, of which **9 need correcting** — the rest are vendored Spec Kit scaffolding under `rust/.specify/templates/` and `rust/.claude/skills/` describing Spec Kit's own convention. `rust/.specify/memory/constitution.md` (4 hits) is repo-authored governance, not scaffolding, and does need fixing. Three of the hits are rustdoc, so they publish to docs.rs |

Same reasoning as the deferred "all five crates": a different claim family with a different cause, and folding it into a schema-claims sweep would make this diff unreviewable. The `check_version.py` one is arguably a real defect rather than a doc bug — a documented check that does nothing. Happy to file these as one issue, or take them as a follow-up PR; say which.

## Review round 5 — what it changed

Fifth pass: **0 blocking**, round-4 item fixed, and it re-proved the three sites by mutation again rather than by reading. Six findings. Three were mine for a reason worth naming: **I copied round 4's numbers into this body without checking them** — the very failure the paragraph they sat in was about.

Corrected above, each verified by me this time:

- **The stated cause of the grep going blind was wrong.** The rewrap did not split the pattern; `two` and `` `required` entries `` were already on separate lines at `3088101`, so that alternate never matched `schema_snapshot.rs`. Deleting `assert only` was the whole cause.
- **"21 places across 6 files" → 17 lines across 4 files.** The overcount came from `publish-crates.yml` matching as a substring of the *current* name `rust-publish-crates.yml`.
- **"`specs/` cited 5×"** → 17 hits across 9 files, most of them vendored Spec Kit scaffolding describing Spec Kit's own convention. My first attempt to check this returned *zero* because `git grep -nE '\bspecs/'` does not behave as I assumed — I caught that only by not believing my own result, which is the round-4 lesson finally applied.

Four real fixes, in `820fdc4`:

- **`rust/Cargo.toml`** said the schema is "embedded by `schema::load_canonical_schema`". `include_str!` is on `CANONICAL_SCHEMA_JSON`; `load_canonical_schema` parses it. `schema.rs:82` draws that distinction explicitly and this PR's own first commit blurred it.
- **`engineering-baseline.md`** described `verify-package-contents.sh` without #174's two added required entries, and without the fact that `tests/canonical_schema.rs` **moved from forbidden to required**. Omitting a move states the opposite of what the script does.
- **`rust-release.yml`** called CI (Python) "the only other place this runs on a non-release path". Publish crates (Rust) has a `pull_request` trigger on `rust/**` and its `gate` job runs the same check. Written in #174, wrong when written.
- **`python/docs-site/api/index.md`** had reference and copy inverted — it called the package resource "a byte-identical copy", when that is the file the code reads. Also #174, and the inversion undoes the page's point.

**The commit message of `68ae440` was amended** (this branch is unmerged, so the rewrite is free) because it carried the wrong-cause explanation, and a squash merge would have landed it on `main`.

## Review round 6 — what it changed

Sixth pass on `820fdc4`: **0 blocking**, all six round-5 items confirmed fixed against artefacts. One item it asked be fixed before merge, and it was right in a way that stings.

**`820fdc4`'s own commit message said the `Cargo.toml` comment "was the only place that blurred" the `include_str!` attribution.** False three times over: `rust/docs/architecture.md:59` and `rust/docs/engineering-baseline.md:278` both said "embedded by `load_canonical_schema` with `include_str!`" — the second in the file that commit *edits*, fifty lines above its other hunk — and `099f1c2`'s message says it too. A squash would have asserted it on line 5 and denied it on line 130. A newly-written false claim of exactly this PR's defect class, in a commit message about that defect class.

Fixed by correcting **all** sites rather than the sentence, which is the PR's own argument applied to itself. `git grep -nE 'embedded by .{0,40}load_canonical_schema'` now returns nothing, and the four places naming `CANONICAL_SCHEMA_JSON` agree.

Also fixed:

- **`CHANGELOG.md:124-129` carried the same false claim as `rust-release.yml`** — that a tag can be cut from a commit that "passed neither pull-request nor `main` CI". `Publish crates (Rust)`'s `gate` runs the check on every `rust/**` PR. Same `#174` origin, one file over; found by the reviewer's sweep, not mine.
- **The package-verification description was still an enumeration** — 4 of the script's 9 required entries, which is the shape that goes stale. Replaced with the rule it encodes: a test ships if a consumer can run it from the tarball alone. That is what the PR's other three fixes did and this one had not.
- The commit message's "omitting a move states the opposite of what the script does" was itself an overstatement — the old text mentioned `canonical_schema.rs` in neither list, so it stated nothing. Reworded.
- A missing article in the new docs-site sentence; `:329` → `:332` in the table above, moved by this PR's own commit; and the `specs/` row now separates repo-authored governance from vendored scaffolding (9 of 17 need correcting, not all 17).

**Rebased onto `a729c71`** (#184 merged) — no conflicts.

## Review round 7 — what it changed

**The fresh sweep found nothing stale outside this PR's own diff — the first time in seven rounds.** Every canonical-schema surface, all five workflow comments, the historical changelog sections and both withdrawn-phrase sweeps came back clean. What is left is entirely self-inflicted, which is the honest summary of rounds 5–7.

Two fixes in `26eaa31`, both introduced by me:

- **`CHANGELOG.md` claimed the two pull-request runners "between them cover every pull request".** They do not: the union of the two `pull_request` path filters misses **ten** tracked paths (`LICENSE`, `.gitignore`, `.github/CODEOWNERS`, `.github/dependabot.yml`, `.github/FUNDING.yml`, `.github/PULL_REQUEST_TEMPLATE.md`, and four `.github/ISSUE_TEMPLATE/` files). Round 6 replaced a false claim here with a *stronger* false one. The true and useful statement is narrower and already existed at `python-ci.yml:129` — the filter covers every path holding a copy, so a pull request that can change one runs the check.
- **Two mid-paragraph stub lines** (25 and 46 characters) left by the previous commit's rewrap — one commit after that commit fixed the same defect.

Also: the first commit's message still carried the old `include_str!` attribution, so it was reworded (`git grep` over the simulated squash body is clean, and the one remaining hit for a withdrawn phrase is a quotation inside a description of its fix); and `:332` → `:335` in the table above, moved again by this PR's own edits — third round running, which is why the reference is to the bullet's name rather than only its line from here on.

### An honest note on this review series

Rounds 1–3 found real problems in the repository, and rounds 5–6 found four more genuine `#174` ones — the `include_str!` attribution, the package-verification description, `rust-release.yml`'s "only other place", and the inverted reference/copy on the docs-site page. Alongside those, rounds 4–7 also repeatedly found problems **I introduced while fixing the previous round's** — a false claim written to replace a stale one, a grep blinded by my own rewrap, numbers copied from a reviewer's report without checking. The rate has not improved with care, which is the argument for `654fd3a`'s guard rather than for more careful prose: prose claims decay because nothing checks them, and that is as true of mine as of the ones this PR corrects. The five deferred consolidation-vintage claims are listed above precisely so they get a mechanism rather than another hand sweep.

## Review round 8 — the changelog finding, and the question behind it

A blocking finding my own eight review rounds missed, one of which swept `CHANGELOG.md` and called it clean. `## [0.3.4]` said *"The crate does not vendor the schema, so `None` is the correct answer from a registry checkout, and `None` is what it returns."*

**The fact is not the defect — that sentence was true when 0.3.4 shipped.** Rewriting a released entry to match the present destroys the one job it has: telling someone on an old version what changed and when. The defect is a past-tense record written in the *present* tense, in a file people also read for current behaviour.

**Shape chosen: 1 (re-tense) + 3 (record the rule).** Not 2 — the objection to forward pointers is right, you add them forever.

I re-tensed **three** entries, not the one reported. The same section also said `tests/canonical_schema.rs` "is excluded from the package" and that `load_canonical_schema` "reaches `python/docs/recipe-schema-v1.json`". All three were true at 0.3.4; all three read as claims about now. Fixing only the reported one would have been the sixth instance of the exact habit under review.

The rule is now in the changelog's own "How to read this file", and **the sweep stops at the first released heading** — verified by injection in both directions: a withdrawn claim in `[Unreleased]` fails the sweep, the same claim under `[0.3.4]` does not. `test_the_changelog_exclusion_keeps_the_live_section` guards that boundary, because a heading regex that stopped matching would silently exclude the whole file.

### Can this class be guarded mechanically? Partly — and the split is the useful answer

**Yes, where a claim is tied to a fact on disk.** This repo already does that four times, and none of them is a wording list: `check_version.py` (manifests agree), `check_schema_copies.py` (three copies byte-identical), `verify-package-contents.sh` (tarball contents), `test_sdist_artifact_content.py` (sdist and wheel contents). Those cannot go stale, because they assert the fact rather than describe it. **That is where effort should go, and it is the right reading of "vendored / shipped / published / packaged is checkable".**

**No, for prose in general — and `test_public_claims.py` should stop being read as if it were.** Its own docstring already says it: *"a regression net, not a semantic checker"*. It catches **reintroduction of a sentence that shipped once**. It cannot catch a near neighbour, by construction — that is not a bug in the pattern, it is what a pattern is. Six rounds of this defect went: two were facts on disk (the `Cargo.toml` vendoring claim, the package-verification description) and would have been caught by asserting the fact; **four were not checkable by any mechanism** — a wrong tense, a wrong count of tests, "the only other place", a reference and its copy the wrong way round. No regex finds those. A reviewer did.

**So the honest position:** the wording list is a *reminder that a specific mistake was made before*, and calling it a guard is the overclaim that let six rounds run. It is worth keeping — it is cheap and it does stop verbatim regressions — but it should not be extended in the hope of covering a class it structurally cannot. Where a claim can be pinned to disk, pin it to disk. Where it cannot, the control is review, and this PR is the evidence: **every finding in rounds 4–8 came from a reviewer, none from a test.**

**And historical records are excluded**, which is the answer to "stop the sweep tripping over history forever" — with the past-tense rule as the compensating control, said out loud rather than left implicit.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace`, `cargo metadata` (the file is a manifest, so it has to still parse), `ruff`, `check_schema_copies.py` (3 copies identical), and the Python suite — 741 tests, which includes the workflow- and manifest-reading claim guards. Comment-only: no manifest key changes, so nothing about dependency resolution moves.










