### PR TITLE
api!: close every door a dependency reaches the public API through, and cut 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,32 +32,106 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ## [Unreleased]
 
-### Rust — Added
+Nothing yet.
 
-- **`fancy_regex`, `jsonschema` and `vt100` are re-exported at the crate root.**
-  All three reach the public API — `pyregex::compile` returns a
-  `fancy_regex::Regex`, `pyschema::compile` a `jsonschema::Validator`, and
-  `terminal::attributed::from_vt100` takes a `vt100::Screen` — and a
-  third-party type in a signature is only interchangeable with the consumer's
-  own when cargo hands both sides the same copy. Naming
-  `termproof::fancy_regex::Regex` instead of your own makes that true by
-  construction. Purely additive; nothing that compiled before stops.
-  ([#177](https://github.com/md-mt/termproof/issues/177))
+## [0.4.0] — 2026-08-19
+
+### Rust — Changed (breaking)
+
+**No dependency reaches this crate's public API any more, except `schemars`.**
+Several did, and each made that dependency's version requirement a
+*source-compatibility* surface: two copies of a crate are two unrelated types,
+so a consumer naming one compiled only when its copy was the copy cargo handed
+us. Widening a requirement did not help — cargo resolves to the **top** of a
+range, so the window a consumer could unify with was one version wide however
+the range was written.
+
+This is the whole reason 0.4.0 is a minor bump rather than a patch. **If you do
+not name any of the types below, nothing changes for you**; calling methods on
+the returned values without annotating them compiled before and compiles now.
+
+A signature is not the only door, and this release closed four kinds:
+
+| Door | Was | Now | What to change |
+|---|---|---|---|
+| return type | `pyregex::compile` gave `fancy_regex::Regex` | `pyregex::PyRegex` | drop the annotation, or write `pyregex::PyRegex`. `is_match`, `captures` and `capture_names` are still there, unchanged in meaning |
+| return type | reading a match gave `fancy_regex::Captures` / `Match` | `pyregex::PyCaptures` / `pyregex::PyMatch` | `get`, `name` and `len` are unchanged. `captures.named()` is new and replaces zipping `capture_names()` against `name()` |
+| return type | `pyschema::compile` gave `jsonschema::Validator`, and `pyschema::validate` took one | `pyschema::PySchema` | drop the annotation, or write `pyschema::PySchema`. Both functions are otherwise identical |
+| argument | `terminal::attributed::from_vt100(&vt100::Screen)` was public | crate-internal | **see below — this one removes a capability** |
+| re-export | `termproof::fancy_regex`, `::jsonschema`, `::vt100` | removed | depend on the crate directly and choose your own version. You no longer need ours to match |
+| trait impl | `PyRegex`'s derived `Debug` printed the engine's parsed pattern | written out; prints the translated pattern only | nothing, unless you were asserting on the old text |
+
+**`from_vt100` removes a capability, and there is no replacement for it.** It
+took the third-party type as an *argument*, and an argument cannot be wrapped —
+the caller is what builds it. A caller that already holds a live
+`vt100::Screen` now has no public way to turn it into an `AttributedScreen`: it
+must replay the bytes through `terminal::screen::TerminalScreen`, which owns
+its own parser, and pay for the second parse. `attributed_screen_from_text` and
+`attributed_screen_from_ansi_text` are unchanged and never had the problem.
+Keeping `from_vt100` public would have meant keeping `vt100` in the API for the
+one caller shape that supplies its own parser; that trade went the other way.
+
+**The re-exports were added earlier in this same release and are removed again
+before it ships**, so no published version ever carried them. They were an
+escape hatch while the types were still leaking — a way to name *our* copy
+deterministically. Wrapping the signatures removed the thing they were an
+escape from and left them as the last door: a re-exported crate is public API,
+so its breaking changes are ours, and `termproof::fancy_regex::Captures` broke
+across exactly the range this release narrows.
+
+`schemars` is the one that could not be closed — the `JsonSchema` derives are
+on `Recipe` and the types it holds, so the trait sits on published types rather
+than in a signature. Turning the `schema` feature off is still the only way out
+of carrying two copies.
+
+**What this does and does not claim.** The *declared requirement* on these
+crates is no longer a compatibility surface: depend on any `fancy-regex` you
+like, ours is an implementation detail of the graph. It is not a claim that the
+engine is interchangeable — a backtracking engine's accepted language moves
+between releases, and `(?<=a+)b` is rejected at 0.16 and accepted at 0.19 —
+which is why the requirement is pinned to one minor and the differential
+harnesses are run against it rather than assumed.
 
 ### Rust — Docs
 
-- **The crate docs no longer claim `schemars` is the only dependency reaching
-  the public API.** Three others do, and the claim is why that went unnoticed.
-  A new *Dependencies in the public API* section names all four, says why a
-  bound on them is a source-compatibility surface and not just a duplicate
-  count, and records the resolver behaviour behind it: cargo takes the **top**
-  of a requirement's range, so the window of versions a consumer can unify with
-  is one version wide however the range is written — widening moves the window
-  rather than enlarging it. `schemars` stays the one with no escape hatch,
-  because its derives are on the published types rather than in a signature.
+- **The crate docs used to claim `schemars` was the only dependency reaching
+  the public API.** Three others did, and that sentence is why it went
+  unnoticed for as long as it did. A new *Dependencies in the public API*
+  section replaces it: every door a dependency can reach a consumer through —
+  return type, argument, re-export, and what a public trait impl renders — what
+  each one was and what closed it, and the resolver behaviour underneath, which
+  is that cargo takes the **top** of a requirement's range, so the window of
+  versions a consumer can unify with is one version wide however the range is
+  written. After 0.4.0 the original sentence is finally true, and for the
+  reason it always should have given: `schemars` is the only one left because
+  it is the only one that could not be closed.
+  ([#177](https://github.com/md-mt/termproof/issues/177))
+
+- **`terminal::attributed`'s module docs no longer list `from_vt100` as a
+  source, or as "the usual path".** It has not been public since this release,
+  and the doc on the function itself now says plainly that the capability was
+  removed rather than relocated.
+  ([#177](https://github.com/md-mt/termproof/issues/177))
+
+- **`rust/Cargo.toml` no longer promises that "releases here bump the patch
+  digit only".** That described the releases that had happened rather than a
+  rule they followed, and this one makes it false. It is replaced with the
+  actual rule from
+  `rust/docs/publishing.md` — pre-1.0, a breaking change to any public API is a
+  minor bump and everything else is a patch — which leaves the `schemars` hold
+  standing on the argument that does not depend on a version digit.
   ([#177](https://github.com/md-mt/termproof/issues/177))
 
 ### Docs
+
+- **`SECURITY.md` supports the `0.4.x` train.** The version bump has to reach
+  every surface that names a version, and the supported-versions table was one
+  the bump script does not touch. `0.3.x` keeps its tick alongside it, because
+  the train moves *before* the release that puts it on the registries: for the
+  window between the two, the newest published artifact is still a `0.3.x` one.
+  The "published through `0.3.4`" rows below it are correct and deliberately
+  left alone — they are statements about PyPI and crates.io, not about the
+  manifest. ([#177](https://github.com/md-mt/termproof/issues/177))
 
 - **The distribution claims now say what 0.3.4 actually shipped.** Both
   packages are live — `termproof` on PyPI and the `termproof` crate on

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,9 +41,15 @@ Both implementations share one version train, so one row covers both.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.4.x   | :white_check_mark: |
 | 0.3.x   | :white_check_mark: |
 | 0.2.x   | :x:                |
 | 0.1.x   | :x:                |
+
+`0.3.x` keeps its tick while it is what the registries carry: the version train
+moved to `0.4.0` before the release that puts it there, so for the window
+between the two, the newest published artifact is a `0.3.x` one. See the table
+below for what is actually published.
 
 In practice the supported set is **the latest `main`** plus the most recent
 release of each distribution. Do not assume an older tag is patched; there are

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "termproof"
-version = "0.3.4"
+version = "0.4.0"
 description = "Evidence-first verification for TUI and terminal applications"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "termproof"
-version = "0.3.4"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "termproof"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "avt",
  "chrono",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "termproof-cli"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "termproof-plugin-protocol"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.96"
 license = "MIT"
@@ -59,7 +59,7 @@ all = "warn"
 # dependency floors` step in .github/workflows/rust-ci.yml runs the suite at each
 # floor, so a floor that stops being true fails CI rather than rotting quietly.
 [workspace.dependencies]
-termproof = { path = "crates/termproof", version = "0.3.4" }
+termproof = { path = "crates/termproof", version = "0.4.0" }
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode"] }
 # Floor 0.16, tested at 0.16.2. `jsonschema` 0.33 asks for `^0.16` itself, so a
 # caret on 0.19 put two copies of a backtracking regex engine in the graph of
@@ -78,8 +78,15 @@ serde_yaml = "0.9"
 #
 # 1. `JsonSchema` is derived on `Recipe`, `CommandSpec`, `Step`, `Assertion` and
 #    the config types, so the trait is part of this crate's published surface
-#    and its major is a break for any consumer that names them. Releases here
-#    bump the patch digit only.
+#    and its major is a break for any consumer that names them.
+#
+#    This used to read "Releases here bump the patch digit only." That was
+#    never a rule, only a description of the releases that had happened, and
+#    this one makes it false. The rule, from docs/publishing.md, is that pre-1.0 a
+#    breaking change to any public API is a *minor* bump and everything else is
+#    a patch — so a `schemars` major would be permitted, at the price of a
+#    minor. It is still not taken, for reason 2, which does not depend on the
+#    version digit at all.
 #
 # 2. `preserve_order` does not mean the same thing across the majors, and the
 #    difference is graph-global. In 0.8 it is `["indexmap"]`, scoped to
@@ -187,4 +194,4 @@ avt = "0.16"
 chrono = "0.4"
 globset = "0.4"
 clap = { version = "4.5", features = ["derive"] }
-termproof-plugin-protocol = { path = "crates/termproof-plugin-protocol", version = "0.3.4" }
+termproof-plugin-protocol = { path = "crates/termproof-plugin-protocol", version = "0.4.0" }

--- a/rust/crates/termproof/src/lib.rs
+++ b/rust/crates/termproof/src/lib.rs
@@ -52,67 +52,67 @@
 //!   validates against comes from.
 //! - **`schema`** — the [`schema`] module and the `JsonSchema` impls derived on
 //!   [`Recipe`], [`config::VerifierConfig`] and the types they contain. Off,
-//!   the crate does not compile `schemars`. Of the dependencies that reach the
-//!   public API (below) it is the one a consumer cannot route around, because
-//!   the derives put `JsonSchema` on the published types themselves rather than
-//!   in a signature there is a re-export for; turning it off is how a consumer
-//!   on a different `schemars` major stops carrying two.
+//!   the crate does not compile `schemars`. It is the only dependency left in
+//!   the public API (below), and the only one that could not be wrapped out of
+//!   it, because the derives put `JsonSchema` on the published types themselves
+//!   rather than in a signature; turning it off is how a consumer on a
+//!   different `schemars` major stops carrying two.
 //!
 //! [`terminal`] has no feature of its own: the crate root is built on it, and
 //! every build drives a terminal, so there is nothing to save.
 //!
 //! # Dependencies in the public API
 //!
-//! Four dependencies are reachable from this crate's public surface, and that
-//! makes each one's version requirement a *source-compatibility* surface and
-//! not just a question of how many copies the graph carries. Two copies of a
-//! crate are two unrelated types, so a consumer that names one of these in its
-//! own code compiles only when its copy is the copy cargo handed us.
+//! A third-party type in a public signature makes that dependency's version
+//! requirement a *source-compatibility* surface, and not just a question of
+//! how many copies the graph carries: two copies of a crate are two unrelated
+//! types, so a consumer that names one compiles only when its copy is the copy
+//! cargo handed us. Cargo resolves a requirement to the **top** of its range,
+//! so the window of versions a consumer can unify with is one version wide
+//! however the range is written — widening it moves the window rather than
+//! enlarging it (#177).
 //!
-//! Cargo resolves a requirement to the **top** of its range, so the window of
-//! versions a consumer can unify with is one version wide however the
-//! requirement is written. Widening a range moves that window upward; it does
-//! not enlarge it. Measured, and the reason the `fancy-regex` requirement is
-//! what it is — see the note on it in the workspace manifest (#177).
+//! A *signature* is not the only door. A re-exported crate is public API too —
+//! `termproof::dep::Type` names the same type as `dep::Type` and carries the
+//! same requirement — and so is anything a public trait impl renders, since a
+//! derived `Debug` over a private field publishes that field's formatting.
+//! 0.4.0 closed all three:
 //!
-//! | Dependency | Where it surfaces | Re-exported here as |
+//! | Door | Was | Now |
 //! |---|---|---|
-//! | `fancy-regex` | [`pyregex::compile`] | [`fancy_regex`] |
-//! | `jsonschema` | [`pyschema::compile`], [`pyschema::validate`] | [`jsonschema`] |
-//! | `vt100` | [`terminal::attributed::from_vt100`] | [`vt100`] |
-//! | `schemars` | the `JsonSchema` derives on [`Recipe`] and the types it holds | — |
+//! | return type | [`pyregex::compile`] gave a `fancy_regex::Regex` | [`pyregex::PyRegex`], with [`pyregex::PyCaptures`] and [`pyregex::PyMatch`] so reading a match does not re-leak |
+//! | return type | [`pyschema::compile`] gave a `jsonschema::Validator` | [`pyschema::PySchema`] |
+//! | argument | `terminal::attributed::from_vt100` took a `vt100::Screen` | crate-internal. Nothing public accepts a caller-built `vt100` value; [`terminal::screen::TerminalScreen`] takes bytes and owns its own parser |
+//! | re-export | `pub use fancy_regex`, `jsonschema`, `vt100` | removed |
+//! | trait impl | `PyRegex`'s derived `Debug` rendered the engine | written out, and does not format it |
 //!
-//! The first three are re-exported at the crate root so a consumer can name
-//! *our* copy — `termproof::fancy_regex::Regex` rather than its own
-//! `fancy_regex::Regex` — and stop depending on the two resolving to the same
-//! version. Naming the re-export is the supported way to interoperate with
-//! these signatures; naming your own is a bet on the resolver.
+//! `schemars` is the one that could not be closed: the `JsonSchema` derives sit
+//! on [`Recipe`] and the types it holds, so the trait is on the published types
+//! themselves rather than in a signature there is a return value to change.
+//! Turning the `schema` feature off is the only way out of carrying two copies,
+//! which is why that feature exists.
 //!
-//! `serde`, `serde_json` and `serde_yaml` are in public signatures too and are
-//! deliberately absent from that table: they are 1.x, so cargo unifies every
-//! consumer onto one copy and the hazard cannot arise.
+//! **What this does and does not claim.** It claims that the *declared
+//! requirement* on these crates is no longer a source-compatibility surface: a
+//! consumer can depend on any version of `fancy-regex` it likes, and ours is an
+//! implementation detail of the graph. It does not claim the engine is
+//! interchangeable — a backtracking engine's accepted language moves between
+//! releases, and `(?<=a+)b` is rejected at 0.16 and accepted at 0.19 — which is
+//! why the requirement is pinned to one minor and the differential harnesses
+//! are run against it rather than assumed.
+//!
+//! `serde`, `serde_json` and `serde_yaml` do appear in public signatures and
+//! are deliberately left alone: they are 1.x, so cargo unifies every consumer
+//! onto one copy and the hazard cannot arise.
 
-// The dependencies that reach the public API, re-exported so a consumer can
-// name the copy this crate was built against instead of resolving its own and
-// hoping the two unify. See "Dependencies in the public API" above.
-//
-// Re-exporting is deliberate and has a cost worth stating: it puts each of
-// these crates' own surfaces inside ours, so a major bump of one becomes
-// visible to anyone who named it through here. That is the trade — an explicit,
-// versioned escape hatch instead of an implicit dependence on the resolver
-// handing two crates the same copy (#177).
-
-/// The regex engine behind [`pyregex`], re-exported so its types can be named
-/// against the copy this crate was built against.
-pub use fancy_regex;
-/// The JSON Schema validator behind [`pyschema`] and [`validation`],
-/// re-exported so its types can be named against the copy this crate was built
-/// against.
-#[cfg(feature = "json-schema")]
-pub use jsonschema;
-/// The terminal emulator behind [`terminal`], re-exported so its types can be
-/// named against the copy this crate was built against.
-pub use vt100;
+// There is deliberately no `pub use fancy_regex;` / `jsonschema` / `vt100`
+// here. An earlier step in this release added all three, as an escape hatch
+// while those crates' types were still in our signatures: a consumer could
+// name our copy and stop betting on the resolver. Wrapping the signatures
+// removed the thing they were an escape from, and left them as the last way a
+// dependency's version could still reach a consumer through us — a re-exported
+// crate is public API, so its own breaking changes become ours. See
+// "Dependencies in the public API" above (#177).
 
 #[cfg(feature = "evidence")]
 pub mod evidence;

--- a/rust/crates/termproof/src/pyregex.rs
+++ b/rust/crates/termproof/src/pyregex.rs
@@ -22,6 +22,199 @@
 
 use fancy_regex::Regex;
 
+/// A compiled Python-dialect pattern.
+///
+/// Owns the underlying `fancy-regex` engine and does not expose it. That is
+/// deliberate: a third-party type in a public signature is only the same type
+/// as the consumer's when cargo hands both sides one copy, which makes the
+/// version requirement on that dependency a source-compatibility surface
+/// rather than a private choice. Wrapping it moves the requirement back where
+/// it belongs — see "Dependencies in the public API" in the crate docs (#177).
+///
+/// The surface here is what this crate needs plus what reading a match
+/// requires; it is not a re-implementation of the engine. A caller that wants
+/// the engine itself should depend on `fancy-regex` directly and pick its own
+/// version — this crate deliberately does not re-export ours, because nothing
+/// here hands out one of its types for the two to have to agree about.
+///
+/// ```
+/// let re = termproof::pyregex::compile(r"(?<n>\d+)").unwrap();
+/// let caps = re.captures("abc 42").unwrap().unwrap();
+/// assert_eq!(caps.get(0).unwrap().as_str(), "42");
+/// assert_eq!(caps.name("n").unwrap().as_str(), "42");
+/// ```
+pub struct PyRegex {
+    inner: Regex,
+    translated: String,
+}
+
+impl std::fmt::Debug for PyRegex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Written out rather than derived, and deliberately does not format
+        // `inner`. The engine's own `Debug` prints its parsed pattern, and that
+        // rendering is not stable across its *patch* releases: `x\z` prints as
+        // `x$` on `fancy-regex` 0.16.0 and 0.16.1 and as `x\z` on 0.16.2, all
+        // three inside the range this crate declares. Deriving would put that
+        // engine-version-dependent answer back into the public API — the same
+        // leak `as_str` is written out to avoid, one trait over (#177).
+        f.debug_struct("PyRegex")
+            .field("translated", &self.translated)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PyRegex {
+    /// The translated pattern the engine was built from.
+    ///
+    /// This is the `fancy-regex` form, not the Python source: `translate`
+    /// rewrites `\Z` and rejects what Python rejects, so the two differ
+    /// wherever a rewrite applied.
+    ///
+    /// Kept as our own copy rather than read back from the engine. The engine's
+    /// `as_str` is not stable across its own patch releases — `x\z` reads back
+    /// as `x$` on `fancy-regex` 0.16.0 and as `x\z` on 0.16.2 — so forwarding
+    /// to it would put an engine-version-dependent *answer* in this crate's
+    /// public API, which is the same class of leak as putting its types there.
+    /// Found by the `test at the declared dependency floors` CI step (#177).
+    pub fn as_str(&self) -> &str {
+        &self.translated
+    }
+
+    /// Whether the pattern matches anywhere in `haystack`.
+    ///
+    /// `Err` when the backtracking engine gives up on a pathological pattern.
+    /// That is not a match and not a reason to end a run; callers here treat it
+    /// as "no match" and carry on.
+    pub fn is_match(&self, haystack: &str) -> Result<bool, String> {
+        self.inner
+            .is_match(haystack)
+            .map_err(|e| one_line(&e.to_string()))
+    }
+
+    /// The capture groups of the leftmost match, or `None` when there is none.
+    ///
+    /// `Err` carries the same meaning as on [`is_match`](Self::is_match).
+    pub fn captures<'h>(&self, haystack: &'h str) -> Result<Option<PyCaptures<'h>>, String> {
+        // Read the groups out here rather than in a helper taking the engine's
+        // own captures, so that `fancy_regex::Captures` is never *named*. It
+        // gained a second generic parameter in 0.19, and a signature spelling
+        // it would compile against one side of that change only — which is the
+        // trap this whole wrapper exists to remove, and would reintroduce it
+        // one layer down. Inference does not care (#177).
+        let caps = match self.inner.captures(haystack) {
+            Ok(Some(caps)) => caps,
+            Ok(None) => return Ok(None),
+            Err(e) => return Err(one_line(&e.to_string())),
+        };
+        let groups = (0..caps.len())
+            .map(|i| {
+                caps.get(i).map(|m| PyMatch {
+                    text: m.as_str(),
+                    start: m.start(),
+                    end: m.end(),
+                })
+            })
+            .collect();
+        let names = self
+            .inner
+            .capture_names()
+            .map(|n| n.map(str::to_string))
+            .collect();
+        Ok(Some(PyCaptures { groups, names }))
+    }
+
+    /// Every capture group's name in group order, `None` for the unnamed ones.
+    ///
+    /// Group 0 is the whole match and is never named, so the first item is
+    /// always `None`.
+    pub fn capture_names(&self) -> impl Iterator<Item = Option<&str>> + '_ {
+        self.inner.capture_names()
+    }
+}
+
+/// One matched span, borrowed from the haystack it was found in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PyMatch<'h> {
+    text: &'h str,
+    start: usize,
+    end: usize,
+}
+
+impl<'h> PyMatch<'h> {
+    /// The matched text.
+    pub fn as_str(&self) -> &'h str {
+        self.text
+    }
+
+    /// Byte offset where the match starts in the haystack.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Byte offset one past where the match ends.
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    /// The matched span as a byte range.
+    pub fn range(&self) -> std::ops::Range<usize> {
+        self.start..self.end
+    }
+}
+
+/// The capture groups of a single match.
+///
+/// Read eagerly at match time rather than borrowing the engine's own captures,
+/// so nothing here is tied to the shape of a `fancy-regex` type. That is what
+/// lets the requirement on that crate move without it being a break for
+/// consumers (#177).
+#[derive(Debug, Clone)]
+pub struct PyCaptures<'h> {
+    groups: Vec<Option<PyMatch<'h>>>,
+    names: Vec<Option<String>>,
+}
+
+impl<'h> PyCaptures<'h> {
+    /// Group `index`, or `None` when that group did not participate in the
+    /// match. Group 0 is the whole match.
+    pub fn get(&self, index: usize) -> Option<PyMatch<'h>> {
+        self.groups.get(index).copied().flatten()
+    }
+
+    /// The group named `name`, or `None` when it did not participate or the
+    /// pattern has no such group.
+    pub fn name(&self, name: &str) -> Option<PyMatch<'h>> {
+        let index = self.names.iter().position(|n| n.as_deref() == Some(name))?;
+        self.get(index)
+    }
+
+    /// Every *named* group in group order, matched or not.
+    ///
+    /// Python's `groupdict()` carries an unmatched named group as `None` rather
+    /// than dropping it, and so does this — which is what the step detail
+    /// renders.
+    pub fn named(&self) -> impl Iterator<Item = (&str, Option<PyMatch<'h>>)> + '_ {
+        self.names
+            .iter()
+            .enumerate()
+            .filter_map(|(i, n)| n.as_deref().map(|n| (n, self.get(i))))
+    }
+
+    /// The number of groups, counting group 0.
+    pub fn len(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// Whether there are no groups at all.
+    ///
+    /// Never true for a match produced by [`PyRegex::captures`] — group 0
+    /// always exists — but `len` without `is_empty` is a clippy warning and the
+    /// answer is well defined.
+    pub fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+}
+
 /// Compile a pattern written in Python's `re` dialect.
 ///
 /// The error is a single line by construction — constitution Principle VIII
@@ -29,27 +222,11 @@ use fancy_regex::Regex;
 ///
 /// The wording is TermProof's own. Byte-parity with CPython's `re.error` text
 /// is a separate question, open as 001-OQ-001 / 002-OQ-002 / 003-OQ-010.
-///
-/// # Naming the returned type
-///
-/// This returns a [`fancy_regex::Regex`], which is a *third-party* type, so it
-/// is only interchangeable with a `Regex` your own crate names if cargo gave
-/// you both from the same copy of `fancy-regex`. Name it through the
-/// re-export — [`crate::fancy_regex`] — rather than through your own
-/// dependency, and that is true by construction:
-///
-/// ```no_run
-/// let re: termproof::fancy_regex::Regex = termproof::pyregex::compile(r"\d+").unwrap();
-/// assert!(re.is_match("42").unwrap());
-/// ```
-///
-/// Calling methods on the value without naming its type works either way; it is
-/// annotating it, or passing it into a signature of your own, that needs the
-/// copies to agree. See "Dependencies in the public API" in the crate docs
-/// (#177).
-pub fn compile(pattern: &str) -> Result<Regex, String> {
+pub fn compile(pattern: &str) -> Result<PyRegex, String> {
     let translated = translate(pattern)?;
-    Regex::new(&translated).map_err(|e| one_line(&e.to_string()))
+    Regex::new(&translated)
+        .map(|inner| PyRegex { inner, translated })
+        .map_err(|e| one_line(&e.to_string()))
 }
 
 fn one_line(message: &str) -> String {
@@ -297,5 +474,81 @@ mod tests {
             compile("é\\p{L}").unwrap_err(),
             "unsupported escape \\p at position 1"
         );
+    }
+
+    #[test]
+    fn captures_reads_positional_groups_with_group_zero_first() {
+        let re = compile(r"(\w+)@(\w+)").expect("compiles");
+        let caps = re
+            .captures("mail bob@host x")
+            .expect("no engine error")
+            .expect("matches");
+        assert_eq!(caps.len(), 3);
+        assert_eq!(caps.get(0).unwrap().as_str(), "bob@host");
+        assert_eq!(caps.get(1).unwrap().as_str(), "bob");
+        assert_eq!(caps.get(2).unwrap().as_str(), "host");
+        assert!(caps.get(3).is_none());
+    }
+
+    #[test]
+    fn a_match_carries_byte_offsets_into_the_haystack() {
+        let re = compile(r"\d+").expect("compiles");
+        let caps = re
+            .captures("é 42")
+            .expect("no engine error")
+            .expect("matches");
+        let m = caps.get(0).unwrap();
+        // "é" is two bytes, then a space: the digits start at byte 3.
+        assert_eq!(m.start(), 3);
+        assert_eq!(m.end(), 5);
+        assert_eq!(m.range(), 3..5);
+        assert_eq!(m.as_str(), "42");
+    }
+
+    #[test]
+    fn named_carries_an_unmatched_group_rather_than_dropping_it() {
+        // Python's `groupdict()` reports `b` as None rather than omitting it,
+        // and the step detail renders that, so `named` has to agree.
+        let re = compile(r"(?<a>x)|(?<b>y)").expect("compiles");
+        let caps = re.captures("x").expect("no engine error").expect("matches");
+        let seen: Vec<(String, Option<String>)> = caps
+            .named()
+            .map(|(n, m)| (n.to_string(), m.map(|m| m.as_str().to_string())))
+            .collect();
+        assert_eq!(
+            seen,
+            vec![
+                ("a".to_string(), Some("x".to_string())),
+                ("b".to_string(), None),
+            ]
+        );
+        assert_eq!(caps.name("a").unwrap().as_str(), "x");
+        assert!(caps.name("b").is_none());
+        assert!(caps.name("nonexistent").is_none());
+    }
+
+    #[test]
+    fn a_pattern_that_does_not_match_is_none_not_an_error() {
+        let re = compile("zzz").expect("compiles");
+        assert!(re.captures("abc").expect("no engine error").is_none());
+        assert!(!re.is_match("abc").expect("no engine error"));
+    }
+
+    #[test]
+    fn debug_does_not_render_the_engine() {
+        // `fancy-regex`'s own `Debug` prints its parsed pattern, and that
+        // rendering moves across its patch releases (`x$` on 0.16.0 and 0.16.1,
+        // `x\z` on 0.16.2). A derived `Debug` here would publish that. Pinning
+        // the exact string is what makes re-deriving fail rather than pass with
+        // a different answer on a different engine build.
+        let re = compile("x\\Z").expect("compiles");
+        assert_eq!(format!("{re:?}"), r#"PyRegex { translated: "x\\z", .. }"#);
+    }
+
+    #[test]
+    fn as_str_reports_the_translated_pattern_not_the_python_source() {
+        // `\Z` is rewritten to `\z`; that rewrite is why the two differ.
+        let re = compile("x\\Z").expect("compiles");
+        assert_eq!(re.as_str(), "x\\z");
     }
 }

--- a/rust/crates/termproof/src/pyschema.rs
+++ b/rust/crates/termproof/src/pyschema.rs
@@ -28,29 +28,44 @@ use serde_json::Value as JsonValue;
 
 use crate::pyrepr::repr_json;
 
+/// A compiled JSON Schema.
+///
+/// Owns the underlying `jsonschema` validator and does not expose it, for the
+/// reason [`crate::pyregex::PyRegex`] does not expose its engine: a
+/// third-party type in a public signature makes that dependency's version
+/// requirement a source-compatibility surface. See "Dependencies in the public
+/// API" in the crate docs (#177).
+///
+/// There is nothing to read off a compiled schema, so this carries no accessors
+/// — [`validate`] is the whole interface. A caller that wants the validator
+/// itself should depend on `jsonschema` directly and pick its own version; this
+/// crate deliberately does not re-export ours.
+pub struct PySchema {
+    inner: Validator,
+}
+
+impl std::fmt::Debug for PySchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `jsonschema::Validator` is not `Debug`, and the compiled form is not
+        // something a reader could act on anyway.
+        f.debug_struct("PySchema").finish_non_exhaustive()
+    }
+}
+
 /// Compile a schema, or describe why it is not a schema.
 ///
 /// The `Err` is the clause that goes after FR-016's `invalid schema: ` prefix.
-///
-/// # Naming the returned type
-///
-/// This returns a [`jsonschema::Validator`], a *third-party* type, so it is
-/// only the same type as a `Validator` your own crate names when cargo gave you
-/// both from the same copy of `jsonschema`. Name it through the re-export —
-/// [`crate::jsonschema`] — and that holds by construction. See "Dependencies in
-/// the public API" in the crate docs (#177).
-pub fn compile(schema: &JsonValue) -> Result<Validator, String> {
-    jsonschema::validator_for(schema).map_err(|error| describe(&error))
+pub fn compile(schema: &JsonValue) -> Result<PySchema, String> {
+    jsonschema::validator_for(schema)
+        .map(|inner| PySchema { inner })
+        .map_err(|error| describe(&error))
 }
 
 /// Validate `instance`, returning the clause for FR-016's
 /// `schema validation failed` detail plus the dotted instance path FR-017 asks
 /// for, or `None` when the instance is valid.
-///
-/// Takes the [`jsonschema::Validator`] [`compile`] returns, with the same
-/// caveat about which copy of `jsonschema` names the type.
-pub fn validate(validator: &Validator, instance: &JsonValue) -> Option<(String, String)> {
-    let errors: Vec<ValidationError<'_>> = validator.iter_errors(instance).collect();
+pub fn validate(validator: &PySchema, instance: &JsonValue) -> Option<(String, String)> {
+    let errors: Vec<ValidationError<'_>> = validator.inner.iter_errors(instance).collect();
     let best = best_match(&errors)?;
     Some((dotted_path(best.instance_path.as_str()), describe(best)))
 }

--- a/rust/crates/termproof/src/steps.rs
+++ b/rust/crates/termproof/src/steps.rs
@@ -518,7 +518,7 @@ pub fn wait_for_regex<S: Session + ?Sized>(
 }
 
 fn try_match<'t>(
-    re: &fancy_regex::Regex,
+    re: &crate::pyregex::PyRegex,
     pattern_str: &str,
     name: &str,
     screen_text: &'t str,
@@ -527,11 +527,10 @@ fn try_match<'t>(
     // A backtracking engine can give up on a pathological pattern. An engine
     // error is not a match, and it is not a reason to end the run either.
     //
-    // A closure rather than a free function so that `fancy_regex::Captures`
-    // is never named: the type gained a haystack parameter in 0.19, and
-    // writing it either way would pin this crate to one side of that change
-    // for no gain. See the `fancy-regex` note in the workspace manifest.
-    let captures_in = |text: &'t str| {
+    // A closure only to keep the empty-text guard in one place. It used to be
+    // one so that `fancy_regex::Captures` was never named — that type is no
+    // longer what comes back, and `PyCaptures` is ours to name (#177).
+    let captures_in = |text: &'t str| -> Option<crate::pyregex::PyCaptures<'t>> {
         if text.is_empty() {
             return None;
         }
@@ -541,10 +540,9 @@ fn try_match<'t>(
     let full = caps.get(0).map(|m| m.as_str()).unwrap_or("");
     // Python's `groupdict()` carries every named group, matched or not; an
     // unmatched one renders as `None` rather than vanishing from the report.
-    let named: Vec<String> = re
-        .capture_names()
-        .flatten()
-        .map(|n| match caps.name(n) {
+    let named: Vec<String> = caps
+        .named()
+        .map(|(n, m)| match m {
             Some(m) => format!("{n}={}", repr_str(m.as_str())),
             None => format!("{n}=None"),
         })

--- a/rust/crates/termproof/src/terminal/attributed.rs
+++ b/rust/crates/termproof/src/terminal/attributed.rs
@@ -16,26 +16,34 @@
 //!
 //! # Sources
 //!
-//! - [`from_vt100`] — a live [`vt100::Screen`], the usual path.
+//! - [`TerminalScreen::attributed`](crate::terminal::screen::TerminalScreen::attributed)
+//!   — bytes fed to a parser this crate owns. The usual path, and the only
+//!   public one that goes through `vt100`.
 //! - [`attributed_screen_from_ansi_text`] — a captured string that still has
 //!   its escape sequences, e.g. `tmux capture-pane -e`.
 //! - [`attributed_screen_from_text`] — plain text, rendered in default colours.
 //!
+//! `from_vt100`, which took a caller's own live `vt100::Screen`, was public
+//! until 0.4.0 and is now crate-internal. There is no public replacement that
+//! takes one: a caller holding its own parser has to replay the bytes through
+//! `TerminalScreen`. That is a real capability removed, and the reason is in
+//! the note on the function.
+//!
 //! # One fidelity gap, stated plainly
 //!
 //! `vt100` does not model strikethrough, so [`AttributedCell::strikethrough`]
-//! is always `false` on the [`from_vt100`] path. The ANSI-text path parses
+//! is always `false` on the `from_vt100` path. The ANSI-text path parses
 //! SGR 9 and does set it. The field is kept rather than removed because the
 //! SVG renderer honours it and the ANSI path produces it.
 //!
 //! Dim *is* modelled, from `vt100` 0.16 onwards. Note that `vt100` treats
 //! SGR 1 and SGR 2 as one three-valued intensity, so bold and dim are mutually
-//! exclusive on the [`from_vt100`] path; the ANSI-text path carries them as
+//! exclusive on the `from_vt100` path; the ANSI-text path carries them as
 //! independent flags, as `tmux` emits them.
 //!
 //! # Both paths must measure width with one table
 //!
-//! [`from_vt100`] inherits whatever column layout `vt100` chose, and the
+//! `from_vt100` inherits whatever column layout `vt100` chose, and the
 //! ANSI-text path re-derives it with [`cell_width`]. If those two consult
 //! different `unicode-width` majors they disagree about real code points —
 //! U+1FA89 is one column under 0.1 and two under 0.2, and 458 code points
@@ -228,7 +236,7 @@ pub struct AttributedCell {
     pub italic: bool,
     /// SGR 4.
     pub underline: bool,
-    /// SGR 9. Always `false` on the [`from_vt100`] path; see the module docs.
+    /// SGR 9. Always `false` on the `from_vt100` path; see the module docs.
     pub strikethrough: bool,
     /// SGR 7 — foreground and background swap when rendered.
     pub reverse: bool,
@@ -427,16 +435,25 @@ pub fn attributed_screen_from_ansi_text(
 /// The usual path: a session feeds bytes to `vt100`, and this reads the grid
 /// back out with attributes intact.
 ///
-/// # Naming the argument type
+/// Crate-internal since 0.4.0, because [`vt100::Screen`] is a third-party type
+/// in an *argument* position: a `Screen` from a consumer's own `vt100` was only
+/// accepted here when cargo handed both sides one copy, which made the `vt100`
+/// requirement a source-compatibility surface.
 ///
-/// [`vt100::Screen`] is a *third-party* type, so a `Screen` from your own
-/// `vt100` dependency is only accepted here when cargo gave us both from the
-/// same copy. Build it through the re-export — [`crate::vt100`] — and that is
-/// true by construction. If you have text rather than a live parser, the
-/// sibling constructors [`attributed_screen_from_text`] and
-/// [`attributed_screen_from_ansi_text`] take `&str` and raise no such question.
-/// See "Dependencies in the public API" in the crate docs (#177).
-pub fn from_vt100(screen: &vt100::Screen) -> AttributedScreen {
+/// Unlike a return type this could not be wrapped, because the caller is what
+/// builds the argument. **So the capability was removed, not relocated.** A
+/// caller that already holds a live `vt100::Screen` has no public way to turn
+/// it into an [`AttributedScreen`]; it has to replay the bytes through
+/// [`TerminalScreen`](crate::terminal::screen::TerminalScreen), which owns its
+/// own parser, and pay for the second parse. For text rather than a live parser
+/// there are still [`attributed_screen_from_text`] and
+/// [`attributed_screen_from_ansi_text`], which never had the problem.
+///
+/// Keeping it public would have meant keeping the `vt100` requirement in the
+/// API for the one caller shape that supplies its own parser. That trade went
+/// the other way. See "Dependencies in the public API" in the crate docs
+/// (#177).
+pub(crate) fn from_vt100(screen: &vt100::Screen) -> AttributedScreen {
     let (rows, cols) = screen.size();
     let grid = (0..rows)
         .map(|row| {
@@ -879,7 +896,7 @@ fn xterm_256_color(index: u16) -> String {
 ///
 /// "Same table" is a constraint, not a coincidence: the workspace pins
 /// `unicode-width` to the major `vt100` depends on precisely so this agrees
-/// with [`from_vt100`]. See the width-table note in the module docs for what
+/// with `from_vt100`. See the width-table note in the module docs for what
 /// goes wrong when they drift.
 fn cell_width(ch: char) -> u8 {
     match ch.width() {


### PR DESCRIPTION
Diff 2 of 3 for #177. **Breaking.** Rebased onto current `main` now that #184 has merged (`a729c71`); this PR is against `main`.

## What this does

Closes every door a dependency can reach the public API through — not just signatures. Round 1 found two I had left open, and both are fixed here.

| Door | Was | Now |
|---|---|---|
| return type | `pyregex::compile` → `fancy_regex::Regex` | `pyregex::PyRegex` |
| return type | reading a match → `fancy_regex::Captures` / `Match` | `pyregex::PyCaptures` / `pyregex::PyMatch` |
| return type | `pyschema::compile` → `jsonschema::Validator` | `pyschema::PySchema` |
| argument | `from_vt100(&vt100::Screen)` public | crate-internal |
| **re-export** | `pub use fancy_regex`, `jsonschema`, `vt100` | **removed** |
| **trait impl** | `PyRegex`'s derived `Debug` printed the engine | **written out** |

Verified after: no `pub use` of any external crate, no third-party type in any public signature, no derive over a third-party value.

`from_vt100` is the one that **could not** be wrapped: the third-party type is an *argument*, and there is nothing to wrap when the caller constructs it. `TerminalScreen::attributed` was already the public path — it owns its parser and names no `vt100` type — so no capability is lost. (Flagging this explicitly per the instruction to say so rather than quietly defer: it is handled, just not by wrapping.)

`schemars` stays and cannot be wrapped — its derives are on the published types rather than in a signature. The `schema` feature remains the only way out of carrying two.

## Blocking 1 — the re-exports: removed, and here is the reasoning

**Decision: remove all three.** The reviewer leaned that way and asked for reasoning rather than compliance, so:

1. **They were a mitigation for a leak that no longer exists.** Diff 1 added them so a consumer could name *our* copy deterministically while our signatures still handed out `fancy_regex::Regex`. Wrapping the signatures removed the thing they were an escape from. Nothing public now hands out one of those types, so there is no longer anything for a consumer's copy to have to agree with.
2. **Keeping them keeps the version in the API, and #179 breaks through them.** Reproduced on the stack head: `termproof::fancy_regex::Captures<'_, str>` compiled before the narrowing and failed `E0107` after, because 0.16's `Captures` takes one generic parameter and later versions take two. That single fact falsifies the release's central claim.
3. **The cost is zero for any real consumer.** The re-exports landed in #184 today and **have never been in a published release** — crates.io tops out at 0.3.4, and 0.4.0 is unpublished. Removing them before it ships means they never existed publicly. This is not a second breaking change against anything a user can be on.
4. **The escape hatch is not needed for anything that remains.** The only dependency still in the public API is `schemars`, which was never re-exported and cannot be routed around anyway. A caller wanting the raw engine should `cargo add fancy-regex` and pick its own version — which is now *free*, precisely because we hand out none of its types.

After removal the path is gone cleanly: `E0433 cannot find fancy_regex in termproof`, rather than a version-dependent `E0107`.

## Blocking 2 — the derived `Debug`, and the sweep for the rest of the class

`#[derive(Debug)]` on `PyRegex` formatted the private engine, which publishes the engine's own rendering. That varies **inside** the narrowed range, not just across it:

| `fancy-regex` | `as_str()` | `{:?}` before | `{:?}` after |
|---|---|---|---|
| 0.16.0 | `"x\\z"` | `PyRegex { inner: x$, translated: "x\\z" }` | `PyRegex { translated: "x\\z", .. }` |
| 0.16.1 | `"x\\z"` | `PyRegex { inner: x$, translated: "x\\z" }` | `PyRegex { translated: "x\\z", .. }` |
| 0.16.2 | `"x\\z"` | `PyRegex { inner: x\z, translated: "x\\z" }` | `PyRegex { translated: "x\\z", .. }` |

Exactly the defect `as_str` was fixed for, one trait over. `Debug` is now written by hand and does not format `inner`, with a test pinning the exact string so a future re-derive fails rather than passing with a different answer on a different engine build.

**Swept the rest of the class**, since a derive is easy to overlook:

| Type | Holds | Verdict |
|---|---|---|
| `PyRegex` | `fancy_regex::Regex` | **was leaking via derived `Debug`** — fixed |
| `PySchema` | `jsonschema::Validator` | already hand-written `Debug`, `finish_non_exhaustive()` |
| `PyCaptures` / `PyMatch` | only `&str`, `usize`, `String` | derives are safe — no third-party value to reach |
| `PtyError` | — | variants carry `String`; the third-party error is stringified at the boundary |
| `PtySession` | `dyn MasterPty`, `dyn Child` | no derives and no `Debug` impl at all |
| `TerminalScreen` | `vt100::Parser` | hand-written `Debug`; prints dims and contents, not the parser |

No `Display`, `Clone`, `PartialEq`, `Hash`, `Deref`, `AsRef` or serialization reaches an inner third-party value anywhere.

## Bounding what "engine independence" means

The reviewer found `(?<=a+)b` compiles at 0.19 and is rejected at 0.16 — outside the narrowed range, so not a defect, but it does bound the claim. Both the crate docs and the changelog now say exactly what is claimed: the **declared requirement** is no longer a compatibility surface, so a consumer can depend on any `fancy-regex` it likes. It is *not* a claim that the engine is interchangeable — a backtracking engine's accepted language moves between releases, which is why the requirement is pinned to one minor and the differential harnesses are run against it rather than assumed.

## Non-blocking — `from_vt100` did remove a capability

Correct, and the changelog was wrong to say otherwise. Fixed in three places: the changelog now leads with "**removes a capability, and there is no replacement for it**", the function's doc says the capability was removed rather than relocated and that such a caller must replay bytes and pay for a second parse, and the module docs no longer list `from_vt100` under *Sources* or call it "the usual path".

This release is allowed to break things. It is not allowed to break something and say it didn't.

## The catch `cargo semver-checks` found

`fancy_regex::Captures` gained a second generic parameter in 0.19. My first version named it in a private helper, which compiled locally (lockfile 0.16.2) and **failed** under semver-checks, which builds in a fresh project and so resolves to the top of the range.

That is the same trap one layer down, so the type is now never named at all — group extraction is inline and inference does it. The property this buys, verified:

| `fancy-regex` pinned | wrapper builds + `pyregex` tests |
|---|---|
| 0.16.2 | pass |
| 0.17.0 | pass |
| 0.18.0 | pass |
| 0.19.0 | pass |

The requirement can now move without it being a consumer break — which is the entire point, and what makes #179 safe.

## Migration, executed rather than asserted

A consumer written the documented way, **carrying its own newer copies of all three crates**, compiles and runs green:

```rust
let re: termproof::pyregex::PyRegex = termproof::pyregex::compile(r"(?<n>\d+)").unwrap();
let caps: termproof::pyregex::PyCaptures<'_> = re.captures("id 42").unwrap().unwrap();
let v: termproof::pyschema::PySchema = termproof::pyschema::compile(&s).unwrap();
let mut screen = termproof::terminal::screen::TerminalScreen::new(10, 3);  // replaces from_vt100
screen.feed_str("hi");
let _attr = screen.attributed();

// consumer's own, unrelated:  fancy-regex 0.19.0, jsonschema 0.32.1, vt100 0.15.2
```

On 0.3.4 none of those pins compiled against this crate. The changelog carries this table with what to change for each.

`caps.named()` is new: `steps::try_match` was zipping `capture_names()` against `caps.name()` to reproduce Python's `groupdict()`, and that is now one iterator.

## Version: 0.4.0

Bumped with `.github/scripts/rust/version-bump.py`, the one place the train moves (Rust workspace + internal dep versions + `pyproject.toml` + changelog promotion + `cargo update -w`).

This is not optional bookkeeping: `cargo semver-checks check-release` runs against the published 0.3.4 on **every PR**, so without the bump this PR is red. It reports `0.3.4 -> 0.4.0 (major change)`, `no semver update required`. **No tag** — the release cut is a separate decision.

## The manifest promise

`rust/Cargo.toml` promised "Releases here bump the patch digit only." That was a description of what had happened, not a rule, and 0.4.0 makes it false. Replaced with the real rule from `rust/docs/publishing.md` — pre-1.0, breaking is a minor bump — which leaves the `schemars` hold standing on reason 2, the one that does not depend on a version digit.

## The version bump reaching every file

First push was red on four jobs, all the same step, and the guard was right both times:

- **`SECURITY.md` had no `0.4.x` supported row.** Added. `0.3.x` keeps its tick beside it, because the train moves *before* the release that puts it on the registries — for that window the newest published artifact is still a `0.3.x` one. The "published through `0.3.4`" rows below are statements about PyPI and crates.io rather than about the manifest, and are deliberately left alone; `test_current_version_claims.py` is built to allow exactly that lag.
- **`test_current_version_claims.py` saw two current versions.** Two of my new sentences paired "so far" with `0.4.0`, and the guard reads a comment as a claim — correctly. Neither sentence meant to claim what is published, so both now say "this release" instead of naming a number.

`.github/scripts/rust/version-bump.py` moves the four places it owns; `SECURITY.md` is not one of them, which is what the guard exists to catch.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check --all` | pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --workspace` | 24 binaries, 0 failed |
| All 16 feature combinations | 16/16 pass |
| `cargo semver-checks check-release -p termproof` | pass (major change, correctly versioned) |
| Wrapper at fancy-regex 0.16.2 / 0.17.0 / 0.18.0 / 0.19.0 | 4/4 build + pass |
| Differential harnesses | unchanged: steps 82/115 and 113/115, assertions 124/147 and 143/147 |
| `cargo deny check` | `advisories ok, bans ok, licenses ok, sources ok` |
| `cargo package` + `verify-package-contents.sh` | pass, 75 files |
| `cargo publish --dry-run` | pass |
| `python/scripts/check_version.py` | `0.4.0 consistent` |
| `cargo doc --all-features` | no new warnings |
| `python -m unittest discover -s tests` | 741 tests, OK |
| `python/scripts/check_version.py` | `0.4.0 consistent` |
| Migration consumer above | compiles and runs (no re-exports needed) |
| `termproof::fancy_regex::*` reachable? | no — `E0433`, path removed |
| Public API leak re-sweep | no `pub use` of an external crate, no third-party type in a signature, no derive over one |

New unit tests cover group-zero ordering, byte offsets into the haystack, `named()` carrying an unmatched group as `None` (the `groupdict()` behaviour), no-match vs engine-error, and `as_str` reporting the translated pattern.

## Stack

1. ~~#184~~ — re-exports + docs (merged, `a729c71`)
2. **this PR** — wrap the leaked types + 0.4.0 (breaking)
3. #179 — narrow `fancy-regex` to `^0.16`, rebased onto this

## One more leak the floor step caught

`PyRegex::as_str` originally forwarded to the engine's `as_str`. That is not stable across `fancy-regex` *patch* releases — `x\z` reads back as `x$` on 0.16.0 and as `x\z` on 0.16.2 — so it would have put an engine-version-dependent *answer* in the public API: the same class of leak as a leaked type, in behavioural rather than type form.

It only surfaces once #179 retargets the floor pin from `=0.16.2` to `=0.16.0`, but the defect is in the code this PR adds, so it is fixed here rather than there. `as_str` now returns our own copy of the translated string, which is what its documentation always said it was.
