### PR TITLE
api: additive seams for an imperative consumer — capture_text, recordings, Selectable, Comparable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,29 @@ between releases, and `(?<=a+)b` is rejected at 0.16 and accepted at 0.19 —
 which is why the requirement is pinned to one minor and the differential
 harnesses are run against it rather than assumed.
 
+- **`select`, `select_names`, `compute_deltas` and `build_before_after` are
+  generic.** Each took a concrete slice and read two or three fields of it;
+  each now takes `R: Selectable` or `R: Comparable`. Every call that names its
+  element type compiles unchanged and resolves to the same types it did before,
+  and `BeforeAfterResult` on its own still means `BeforeAfterResult<RunResult>`
+  — verified by compiling a consumer that names the bare type in a struct
+  field, a return position, an argument, a `let` annotation, a struct literal
+  and nested inside another generic.
+
+  **What breaks:** a call that passed an untyped empty literal, as in
+  `compute_deltas(&[], &[])` or `select_names(&[], &[], &cfg)`. The element
+  type used to be fixed by the signature and is now inferred, and an empty
+  literal gives inference nothing to work with. Annotate the slice —
+  `compute_deltas(&[] as &[RunResult], …)` — or pass a typed binding. There are
+  no such calls in this repository.
+
+  Rust has no default type parameter for a function, so no arrangement of
+  defaults avoids this; `cargo semver-checks` reports it as
+  `function_requires_different_generic_type_params` and asks for a major bump,
+  which under this project's pre-1.0 rule is the minor digit. It therefore
+  belongs in the same breaking release as the wrapping above rather than asking
+  for a second one.
+
 ### Rust — Docs
 
 - **The crate docs used to claim `schemars` was the only dependency reaching
@@ -231,6 +254,13 @@ harnesses are run against it rather than assumed.
   the schema too. `load_recipe_schema()` lost its `docs/` fallback, which
   existed only because the resource was conditional (#174).
 
+- **A published step's `step-NN.txt` no longer gains a trailing newline.** The
+  screen is written verbatim, as the Rust implementation writes it. Found by
+  running both implementations over one scenario and diffing what they wrote:
+  the manifests agreed byte-for-byte and four of the files they pointed at did
+  not. Only reachable through `termproof.collector`, which is new in the same
+  release, so no published artifact changes shape.
+
 ### Rust — Fixed
 
 - `schema::load_canonical_schema` returns the canonical schema for every
@@ -250,6 +280,45 @@ harnesses are run against it rather than assumed.
   in 0.3.4 because it read outside the crate; it no longer does, so the seam is
   testable from the artifact that is published — including the decoy-directory
   regression (#174).
+
+- **`EvidenceCollector::capture_text`** records a screen the caller already
+  holds. `capture` and `capture_failure` pull from a `ScreenSource`, which
+  presumes something live to pull from; text recovered from a log, the screen a
+  step returned before the session moved on, or a golden file in a test arrives
+  no other way, and recording one meant writing a throwaway `ScreenSource`
+  whose only job was to hand back a string. It is a step like any other — same
+  sequence, same index, same filename scheme — so the manifest does not develop
+  a gap where one was taken. No raw output log is attached even for
+  `CaptureKind::Failure`: there is no source to ask for one.
+
+- **`Recording`, `EvidenceCollector::attach_recording` and
+  `EvidenceCollector::recordings`** carry whole-session recordings into the
+  manifest. A collector's captures are instants; a run also produces a span —
+  the terminal recording and whatever video was encoded from it — and a caller
+  keeping both had to write a second document beside the manifest and join them
+  by convention. The collector does not *produce* recordings: encoding a cast
+  is a tool-shelling job with its own failure modes and its own choice of tool.
+  One `error` field rather than separate conversion and upload errors, because
+  a conversion that failed leaves nothing to upload. `recordings` is
+  `skip_serializing_if = "Vec::is_empty"`, so a run that records nothing writes
+  byte-for-byte the document it wrote before — which is why
+  `EVIDENCE_MANIFEST_VERSION` does not move, and it is asserted by a test.
+
+- **`selection::Selectable` and `before_after::Comparable`** let both modules
+  work on results that are not this crate's. A suite whose recipes branch on
+  what the screen shows cannot be expressed as a declarative `Recipe`, but it
+  has names and `ci_paths` and still has the problem of running everything on
+  every change; a caller whose results carry fields this crate does not model
+  had to convert to a `RunResult` and back to ask whether anything flipped,
+  losing those fields on the way. One accessor per field actually read.
+  `(String, Vec<String>)` implements `Selectable` too, so a caller can ask the
+  question without writing an impl — that pairing is what the Python
+  implementation's `select_names` has always taken.
+
+  No third-party type appears in any of this. `Recording` holds `String` and
+  `Option<String>` and derives nothing that reaches past them; `Selectable` and
+  `Comparable` are generic over the caller's own types and their accessors
+  return `&str`, `&[String]` and `bool`.
 
 ### Changed
 
@@ -309,6 +378,31 @@ harnesses are run against it rather than assumed.
   text and grid together, and `termproof.builtin_steps.step_result` for step
   actions that want the same. The grid is read first and the text derived from
   it, so `steps/NN.txt` and `steps/NN.svg` cannot describe different instants.
+
+- **`termproof.collector`** — the evidence collector Rust has had since the
+  consolidation. `termproof.evidence` renders whatever a finished `RunResult`
+  happens to carry, which is enough for a declarative recipe where the runner
+  knows every step before it starts. A caller driving a session imperatively
+  decides *while running* which moments are worth keeping, and had nowhere to
+  put them. `capture`, `capture_failure`, `capture_text`, `attach_recording`
+  and a `publish` that writes text, renders, dedupes, uploads and emits
+  `evidence.json`. Mirrored deliberately down to the manifest field names and
+  the `step-NN-label` filename scheme, so the two implementations produce one
+  document format.
+
+  The two modules are not layered on one another and answer different
+  questions; the module docstring now carries a table of which is for what, and
+  why consolidating them is a separate change with its own compatibility
+  question — `render_artifacts`'s file layout is what every existing reader of
+  a run directory depends on.
+
+- **`EvidenceManifest.attach_to`** joins a manifest to a `RunResult` and
+  refuses one belonging to a different run. Evidence sits beside the result
+  rather than inside it, so nothing about the file layout stops a caller
+  pairing run A's evidence with run B's result. Rust has had this; Python's
+  `RunResult` carries the same `recipe_name`, `renderer` and `artifacts`
+  contract, so it behaves identically apart from raising `ValueError` where
+  Rust returns `Err`.
 
 ### Python — Fixed
 
@@ -381,6 +475,22 @@ harnesses are run against it rather than assumed.
   workflows now declare a `timeout-minutes`, and `test_ci_timeouts.py` fails if
   a new one does not. Affects CI only; neither published artifact changes.
   ([#183](https://github.com/md-mt/termproof/issues/183))
+
+### Testing
+
+- **A third differential harness, for the evidence manifest.**
+  `conformance/probe_evidence_manifest.py` drives the Python collector over a
+  fixed scenario and records the published `evidence.json` together with the
+  contents of every file it wrote;
+  `crates/termproof/tests/differential_evidence_manifest.rs` builds the same
+  scenario through the Rust collector and compares the whole recording.
+
+  It replaces a Python unit test that asserted the manifest key set by spelling
+  the Rust field names out — a list derived by reading the Rust structs rather
+  than by running them, which could only ever catch a rename on the Python
+  side. The files are compared as well as the document because a manifest is a
+  set of paths, and agreeing on paths is not agreeing on files: that is what
+  caught the trailing newline above.
 
 ## [0.3.4] — 2026-08-17
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -7,6 +7,7 @@ per layer, each the same two-half shape:
 |---|---|---|---|
 | Steps | `probe_steps.py` | `tests/differential_steps.rs` | `corpus/cases.json` |
 | Assertions | `probe_assertions.py` | `tests/differential_assertions.rs` | `corpus/assertion_cases.json` |
+| Evidence manifest | `probe_evidence_manifest.py` | `tests/differential_evidence_manifest.rs` | `corpus/evidence_manifest.expected.json` |
 
 They exist because the port claimed corpus parity several times over with green
 local gates, and a differential run against the Python implementation still
@@ -359,3 +360,80 @@ with the error. It only ever separates two non-`type` errors under differently
 typed subschemas, and no corpus case exercises that, but it is an approximation
 rather than a transcription. FR-017's selection is a library heuristic either
 way, which 003-OQ-010 says explicitly.
+
+# Evidence manifest
+
+A third harness, same two-half shape, for the document
+`EvidenceCollector::publish` writes.
+
+## Shape
+
+| Half | Where | What it does |
+|---|---|---|
+| Oracle | `probe_evidence_manifest.py` | Drives the Python collector over a fixed scenario and records the published `evidence.json` **and the contents of every file it wrote** into `corpus/evidence_manifest.expected.json`. |
+| Port | `crates/termproof/tests/differential_evidence_manifest.rs` | Builds the same scenario through the Rust collector and compares the whole recording. |
+
+Unlike the other two, there is no corpus of cases: one document shape is built
+by calling an API rather than by replaying data, so the scenario **is** the code
+in each half and the two are transcriptions of one another. They are short and
+commented line-for-line; keep them in step.
+
+## Why it exists
+
+`termproof.collector` was written to mirror `termproof::evidence::collector`
+field for field, and the mirror was checked by a Python unit test that spelled
+the Rust field names out — a list derived by *reading* the Rust structs, never
+by running them. That can catch a rename on the Python side and nothing else:
+not a rename on the Rust side, not a field added to one implementation and not
+the other, not a value the two spell differently.
+
+Running both and diffing found the claim was very nearly true. Every manifest
+key, every value, the `step-NN-label` filename scheme, the dedup verdict and
+its `same_as` back-reference, the `kind` spelling, the recordings and their
+omission when empty — all identical. One thing was not: **Python appended a
+trailing newline to each `step-NN.txt` and Rust wrote the screen verbatim.**
+Four files differed under manifests that agreed byte-for-byte.
+
+That is why this harness compares the written files and not just the document.
+A manifest is a set of paths, and agreeing on paths is not agreeing on files.
+Python was changed to match Rust, which writes what an assertion was actually
+evaluated against with nothing added to it.
+
+## What is deliberately neutralised
+
+Two things in the scenario are properties of the machine rather than of either
+implementation, and both halves handle them the same way:
+
+- **The rasteriser.** `ScreenshotRenderer` shells out to `rsvg-convert`, so on a
+  host without it every step would record a render error whose text belongs to
+  the operating system. Both halves stub the tool and write a fixed byte, so a
+  screenshot is recorded on every host.
+- **The publish directory**, which is a fresh temporary directory. Both halves
+  substitute it for `@DIR` before comparing.
+
+Nothing else is normalised. In particular the file *contents* are compared
+literally, which is the check that found the divergence above.
+
+## Regenerating the expectations
+
+```sh
+cd /path/to/termproof/python
+TERMPROOF_PYTHON_REPO=$PWD uv run python \
+    ../conformance/probe_evidence_manifest.py \
+    > ../conformance/corpus/evidence_manifest.expected.json
+```
+
+Only regenerate deliberately: the file is the oracle's testimony, and quietly
+re-recording it turns a failing comparison into a passing one without changing
+any behaviour. If the Rust half is the one that changed, fix the Rust half.
+
+## Reading the result
+
+```sh
+cargo test -p termproof --test differential_evidence_manifest
+```
+
+Pass or fail, with the two documents printed on failure. There is no agreement
+ratchet here as there is for steps and assertions: the two implementations
+either write the same document or they do not, and a partial score for a file
+format is not a useful number.

--- a/conformance/corpus/evidence_manifest.expected.json
+++ b/conformance/corpus/evidence_manifest.expected.json
@@ -1,0 +1,124 @@
+{
+  "files": {
+    "step-00-menu-open.png": "png",
+    "step-00-menu-open.txt": "MENU\nitem one",
+    "step-01-menu-open-again.txt": "MENU\nitem one",
+    "step-02-from-log.png": "png",
+    "step-02-from-log.txt": "RECOVERED",
+    "step-03-post-mortem.png": "png",
+    "step-03-post-mortem.txt": "LAST SCREEN",
+    "step-04-boom-raw.txt": "log bytes",
+    "step-04-boom.png": "png",
+    "step-04-boom.txt": "ERROR",
+    "step-05-styled.png": "png",
+    "step-05-styled.txt": "\u001b[31mALERT\u001b[0m",
+    "step-06-unstyled.png": "png",
+    "step-06-unstyled.txt": "ALERT"
+  },
+  "manifest": {
+    "manifest_version": 1,
+    "recordings": [
+      {
+        "cast": "/tmp/session.cast",
+        "error": null,
+        "label": "full-session",
+        "url": "https://example.invalid/session.mp4",
+        "video": "/tmp/session.mp4"
+      },
+      {
+        "cast": "/tmp/broken.cast",
+        "error": "video conversion failed",
+        "label": "failed-encode",
+        "url": null,
+        "video": null
+      }
+    ],
+    "run": {
+      "recipe_name": "login",
+      "renderer": "default",
+      "run_id": "20240101-000000-000000-login-default-1"
+    },
+    "steps": [
+      {
+        "error": null,
+        "index": 0,
+        "kind": "checkpoint",
+        "label": "menu-open",
+        "raw_output": null,
+        "same_as": null,
+        "screen_text": "@DIR/step-00-menu-open.txt",
+        "screenshot": "@DIR/step-00-menu-open.png",
+        "url": "https://example.invalid/step-00-menu-open.png"
+      },
+      {
+        "error": null,
+        "index": 1,
+        "kind": "checkpoint",
+        "label": "menu-open-again",
+        "raw_output": null,
+        "same_as": {
+          "index": 0,
+          "label": "menu-open"
+        },
+        "screen_text": "@DIR/step-01-menu-open-again.txt",
+        "screenshot": "@DIR/step-00-menu-open.png",
+        "url": "https://example.invalid/step-00-menu-open.png"
+      },
+      {
+        "error": null,
+        "index": 2,
+        "kind": "checkpoint",
+        "label": "from-log",
+        "raw_output": null,
+        "same_as": null,
+        "screen_text": "@DIR/step-02-from-log.txt",
+        "screenshot": "@DIR/step-02-from-log.png",
+        "url": "https://example.invalid/step-02-from-log.png"
+      },
+      {
+        "error": null,
+        "index": 3,
+        "kind": "failure",
+        "label": "post-mortem",
+        "raw_output": null,
+        "same_as": null,
+        "screen_text": "@DIR/step-03-post-mortem.txt",
+        "screenshot": "@DIR/step-03-post-mortem.png",
+        "url": "https://example.invalid/step-03-post-mortem.png"
+      },
+      {
+        "error": null,
+        "index": 4,
+        "kind": "failure",
+        "label": "boom",
+        "raw_output": "@DIR/step-04-boom-raw.txt",
+        "same_as": null,
+        "screen_text": "@DIR/step-04-boom.txt",
+        "screenshot": "@DIR/step-04-boom.png",
+        "url": "https://example.invalid/step-04-boom.png"
+      },
+      {
+        "error": null,
+        "index": 5,
+        "kind": "checkpoint",
+        "label": "styled",
+        "raw_output": null,
+        "same_as": null,
+        "screen_text": "@DIR/step-05-styled.txt",
+        "screenshot": "@DIR/step-05-styled.png",
+        "url": "https://example.invalid/step-05-styled.png"
+      },
+      {
+        "error": null,
+        "index": 6,
+        "kind": "checkpoint",
+        "label": "unstyled",
+        "raw_output": null,
+        "same_as": null,
+        "screen_text": "@DIR/step-06-unstyled.txt",
+        "screenshot": "@DIR/step-06-unstyled.png",
+        "url": "https://example.invalid/step-06-unstyled.png"
+      }
+    ]
+  }
+}

--- a/conformance/probe_evidence_manifest.py
+++ b/conformance/probe_evidence_manifest.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Oracle half of the evidence-manifest differential harness.
+
+Drives the Python :class:`termproof.collector.EvidenceCollector` over the
+scenario below and writes to stdout both halves of what a publish produces:
+the ``evidence.json`` document, and the contents of every file it wrote. The
+publish directory is substituted out so the result is comparable across
+machines.
+
+Both halves, because the manifest is a set of paths and agreeing on the paths
+is not agreeing on the files. The first run of this harness found the two
+implementations writing byte-identical manifests pointing at step text files
+that differed by a trailing newline.
+
+The scenario is not a corpus file, unlike the step and assertion harnesses.
+There is only one document shape to compare and it is built by calling an API
+rather than by replaying data, so the cases are the code below and the Rust
+half transcribes them. Keep the two in step: ``differential_evidence_manifest``
+compares byte-for-byte and will say so if they drift.
+
+Regenerate deliberately::
+
+    cd /path/to/termproof/python
+    TERMPROOF_PYTHON_REPO=$PWD uv run python \\
+        ../conformance/probe_evidence_manifest.py \\
+        > ../conformance/corpus/evidence_manifest.expected.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.environ.get("TERMPROOF_PYTHON_REPO", str(Path(__file__).parent.parent / "python")))
+
+from termproof.attributed import AttributedScreen  # noqa: E402
+from termproof.collector import (  # noqa: E402
+    MANIFEST_FILE,
+    CaptureKind,
+    EvidenceCollector,
+    EvidencePublisher,
+    Recording,
+    RunIdentity,
+    static_source,
+)
+
+#: Stands in for the publish directory, which differs on every machine and
+#: between the two halves.
+DIRECTORY_PLACEHOLDER = "@DIR"
+
+IDENTITY = RunIdentity(
+    recipe_name="login",
+    renderer="default",
+    run_id="20240101-000000-000000-login-default-1",
+)
+
+
+class _StubRenderer:
+    """A renderer that writes a fixed byte and reports success.
+
+    The real rasteriser shells out to ``rsvg-convert``, whose presence and
+    version are properties of the machine rather than of either implementation.
+    Both halves stub it identically so the manifest records a rendered
+    screenshot on every host.
+    """
+
+    extension = "png"
+
+    def render_attributed(
+        self, screen: AttributedScreen, output_path: Path, cols: int, rows: int
+    ) -> None:
+        output_path.write_bytes(b"png")
+
+
+class _StubUploader:
+    """Returns a deterministic URL derived from the filename."""
+
+    def upload(self, path: Path) -> str | None:
+        return f"https://example.invalid/{path.name}"
+
+
+def build(directory: Path) -> tuple[dict[str, object], dict[str, str]]:
+    collector = EvidenceCollector()
+
+    # A plain checkpoint read from a source.
+    collector.capture("menu-open", static_source("MENU\nitem one"))
+    # The same screen again: dedup, so `same_as` points back at step 0 and no
+    # second image is written.
+    collector.capture("menu-open-again", static_source("MENU\nitem one"))
+    # A screen the caller already held, with no source to read it from.
+    collector.capture_text("from-log", "RECOVERED", CaptureKind.CHECKPOINT)
+    # A text capture marked as a failure still carries no raw output: there is
+    # no source to ask for one.
+    collector.capture_text("post-mortem", "LAST SCREEN", CaptureKind.FAILURE)
+    # A failure read from a source does carry the log.
+    collector.capture_failure("boom", static_source("ERROR", raw_output="log bytes"))
+    # Two screens whose text differs only by SGR escapes. Both sides build the
+    # grid for a text capture from plain lines rather than by parsing ANSI, so
+    # whether these dedupe together is a statement about that choice — and one
+    # the two implementations have to make the same way, since the dedup
+    # verdict reaches the manifest.
+    collector.capture_text("styled", "\x1b[31mALERT\x1b[0m", CaptureKind.CHECKPOINT)
+    collector.capture_text("unstyled", "ALERT", CaptureKind.CHECKPOINT)
+
+    collector.attach_recording(
+        Recording(
+            label="full-session",
+            cast="/tmp/session.cast",
+            video="/tmp/session.mp4",
+            url="https://example.invalid/session.mp4",
+        )
+    )
+    collector.attach_recording(
+        Recording(
+            label="failed-encode",
+            cast="/tmp/broken.cast",
+            error="video conversion failed",
+        )
+    )
+
+    manifest = collector.publish(
+        EvidencePublisher(
+            directory=directory,
+            identity=IDENTITY,
+            renderer=_StubRenderer(),
+            uploader=_StubUploader(),
+        )
+    )
+    document = json.loads(manifest.path.read_text(encoding="utf-8"))
+    # `evidence.json` is excluded: it is `document`, and recording it twice
+    # would let the two copies disagree.
+    files = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in sorted(directory.iterdir())
+        if path.is_file() and path.name != MANIFEST_FILE
+    }
+    return document, files
+
+
+def normalize(document: object, directory: Path) -> object:
+    """Replace the publish directory with :data:`DIRECTORY_PLACEHOLDER`."""
+    prefix = str(directory)
+    if isinstance(document, dict):
+        return {k: normalize(v, directory) for k, v in document.items()}
+    if isinstance(document, list):
+        return [normalize(v, directory) for v in document]
+    if isinstance(document, str):
+        return document.replace(prefix, DIRECTORY_PLACEHOLDER)
+    return document
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        directory = Path(tmpdir) / "evidence"
+        manifest, files = build(directory)
+        recorded = normalize({"manifest": manifest, "files": files}, directory)
+    json.dump(recorded, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/termproof/collector.py
+++ b/python/termproof/collector.py
@@ -11,23 +11,59 @@ worth keeping, and had nowhere to put them.
 
 The shape mirrors ``termproof::evidence::collector`` deliberately, down to the
 field names in the manifest, so that the two implementations produce documents
-a single reader can consume. See ``spec/`` for what is guaranteed to match.
+a single reader can consume. ``conformance/probe_evidence_manifest.py`` and
+``differential_evidence_manifest.rs`` compare the two whole, manifest and
+written files both; see ``spec/`` for what is guaranteed to match.
 
 Needs a renderer for images. Text is written regardless of whether one is
 available, because the text is what an assertion was evaluated against and a
 picture cannot answer that question.
+
+.. _collector-versus-evidence:
+
+Which of this and :mod:`termproof.evidence` to use
+--------------------------------------------------
+
+Both render screens and both dedupe them, and they are **not** layered on one
+another. They answer different questions and produce different documents, so
+the split is deliberate rather than pending cleanup:
+
+===============  =================================  ===============================
+                 :mod:`termproof.evidence`          this module
+===============  =================================  ===============================
+Driven by        a finished :class:`RunResult`      a caller, while it runs
+Step list        the recipe's, fixed in advance     whatever the caller captured
+Writes           ``final.*``, ``steps/``,           ``step-NN-label.*`` and
+                 ``steps-manifest.json``, video     ``evidence.json``
+Dedup fingerprint the step's grid, or one parsed    the grid the source reported,
+                 from its ANSI text                 or one built from plain lines
+Dedup records    ``unchanged_from_previous``        ``same_as: {index, label}``
+Dedup is         off unless configured              always on
+A render failure fails the run                      is recorded on the step
+Rust counterpart ``evidence::report``               ``evidence::collector``
+===============  =================================  ===============================
+
+Use :mod:`termproof.evidence` for a declarative recipe run by
+:class:`~termproof.runner.TermProofRunner` — that is what it is wired into. Use
+this module when the caller decides what to capture as it goes, which a
+declarative recipe cannot express.
+
+Consolidating the two would mean changing the file layout
+:func:`termproof.evidence.render_artifacts` has always written, which every
+existing reader of a run directory depends on. That is a separate change with
+its own compatibility question, not a tidy-up to fold in here.
 """
 
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Protocol
 
 from .attributed import DEFAULT_COLUMNS, DEFAULT_ROWS, AttributedScreen, attributed_screen_from_lines
+from .models import RunResult
 
 #: Schema version of the published manifest. Shared with the Rust
 #: implementation; move the two together or not at all.
@@ -146,8 +182,17 @@ class RunIdentity:
     notice.
     """
 
+    #: Recipe this evidence came from; matches :attr:`RunResult.recipe_name`.
     recipe_name: str
+    #: Renderer this evidence came from; matches :attr:`RunResult.renderer`.
     renderer: str
+    #: Identifier for this run in particular.
+    #:
+    #: Recipe and renderer separate two different runs; they do not separate two
+    #: runs of the *same* recipe. :class:`~termproof.models.RunResult` has no
+    #: field to check this against, so it is recorded rather than verified: a
+    #: reader holding a run directory can compare it, and two manifests can be
+    #: told apart.
     run_id: str
 
     def to_dict(self) -> dict[str, str]:
@@ -156,6 +201,14 @@ class RunIdentity:
             "renderer": self.renderer,
             "run_id": self.run_id,
         }
+
+    def matches(self, result: RunResult) -> bool:
+        """Whether ``result`` is the run this identity describes.
+
+        Compares what the two documents share. See :attr:`run_id` for what this
+        cannot rule out.
+        """
+        return self.recipe_name == result.recipe_name and self.renderer == result.renderer
 
 
 class ScreenshotRendererLike(Protocol):
@@ -265,12 +318,34 @@ class EvidenceManifest:
     def to_json_pretty(self) -> str:
         return json.dumps(self.to_dict(), indent=2) + "\n"
 
+    def attach_to(self, result: RunResult) -> None:
+        """Point ``result`` at this manifest, refusing another run's.
+
+        Evidence sits beside the result rather than inside it, so nothing about
+        the file layout stops a caller pairing run A's evidence with run B's
+        result. This is the seam that notices — the same contract as the Rust
+        ``EvidenceManifest::attach_to``, which returns an error where this
+        raises.
+
+        :raises ValueError: if the manifest belongs to a different run.
+        """
+        if not self.run.matches(result):
+            raise ValueError(
+                f"evidence for {self.run.recipe_name}/{self.run.renderer} cannot be "
+                f"attached to a result for {result.recipe_name}/{result.renderer}"
+            )
+        result.artifacts.update(self.artifacts())
+
     def artifacts(self) -> dict[str, str]:
         """One entry pointing at this manifest, not one per step.
 
-        The manifest is the index; a caller wanting per-step paths reads it,
-        rather than having them duplicated into a flat map with no way to
-        express order.
+        Prefer :meth:`attach_to`, which will not pair a manifest with a result
+        from another run. This is for callers building an index that is not a
+        :class:`~termproof.models.RunResult`.
+
+        One entry, not one per step: the manifest is the index, and a caller
+        that wants the per-step paths reads it rather than having them
+        duplicated into a flat map that has no way to express order.
         """
         return {"evidence_manifest": str(self.path)}
 
@@ -465,8 +540,6 @@ def static_source(screen: str, raw_output: str = "") -> ScreenSource:
 
     return _Static()
 
-
-ToolRunnerLike = Callable[[str, list[str], int], None]
 
 __all__ = [
     "EVIDENCE_MANIFEST_VERSION",

--- a/python/termproof/collector.py
+++ b/python/termproof/collector.py
@@ -1,0 +1,487 @@
+"""An ordered, labelled record of what the screen looked like during a run.
+
+The Rust implementation has had this since it was consolidated into this
+repository; the Python side had only the module-level helpers in
+:mod:`termproof.evidence`, which render whatever a completed
+:class:`~termproof.models.RunResult` happens to carry. That is enough for a
+declarative recipe, where the runner knows every step in advance. It is not
+enough for a caller driving a session imperatively — branching on what the
+screen shows — because such a caller decides *while running* which moments are
+worth keeping, and had nowhere to put them.
+
+The shape mirrors ``termproof::evidence::collector`` deliberately, down to the
+field names in the manifest, so that the two implementations produce documents
+a single reader can consume. See ``spec/`` for what is guaranteed to match.
+
+Needs a renderer for images. Text is written regardless of whether one is
+available, because the text is what an assertion was evaluated against and a
+picture cannot answer that question.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Protocol
+
+from .attributed import DEFAULT_COLUMNS, DEFAULT_ROWS, AttributedScreen, attributed_screen_from_lines
+
+#: Schema version of the published manifest. Shared with the Rust
+#: implementation; move the two together or not at all.
+EVIDENCE_MANIFEST_VERSION = 1
+
+#: Manifest filename written into the publish directory.
+MANIFEST_FILE = "evidence.json"
+
+#: Longest label fragment allowed in a generated filename.
+MAX_LABEL_IN_FILENAME = 40
+
+
+class RawOutput(Enum):
+    """Whether a capture should carry the cumulative output log with it."""
+
+    #: Include it — the caller is recording a failure.
+    KEEP = "keep"
+    #: Leave it out. The log is cumulative, so a copy per checkpoint is
+    #: quadratic and every copy but the last is a prefix of a later one.
+    SKIP = "skip"
+
+
+class CaptureKind(Enum):
+    """Why a step was captured."""
+
+    CHECKPOINT = "checkpoint"
+    FAILURE = "failure"
+
+    def raw_output(self) -> RawOutput:
+        return RawOutput.KEEP if self is CaptureKind.FAILURE else RawOutput.SKIP
+
+
+@dataclass(frozen=True)
+class ScreenCapture:
+    """One self-consistent reading of a screen."""
+
+    #: Screen text at the captured instant.
+    screen: str
+    #: The grid at the same instant, when the source has attributes to report.
+    attributed: AttributedScreen | None = None
+    #: The cumulative output log, when :attr:`RawOutput.KEEP` was asked for.
+    raw_output: str | None = None
+
+
+class ScreenSource(Protocol):
+    """Something a collector can read a screen from.
+
+    One method, not three, for the reason the Rust docstring gives at length:
+    text, grid and raw log have to describe the same moment, and against a live
+    program they will not if they are fetched separately. A pty session serves
+    its text from the last sync point while its grid is read live; a tmux
+    backend re-runs ``capture-pane`` as a side effect of being asked for the
+    grid. Fetched one at a time the result is a manifest that validates and
+    lies — ``step-NN.txt`` describing the screen before an action while
+    ``step-NN.png`` describes the screen after it.
+    """
+
+    def capture_screen(self, raw: RawOutput) -> ScreenCapture: ...
+
+
+@dataclass
+class CapturedStep:
+    """One captured screen, in capture order."""
+
+    #: Position in capture order, zero-based. Filenames use the same number.
+    index: int
+    #: Caller-supplied label.
+    label: str
+    #: Why it was captured.
+    kind: CaptureKind
+    #: Screen text at capture time.
+    screen: str
+    #: The grid at capture time, synthesised from the text when the source had
+    #: no attributed screen of its own.
+    attributed: AttributedScreen
+    #: Cumulative output log, kept for :attr:`CaptureKind.FAILURE` only.
+    raw_output: str | None = None
+
+    def file_stem(self) -> str:
+        """Filename stem shared by this step's artifacts."""
+        return f"step-{self.index:02d}-{_sanitize(self.label[:MAX_LABEL_IN_FILENAME])}"
+
+
+@dataclass
+class Recording:
+    """A recording of a whole session, as against one screen out of it.
+
+    ``error`` is one field rather than separate conversion and upload errors:
+    they are mutually exclusive, since a conversion that failed leaves nothing
+    to upload.
+    """
+
+    label: str
+    cast: str
+    video: str | None = None
+    url: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "label": self.label,
+            "cast": self.cast,
+            "video": self.video,
+            "url": self.url,
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class RunIdentity:
+    """Which run a manifest belongs to.
+
+    Evidence sits beside the result rather than inside it, so nothing about the
+    file layout stops a caller pointing run A's result at run B's evidence.
+    This is what lets a reader — and :meth:`EvidenceManifest.attach_to` —
+    notice.
+    """
+
+    recipe_name: str
+    renderer: str
+    run_id: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "recipe_name": self.recipe_name,
+            "renderer": self.renderer,
+            "run_id": self.run_id,
+        }
+
+
+class ScreenshotRendererLike(Protocol):
+    """The renderer protocol, satisfied by :class:`termproof.rsvg.RsvgPngRenderer`."""
+
+    extension: str
+
+    def render_attributed(
+        self, screen: AttributedScreen, output_path: Path, cols: int, rows: int
+    ) -> None: ...
+
+
+class UploaderLike(Protocol):
+    """Optional upload seam. Returns ``None`` when the upload did not happen."""
+
+    def upload(self, path: Path) -> str | None: ...
+
+
+@dataclass
+class EvidencePublisher:
+    """Where published evidence goes and how it gets there."""
+
+    #: Directory the artifacts are written into.
+    directory: Path
+    #: Which run this evidence belongs to. Required rather than optional: a
+    #: manifest that cannot say whose it is cannot be checked by anyone.
+    identity: RunIdentity
+    #: Renders a captured grid to an image. Without one, only text is written.
+    renderer: ScreenshotRendererLike | None = None
+    #: Uploads are best-effort: a failure leaves the step's ``url`` empty
+    #: rather than failing the publish.
+    uploader: UploaderLike | None = None
+
+    def manifest_path(self) -> Path:
+        return self.directory / MANIFEST_FILE
+
+
+@dataclass
+class ReusedFrom:
+    """The step whose screenshot another step reuses.
+
+    Both halves, because either alone is not enough: labels are caller-supplied
+    and may repeat, so ``"check"`` does not say *which* ``check``; the index
+    alone says which but makes the manifest unreadable without
+    cross-referencing.
+    """
+
+    index: int
+    label: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {"index": self.index, "label": self.label}
+
+
+@dataclass
+class PublishedStep:
+    """One step as it came out of :meth:`EvidenceCollector.publish`."""
+
+    index: int
+    label: str
+    kind: CaptureKind
+    screen_text: str
+    raw_output: str | None = None
+    screenshot: str | None = None
+    url: str | None = None
+    same_as: ReusedFrom | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "index": self.index,
+            "label": self.label,
+            "kind": self.kind.value,
+            "screen_text": self.screen_text,
+            "raw_output": self.raw_output,
+            "screenshot": self.screenshot,
+            "url": self.url,
+            "same_as": self.same_as.to_dict() if self.same_as else None,
+            "error": self.error,
+        }
+
+
+@dataclass
+class EvidenceManifest:
+    """What a publish produced."""
+
+    manifest_version: int
+    run: RunIdentity
+    steps: list[PublishedStep]
+    recordings: list[Recording] = field(default_factory=list)
+    path: Path = Path()
+
+    def to_dict(self) -> dict[str, object]:
+        document: dict[str, object] = {
+            "manifest_version": self.manifest_version,
+            "run": self.run.to_dict(),
+            "steps": [s.to_dict() for s in self.steps],
+        }
+        # Omitted entirely when empty, so a run that records nothing writes the
+        # document it wrote before the field existed. That is what lets it be
+        # additive without moving EVIDENCE_MANIFEST_VERSION, and it is the same
+        # rule the Rust implementation follows.
+        if self.recordings:
+            document["recordings"] = [r.to_dict() for r in self.recordings]
+        return document
+
+    def to_json_pretty(self) -> str:
+        return json.dumps(self.to_dict(), indent=2) + "\n"
+
+    def artifacts(self) -> dict[str, str]:
+        """One entry pointing at this manifest, not one per step.
+
+        The manifest is the index; a caller wanting per-step paths reads it,
+        rather than having them duplicated into a flat map with no way to
+        express order.
+        """
+        return {"evidence_manifest": str(self.path)}
+
+    def deduped(self) -> list[PublishedStep]:
+        """Steps whose screen matched the one before, so no image of their own."""
+        return [s for s in self.steps if s.same_as is not None]
+
+
+class EvidenceCollector:
+    """Collects labelled screen snapshots during a run."""
+
+    def __init__(self, columns: int = DEFAULT_COLUMNS, rows: int = DEFAULT_ROWS) -> None:
+        self._steps: list[CapturedStep] = []
+        self._recordings: list[Recording] = []
+        # Only consulted for sources that report no attributed screen; a grid
+        # that exists carries its own dimensions.
+        self._columns = columns
+        self._rows = rows
+
+    def capture(self, label: str, source: ScreenSource) -> None:
+        """Capture the screen as an ordinary checkpoint."""
+        self._record(label, CaptureKind.CHECKPOINT, source)
+
+    def capture_failure(self, label: str, source: ScreenSource) -> None:
+        """Capture the screen as a failure, keeping the output log with it."""
+        self._record(label, CaptureKind.FAILURE, source)
+
+    def capture_text(
+        self, label: str, screen: str, kind: CaptureKind = CaptureKind.CHECKPOINT
+    ) -> None:
+        """Record a screen the caller already holds, with no source to read from.
+
+        No raw output log is attached, even for a failure: there is nothing to
+        ask for one.
+        """
+        self._steps.append(
+            CapturedStep(
+                index=len(self._steps),
+                label=label,
+                kind=kind,
+                screen=screen,
+                attributed=self._grid_from_text(screen),
+            )
+        )
+
+    def _record(self, label: str, kind: CaptureKind, source: ScreenSource) -> None:
+        capture = source.capture_screen(kind.raw_output())
+        self._steps.append(
+            CapturedStep(
+                index=len(self._steps),
+                label=label,
+                kind=kind,
+                screen=capture.screen,
+                attributed=capture.attributed or self._grid_from_text(capture.screen),
+                raw_output=capture.raw_output,
+            )
+        )
+
+    def _grid_from_text(self, screen: str) -> AttributedScreen:
+        return attributed_screen_from_lines(
+            screen.splitlines(), columns=self._columns, rows=self._rows
+        )
+
+    def attach_recording(self, recording: Recording) -> None:
+        """Attach a whole-session recording.
+
+        The collector does not produce recordings — encoding a cast is a
+        tool-shelling job with its own failure modes, and which tool is the
+        caller's business. It carries them so that :meth:`publish` can put the
+        stills and the video in one manifest.
+        """
+        self._recordings.append(recording)
+
+    @property
+    def steps(self) -> list[CapturedStep]:
+        return list(self._steps)
+
+    @property
+    def recordings(self) -> list[Recording]:
+        return list(self._recordings)
+
+    def __len__(self) -> int:
+        return len(self._steps)
+
+    def publish(self, publisher: EvidencePublisher) -> EvidenceManifest:
+        """Write text, render, dedupe, upload, and write the manifest.
+
+        Raises only when the *manifest itself* cannot be written. A screenshot
+        that fails to render is recorded on the step as an ``error`` and does
+        not fail the run: the text is already on disk, which is the part an
+        assertion is diagnosed from.
+        """
+        publisher.directory.mkdir(parents=True, exist_ok=True)
+        extension = getattr(publisher.renderer, "extension", "png")
+        published: list[PublishedStep] = []
+        # The image the dedup verdict refers to. Tracked as a step rather than
+        # a label because labels are caller-supplied and may repeat.
+        last_rendered: tuple[ReusedFrom, str, str | None] | None = None
+        previous_fingerprint: str | None = None
+
+        for step in self._steps:
+            stem = step.file_stem()
+            text_path = publisher.directory / f"{stem}.txt"
+            text_path.write_text(step.screen + "\n", encoding="utf-8")
+
+            raw_output_path: str | None = None
+            if step.raw_output is not None:
+                raw_path = publisher.directory / f"{stem}-raw.txt"
+                raw_path.write_text(step.raw_output, encoding="utf-8")
+                raw_output_path = str(raw_path)
+
+            entry = PublishedStep(
+                index=step.index,
+                label=step.label,
+                kind=step.kind,
+                screen_text=str(text_path),
+                raw_output=raw_output_path,
+            )
+
+            # Fingerprint the grid the image is rendered from, not the text, so
+            # that a colour-only change counts as a change.
+            fingerprint = step.attributed.render_fingerprint()
+            if fingerprint == previous_fingerprint and last_rendered is not None:
+                source, image, url = last_rendered
+                entry.same_as = source
+                entry.screenshot = image
+                entry.url = url
+            elif publisher.renderer is None:
+                previous_fingerprint = None
+            else:
+                image_path = publisher.directory / f"{stem}.{extension}"
+                try:
+                    publisher.renderer.render_attributed(
+                        step.attributed,
+                        image_path,
+                        step.attributed.column_count,
+                        len(step.attributed.rows),
+                    )
+                except Exception as exc:  # noqa: BLE001 - best effort by contract
+                    entry.error = str(exc)
+                    # Without this, the next identical screen is told to reuse
+                    # an image that was never produced.
+                    last_rendered = None
+                    previous_fingerprint = None
+                    published.append(entry)
+                    continue
+                url = _upload(publisher, image_path)
+                entry.screenshot = str(image_path)
+                entry.url = url
+                last_rendered = (
+                    ReusedFrom(index=step.index, label=step.label),
+                    str(image_path),
+                    url,
+                )
+            previous_fingerprint = fingerprint
+            published.append(entry)
+
+        manifest = EvidenceManifest(
+            manifest_version=EVIDENCE_MANIFEST_VERSION,
+            run=publisher.identity,
+            steps=published,
+            recordings=list(self._recordings),
+            path=publisher.manifest_path(),
+        )
+        manifest.path.write_text(manifest.to_json_pretty(), encoding="utf-8")
+        return manifest
+
+
+def _upload(publisher: EvidencePublisher, path: Path) -> str | None:
+    if publisher.uploader is None:
+        return None
+    try:
+        return publisher.uploader.upload(path)
+    except Exception:  # noqa: BLE001 - uploads are best effort by contract
+        return None
+
+
+def _sanitize(value: str) -> str:
+    return "".join(c if c.isalnum() or c in "-_" else "-" for c in value)
+
+
+#: A source built from a screen the caller already has. Useful in tests and for
+#: replaying a cast, neither of which has a live program to read from.
+def static_source(screen: str, raw_output: str = "") -> ScreenSource:
+    class _Static:
+        def capture_screen(self, raw: RawOutput) -> ScreenCapture:
+            return ScreenCapture(
+                screen=screen,
+                attributed=None,
+                raw_output=raw_output if raw is RawOutput.KEEP else None,
+            )
+
+    return _Static()
+
+
+ToolRunnerLike = Callable[[str, list[str], int], None]
+
+__all__ = [
+    "EVIDENCE_MANIFEST_VERSION",
+    "MANIFEST_FILE",
+    "CaptureKind",
+    "CapturedStep",
+    "EvidenceCollector",
+    "EvidenceManifest",
+    "EvidencePublisher",
+    "PublishedStep",
+    "RawOutput",
+    "Recording",
+    "ReusedFrom",
+    "RunIdentity",
+    "ScreenCapture",
+    "ScreenSource",
+    "static_source",
+]

--- a/python/termproof/collector.py
+++ b/python/termproof/collector.py
@@ -449,7 +449,12 @@ class EvidenceCollector:
         for step in self._steps:
             stem = step.file_stem()
             text_path = publisher.directory / f"{stem}.txt"
-            text_path.write_text(step.screen + "\n", encoding="utf-8")
+            # Verbatim, with no trailing newline added. The screen is what an
+            # assertion was evaluated against, and the Rust implementation
+            # writes it unaltered; a newline on one side and not the other
+            # makes the two documents' artifacts differ while their manifests
+            # agree. `conformance/probe_evidence_manifest.py` pins this.
+            text_path.write_text(step.screen, encoding="utf-8")
 
             raw_output_path: str | None = None
             if step.raw_output is not None:

--- a/python/termproof/evidence.py
+++ b/python/termproof/evidence.py
@@ -1,3 +1,12 @@
+"""Rendering the artifacts a finished run produced.
+
+Driven by a completed :class:`~termproof.models.RunResult`, whose step list the
+recipe fixed before the run started. A caller that decides what to capture
+*while* running — branching on what the screen shows — wants
+:mod:`termproof.collector` instead; see :ref:`collector-versus-evidence` there
+for what each writes and why they are not layered on one another.
+"""
+
 from __future__ import annotations
 
 import json

--- a/python/tests/test_collector.py
+++ b/python/tests/test_collector.py
@@ -1,0 +1,363 @@
+"""Tests for the evidence collector.
+
+Mirrors ``rust/crates/termproof/src/evidence/collector.rs``'s test module where
+the behaviour is shared, so a divergence between the two implementations shows
+up as a failing test on one side rather than as two manifests that disagree.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from termproof.attributed import AttributedCell, AttributedScreen
+from termproof.collector import (
+    CaptureKind,
+    EvidenceCollector,
+    EvidencePublisher,
+    RawOutput,
+    Recording,
+    RunIdentity,
+    ScreenCapture,
+    static_source,
+)
+
+
+def _identity() -> RunIdentity:
+    return RunIdentity(
+        recipe_name="login",
+        renderer="default",
+        run_id="20240101-000000-login-default-1",
+    )
+
+
+class _Replay:
+    """A source that is not a live session — the case the protocol exists for."""
+
+    def __init__(self, frames: list[str]) -> None:
+        self.frames = frames
+        self.at = 0
+
+    def capture_screen(self, raw: RawOutput) -> ScreenCapture:
+        screen = self.frames[self.at]
+        self.at += 1
+        return ScreenCapture(
+            screen=screen,
+            attributed=None,
+            raw_output="".join(self.frames[: self.at]) if raw is RawOutput.KEEP else None,
+        )
+
+
+class _RecordingRenderer:
+    extension = "png"
+
+    def __init__(self) -> None:
+        self.rendered: list[Path] = []
+
+    def render_attributed(self, screen, output_path: Path, cols: int, rows: int) -> None:
+        self.rendered.append(output_path)
+        output_path.write_text("png")
+
+
+class _FailingRenderer:
+    extension = "png"
+
+    def render_attributed(self, screen, output_path: Path, cols: int, rows: int) -> None:
+        raise ValueError("render failed")
+
+
+class _Uploader:
+    def __init__(self) -> None:
+        self.uploaded: list[Path] = []
+
+    def upload(self, path: Path) -> str | None:
+        self.uploaded.append(path)
+        return f"https://example/{path.name}"
+
+
+class CaptureTest(unittest.TestCase):
+    def test_captures_keep_their_order_and_labels(self) -> None:
+        collector = EvidenceCollector()
+        replay = _Replay(["one", "two"])
+        collector.capture("first", replay)
+        collector.capture_failure("blew-up", replay)
+
+        steps = collector.steps
+        self.assertEqual([0, 1], [s.index for s in steps])
+        self.assertEqual(["first", "blew-up"], [s.label for s in steps])
+        self.assertEqual(CaptureKind.FAILURE, steps[1].kind)
+
+    def test_raw_output_is_kept_for_failures_only(self) -> None:
+        # The log is cumulative, so a copy per checkpoint is quadratic and every
+        # copy but the last is a prefix of a later one.
+        collector = EvidenceCollector()
+        collector.capture("ok", static_source("screen", raw_output="all of it"))
+        collector.capture_failure("bad", static_source("screen", raw_output="all of it"))
+
+        self.assertIsNone(collector.steps[0].raw_output)
+        self.assertEqual("all of it", collector.steps[1].raw_output)
+
+    def test_text_can_be_captured_without_a_source(self) -> None:
+        collector = EvidenceCollector()
+        collector.capture("live", static_source("from a session"))
+        collector.capture_text("from-log", "recovered")
+        collector.capture_text("post-mortem", "last screen", CaptureKind.FAILURE)
+
+        steps = collector.steps
+        self.assertEqual(3, len(steps))
+        self.assertEqual(1, steps[1].index)
+        self.assertEqual("recovered", steps[1].screen)
+        self.assertEqual(CaptureKind.FAILURE, steps[2].kind)
+        self.assertIsNone(steps[2].raw_output)
+
+    def test_a_source_that_reports_a_grid_keeps_it(self) -> None:
+        grid = AttributedScreen(rows=((AttributedCell(text="A", fg="ff0000"),),))
+
+        class _Attributed:
+            def capture_screen(self, raw: RawOutput) -> ScreenCapture:
+                return ScreenCapture(screen="A", attributed=grid)
+
+        collector = EvidenceCollector()
+        collector.capture("coloured", _Attributed())
+        self.assertEqual(grid, collector.steps[0].attributed)
+
+
+class PublishTest(unittest.TestCase):
+    def test_text_is_written_even_with_no_renderer(self) -> None:
+        # The text is what an assertion was evaluated against; a picture cannot
+        # answer that question, so losing the renderer must not lose the text.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture("one", static_source("hello"))
+            manifest = collector.publish(
+                EvidencePublisher(directory=Path(tmpdir), identity=_identity())
+            )
+
+            self.assertEqual(1, len(manifest.steps))
+            self.assertTrue(Path(manifest.steps[0].screen_text).exists())
+            self.assertIsNone(manifest.steps[0].screenshot)
+
+    def test_an_identical_screen_reuses_the_image(self) -> None:
+        renderer = _RecordingRenderer()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("before", "same")
+            collector.capture_text("after", "same")
+            manifest = collector.publish(
+                EvidencePublisher(
+                    directory=Path(tmpdir), identity=_identity(), renderer=renderer
+                )
+            )
+
+        self.assertEqual(1, len(renderer.rendered))
+        self.assertIsNotNone(manifest.steps[1].same_as)
+        self.assertEqual("before", manifest.steps[1].same_as.label)
+        self.assertEqual(manifest.steps[0].screenshot, manifest.steps[1].screenshot)
+        self.assertEqual([manifest.steps[1]], manifest.deduped())
+
+    def test_a_colour_only_change_is_a_change(self) -> None:
+        # Fingerprinting the grid rather than the text is the whole reason the
+        # dedup key is not `step.screen`.
+        plain = AttributedScreen(rows=((AttributedCell(text="A"),),))
+        red = AttributedScreen(rows=((AttributedCell(text="A", fg="ff0000"),),))
+
+        class _Fixed:
+            def __init__(self, grid):
+                self.grid = grid
+
+            def capture_screen(self, raw: RawOutput) -> ScreenCapture:
+                return ScreenCapture(screen="A", attributed=self.grid)
+
+        renderer = _RecordingRenderer()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture("plain", _Fixed(plain))
+            collector.capture("red", _Fixed(red))
+            manifest = collector.publish(
+                EvidencePublisher(
+                    directory=Path(tmpdir), identity=_identity(), renderer=renderer
+                )
+            )
+
+        self.assertEqual(2, len(renderer.rendered))
+        self.assertIsNone(manifest.steps[1].same_as)
+
+    def test_a_render_failure_is_recorded_and_does_not_stop_the_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("one", "hello")
+            manifest = collector.publish(
+                EvidencePublisher(
+                    directory=Path(tmpdir),
+                    identity=_identity(),
+                    renderer=_FailingRenderer(),
+                )
+            )
+            # The text still landed, which is the part a failure is diagnosed
+            # from. Asserted inside the block, while the directory still exists.
+            self.assertTrue(Path(manifest.steps[0].screen_text).exists())
+
+        self.assertEqual("render failed", manifest.steps[0].error)
+        self.assertIsNone(manifest.steps[0].screenshot)
+
+    def test_a_failed_render_is_not_offered_for_reuse(self) -> None:
+        """The next identical screen must not point at an image that was never made."""
+
+        class _FailsOnce:
+            extension = "png"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def render_attributed(self, screen, output_path: Path, cols, rows) -> None:
+                self.calls += 1
+                if self.calls == 1:
+                    raise ValueError("render failed")
+                output_path.write_text("png")
+
+        renderer = _FailsOnce()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("one", "same")
+            collector.capture_text("two", "same")
+            manifest = collector.publish(
+                EvidencePublisher(
+                    directory=Path(tmpdir), identity=_identity(), renderer=renderer
+                )
+            )
+
+        self.assertEqual(2, renderer.calls)
+        self.assertIsNone(manifest.steps[1].same_as)
+        self.assertIsNotNone(manifest.steps[1].screenshot)
+
+    def test_uploads_are_best_effort(self) -> None:
+        class _Broken:
+            def upload(self, path: Path) -> str | None:
+                raise RuntimeError("no network")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("one", "hello")
+            manifest = collector.publish(
+                EvidencePublisher(
+                    directory=Path(tmpdir),
+                    identity=_identity(),
+                    renderer=_RecordingRenderer(),
+                    uploader=_Broken(),
+                )
+            )
+
+        self.assertIsNone(manifest.steps[0].url)
+        self.assertIsNotNone(manifest.steps[0].screenshot)
+
+    def test_the_manifest_is_written_and_reads_back(self) -> None:
+        uploader = _Uploader()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("one", "hello")
+            manifest = collector.publish(
+                EvidencePublisher(
+                    directory=Path(tmpdir),
+                    identity=_identity(),
+                    renderer=_RecordingRenderer(),
+                    uploader=uploader,
+                )
+            )
+
+            document = json.loads(manifest.path.read_text())
+
+        self.assertEqual(1, document["manifest_version"])
+        self.assertEqual("login", document["run"]["recipe_name"])
+        self.assertEqual(1, len(document["steps"]))
+        self.assertEqual("checkpoint", document["steps"][0]["kind"])
+        self.assertEqual(1, len(uploader.uploaded))
+        self.assertEqual({"evidence_manifest": str(manifest.path)}, manifest.artifacts())
+
+
+class RecordingTest(unittest.TestCase):
+    def test_recordings_reach_the_manifest_alongside_the_steps(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("one", "hello")
+            collector.attach_recording(
+                Recording(
+                    label="full-session",
+                    cast="/tmp/session.cast",
+                    video="/tmp/session.mp4",
+                    url="https://example/v",
+                )
+            )
+            manifest = collector.publish(
+                EvidencePublisher(directory=Path(tmpdir), identity=_identity())
+            )
+            document = json.loads(manifest.path.read_text())
+
+        self.assertEqual(1, len(document["recordings"]))
+        self.assertEqual("full-session", document["recordings"][0]["label"])
+
+    def test_a_run_with_no_recordings_omits_the_key(self) -> None:
+        # Additive precisely because it disappears when empty. If this breaks,
+        # EVIDENCE_MANIFEST_VERSION has to move with it -- on both sides.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("one", "hello")
+            manifest = collector.publish(
+                EvidencePublisher(directory=Path(tmpdir), identity=_identity())
+            )
+            document = json.loads(manifest.path.read_text())
+
+        self.assertNotIn("recordings", document)
+
+
+class CrossImplementationShapeTest(unittest.TestCase):
+    """The field names the Rust implementation writes, spelled out.
+
+    Cheap insurance: the two produce one document format, and a rename on
+    either side should fail here rather than in whatever reads both.
+    """
+
+    def test_the_manifest_keys_match_the_rust_document(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_failure("bad", static_source("screen", raw_output="log"))
+            manifest = collector.publish(
+                EvidencePublisher(
+                    directory=Path(tmpdir),
+                    identity=_identity(),
+                    renderer=_RecordingRenderer(),
+                )
+            )
+            document = json.loads(manifest.path.read_text())
+
+        self.assertEqual({"manifest_version", "run", "steps"}, set(document))
+        self.assertEqual({"recipe_name", "renderer", "run_id"}, set(document["run"]))
+        self.assertEqual(
+            {
+                "index",
+                "label",
+                "kind",
+                "screen_text",
+                "raw_output",
+                "screenshot",
+                "url",
+                "same_as",
+                "error",
+            },
+            set(document["steps"][0]),
+        )
+
+    def test_the_file_stem_matches_the_rust_scheme(self) -> None:
+        collector = EvidenceCollector()
+        collector.capture_text("a label/with slashes", "x")
+        self.assertEqual("step-00-a-label-with-slashes", collector.steps[0].file_stem())
+
+    def test_a_long_label_is_truncated_the_same_way(self) -> None:
+        collector = EvidenceCollector()
+        collector.capture_text("x" * 60, "screen")
+        self.assertEqual(f"step-00-{'x' * 40}", collector.steps[0].file_stem())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_collector.py
+++ b/python/tests/test_collector.py
@@ -16,6 +16,7 @@ from termproof.attributed import AttributedCell, AttributedScreen
 from termproof.collector import (
     CaptureKind,
     EvidenceCollector,
+    EvidenceManifest,
     EvidencePublisher,
     RawOutput,
     Recording,
@@ -23,6 +24,7 @@ from termproof.collector import (
     ScreenCapture,
     static_source,
 )
+from termproof.models import RunResult
 
 
 def _identity() -> RunIdentity:
@@ -30,6 +32,22 @@ def _identity() -> RunIdentity:
         recipe_name="login",
         renderer="default",
         run_id="20240101-000000-login-default-1",
+    )
+
+
+def _run_result(recipe_name: str, renderer: str) -> RunResult:
+    return RunResult(
+        recipe_name=recipe_name,
+        passed=True,
+        exit_code=0,
+        duration_seconds=1.0,
+        priority="P0",
+        execution="scripted",
+        renderer=renderer,
+        score=1.0,
+        steps=[],
+        assertions=[],
+        artifacts={},
     )
 
 
@@ -309,6 +327,61 @@ class RecordingTest(unittest.TestCase):
             document = json.loads(manifest.path.read_text())
 
         self.assertNotIn("recordings", document)
+
+
+class AttachToTest(unittest.TestCase):
+    """Joining a manifest to a result, which is what stops A being paired with B."""
+
+    def _manifest(self, tmpdir: str, identity: RunIdentity) -> EvidenceManifest:
+        collector = EvidenceCollector()
+        collector.capture_text("one", "hello")
+        return collector.publish(EvidencePublisher(directory=Path(tmpdir), identity=identity))
+
+    def test_the_manifest_lands_in_the_results_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = self._manifest(tmpdir, _identity())
+            result = _run_result("login", "default")
+            manifest.attach_to(result)
+
+            self.assertEqual(str(manifest.path), result.artifacts["evidence_manifest"])
+
+    def test_existing_artifacts_survive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = self._manifest(tmpdir, _identity())
+            result = _run_result("login", "default")
+            result.artifacts["cast"] = "/tmp/session.cast"
+            manifest.attach_to(result)
+
+            self.assertEqual("/tmp/session.cast", result.artifacts["cast"])
+
+    def test_another_runs_evidence_is_refused(self) -> None:
+        # The whole point: nothing about the file layout stops a caller pairing
+        # run A's evidence with run B's result, so this is where it is noticed.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = self._manifest(tmpdir, _identity())
+            result = _run_result("checkout", "default")
+
+            with self.assertRaises(ValueError) as caught:
+                manifest.attach_to(result)
+
+            self.assertIn("login/default", str(caught.exception))
+            self.assertIn("checkout/default", str(caught.exception))
+            self.assertNotIn("evidence_manifest", result.artifacts)
+
+    def test_a_different_renderer_is_refused_too(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = self._manifest(tmpdir, _identity())
+            result = _run_result("login", "ink")
+
+            with self.assertRaises(ValueError):
+                manifest.attach_to(result)
+
+    def test_artifacts_does_not_check(self) -> None:
+        # Documented as the unchecked seam for callers whose index is not a
+        # RunResult; `attach_to` is the one that refuses.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = self._manifest(tmpdir, _identity())
+            self.assertEqual({"evidence_manifest": str(manifest.path)}, manifest.artifacts())
 
 
 class CrossImplementationShapeTest(unittest.TestCase):

--- a/python/tests/test_collector.py
+++ b/python/tests/test_collector.py
@@ -157,6 +157,20 @@ class PublishTest(unittest.TestCase):
             self.assertTrue(Path(manifest.steps[0].screen_text).exists())
             self.assertIsNone(manifest.steps[0].screenshot)
 
+    def test_the_screen_is_written_verbatim(self) -> None:
+        # No trailing newline added. The Rust implementation writes the screen
+        # unaltered, and a newline on one side only makes the two documents'
+        # artifacts differ while their manifests agree.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("one", "line one\nline two")
+            manifest = collector.publish(
+                EvidencePublisher(directory=Path(tmpdir), identity=_identity())
+            )
+
+            written = Path(manifest.steps[0].screen_text).read_text(encoding="utf-8")
+            self.assertEqual("line one\nline two", written)
+
     def test_an_identical_screen_reuses_the_image(self) -> None:
         renderer = _RecordingRenderer()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -385,41 +399,19 @@ class AttachToTest(unittest.TestCase):
 
 
 class CrossImplementationShapeTest(unittest.TestCase):
-    """The field names the Rust implementation writes, spelled out.
+    """Local checks on the shape shared with the Rust implementation.
 
-    Cheap insurance: the two produce one document format, and a rename on
-    either side should fail here rather than in whatever reads both.
+    The manifest key set used to be asserted here by spelling the Rust field
+    names out, derived by reading the Rust structs rather than by running them.
+    That could only ever catch a rename on the Python side. It now lives in
+    ``conformance/probe_evidence_manifest.py`` and
+    ``rust/crates/termproof/tests/differential_evidence_manifest.rs``, which
+    build the same scenario on both sides and compare the published manifest
+    *and* every file it points at — see ``conformance/README.md``.
+
+    What is left here is the filename scheme, which is cheap to check locally
+    and is the input to the comparison rather than its output.
     """
-
-    def test_the_manifest_keys_match_the_rust_document(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            collector = EvidenceCollector()
-            collector.capture_failure("bad", static_source("screen", raw_output="log"))
-            manifest = collector.publish(
-                EvidencePublisher(
-                    directory=Path(tmpdir),
-                    identity=_identity(),
-                    renderer=_RecordingRenderer(),
-                )
-            )
-            document = json.loads(manifest.path.read_text())
-
-        self.assertEqual({"manifest_version", "run", "steps"}, set(document))
-        self.assertEqual({"recipe_name", "renderer", "run_id"}, set(document["run"]))
-        self.assertEqual(
-            {
-                "index",
-                "label",
-                "kind",
-                "screen_text",
-                "raw_output",
-                "screenshot",
-                "url",
-                "same_as",
-                "error",
-            },
-            set(document["steps"][0]),
-        )
 
     def test_the_file_stem_matches_the_rust_scheme(self) -> None:
         collector = EvidenceCollector()

--- a/rust/crates/termproof/src/before_after.rs
+++ b/rust/crates/termproof/src/before_after.rs
@@ -34,9 +34,43 @@
 
 use crate::result::RunResult;
 
+/// What a before/after comparison needs to know about a run.
+///
+/// Three accessors, because that is all this module reads: what ran, what it
+/// ran under, and whether it passed. Taking [`RunResult`] meant a caller whose
+/// results carry extra fields — a mode, a model, an effort — had to convert to
+/// a [`RunResult`] and back to ask whether anything flipped, and the conversion
+/// was lossy in the direction they cared about.
+///
+/// [`RunResult`] implements this, so existing calls are unchanged.
+pub trait Comparable {
+    /// Which recipe this result is for.
+    fn recipe_name(&self) -> &str;
+
+    /// Which renderer it ran under.
+    fn renderer(&self) -> &str;
+
+    /// Whether it passed.
+    fn passed(&self) -> bool;
+}
+
+impl Comparable for RunResult {
+    fn recipe_name(&self) -> &str {
+        &self.recipe_name
+    }
+
+    fn renderer(&self) -> &str {
+        &self.renderer
+    }
+
+    fn passed(&self) -> bool {
+        self.passed
+    }
+}
+
 /// Outcome label for a run that happened.
-fn outcome(result: &RunResult) -> &'static str {
-    if result.passed {
+fn outcome<R: Comparable>(result: &R) -> &'static str {
+    if result.passed() {
         PASS
     } else {
         FAIL
@@ -51,8 +85,11 @@ pub const FAIL: &str = "FAIL";
 pub const SKIP: &str = "SKIP";
 
 /// Results are matched on this pair.
-fn key(result: &RunResult) -> (String, String) {
-    (result.recipe_name.clone(), result.renderer.clone())
+fn key<R: Comparable>(result: &R) -> (String, String) {
+    (
+        result.recipe_name().to_string(),
+        result.renderer().to_string(),
+    )
 }
 
 /// One recipe/renderer whose outcome changed.
@@ -79,17 +116,20 @@ impl BehaviorDelta {
 }
 
 /// Two runs and what changed between them.
+///
+/// Generic over the result type, defaulting to [`RunResult`] so that
+/// `BeforeAfterResult` on its own still names what it always named.
 #[derive(Debug, Clone)]
-pub struct BeforeAfterResult {
+pub struct BeforeAfterResult<R = RunResult> {
     /// The baseline run.
-    pub before: Vec<RunResult>,
+    pub before: Vec<R>,
     /// The candidate run.
-    pub after: Vec<RunResult>,
+    pub after: Vec<R>,
     /// Outcomes that differ, in `before` order then new arrivals.
     pub deltas: Vec<BehaviorDelta>,
 }
 
-impl BeforeAfterResult {
+impl<R> BeforeAfterResult<R> {
     /// Render the deltas as markdown.
     ///
     /// States "none" explicitly rather than emitting nothing: an empty section
@@ -112,7 +152,7 @@ impl BeforeAfterResult {
 /// Matched by `(recipe_name, renderer)`. Ordering follows `before`, with
 /// recipes that appear only in `after` appended — so a report reads in a stable
 /// order rather than a hash order.
-pub fn compute_deltas(before: &[RunResult], after: &[RunResult]) -> Vec<BehaviorDelta> {
+pub fn compute_deltas<R: Comparable>(before: &[R], after: &[R]) -> Vec<BehaviorDelta> {
     let before_keys: Vec<(String, String)> = before.iter().map(key).collect();
     let after_keys: Vec<(String, String)> = after.iter().map(key).collect();
 
@@ -125,8 +165,8 @@ pub fn compute_deltas(before: &[RunResult], after: &[RunResult]) -> Vec<Behavior
 
     let mut deltas = Vec::new();
     for k in ordered_keys {
-        let b = before.iter().find(|r| key(r) == k);
-        let a = after.iter().find(|r| key(r) == k);
+        let b = before.iter().find(|r| key(*r) == k);
+        let a = after.iter().find(|r| key(*r) == k);
         let before_outcome = b.map(outcome).unwrap_or(SKIP);
         let after_outcome = a.map(outcome).unwrap_or(SKIP);
         if before_outcome != after_outcome {
@@ -142,7 +182,7 @@ pub fn compute_deltas(before: &[RunResult], after: &[RunResult]) -> Vec<Behavior
 }
 
 /// Assemble a [`BeforeAfterResult`] with its deltas computed.
-pub fn build_before_after(before: Vec<RunResult>, after: Vec<RunResult>) -> BeforeAfterResult {
+pub fn build_before_after<R: Comparable>(before: Vec<R>, after: Vec<R>) -> BeforeAfterResult<R> {
     let deltas = compute_deltas(&before, &after);
     BeforeAfterResult {
         before,
@@ -267,5 +307,58 @@ mod tests {
         assert_eq!(r.before.len(), 1);
         assert_eq!(r.after.len(), 1);
         assert_eq!(r.deltas.len(), 1);
+    }
+
+    /// A result type that is not `RunResult` — the case the trait exists for.
+    /// The extra fields are the point: converting to `RunResult` to run this
+    /// comparison would drop them.
+    #[derive(Debug, Clone)]
+    struct ProductResult {
+        recipe: String,
+        renderer: String,
+        passed: bool,
+        #[allow(dead_code)]
+        agent_model: String,
+    }
+
+    impl Comparable for ProductResult {
+        fn recipe_name(&self) -> &str {
+            &self.recipe
+        }
+
+        fn renderer(&self) -> &str {
+            &self.renderer
+        }
+
+        fn passed(&self) -> bool {
+            self.passed
+        }
+    }
+
+    fn product(name: &str, passed: bool) -> ProductResult {
+        ProductResult {
+            recipe: name.to_string(),
+            renderer: "ink".to_string(),
+            passed,
+            agent_model: "gpt-5.5".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_foreign_result_type_can_be_compared() {
+        let r = build_before_after(
+            vec![product("login", true), product("search", true)],
+            vec![product("login", false), product("search", true)],
+        );
+        assert_eq!(r.deltas.len(), 1);
+        assert_eq!(r.deltas[0].explanation(), "login [ink]: PASS -> FAIL");
+        // The results themselves survive the round trip, extra fields and all.
+        assert_eq!("gpt-5.5", r.after[0].agent_model);
+    }
+
+    #[test]
+    fn skips_work_for_a_foreign_type_too() {
+        let deltas = compute_deltas(&[product("login", true)], &[]);
+        assert_eq!(deltas[0].explanation(), "login [ink]: PASS -> SKIP");
     }
 }

--- a/rust/crates/termproof/src/evidence/collector.rs
+++ b/rust/crates/termproof/src/evidence/collector.rs
@@ -291,6 +291,31 @@ impl EvidenceCollector {
         self.record(label, CaptureKind::Failure, source);
     }
 
+    /// Record a screen the caller already holds, with no source to read from.
+    ///
+    /// [`capture`](Self::capture) and [`capture_failure`](Self::capture_failure)
+    /// pull from a [`ScreenSource`], which presumes there is something live to
+    /// pull from. Not every screen worth keeping arrives that way: text
+    /// recovered from a log, the screen a step returned before the session
+    /// moved on, a golden file in a test. Without this, recording one of those
+    /// means writing a throwaway `ScreenSource` whose only job is to hand back a
+    /// string it was constructed with.
+    ///
+    /// No raw output log is attached, even for [`CaptureKind::Failure`]: there
+    /// is no source to ask for one. A caller holding the log can write it out
+    /// alongside.
+    pub fn capture_text(&mut self, label: &str, screen: &str, kind: CaptureKind) {
+        let attributed = attributed_screen_from_text(screen, self.columns, self.rows);
+        self.steps.push(CapturedStep {
+            index: self.steps.len(),
+            label: label.to_string(),
+            kind,
+            screen: screen.to_string(),
+            attributed,
+            raw_output: None,
+        });
+    }
+
     fn record<S: ScreenSource + ?Sized>(&mut self, label: &str, kind: CaptureKind, source: &mut S) {
         let capture = source.capture_screen(kind.raw_output());
         let attributed = capture.attributed.unwrap_or_else(|| {
@@ -865,6 +890,26 @@ mod tests {
             .map(|s| s.screen.as_str())
             .collect();
         assert_eq!(screens, ["one", "two"]);
+    }
+
+    #[test]
+    fn text_can_be_captured_without_a_source() {
+        let mut s = session("live");
+        let mut collector = EvidenceCollector::new();
+        collector.capture("from-session", &mut s);
+        collector.capture_text("from-log", "recovered", CaptureKind::Checkpoint);
+        collector.capture_text("post-mortem", "last screen", CaptureKind::Failure);
+
+        // A text capture is a step like any other: same sequence, same
+        // numbering, so filenames and the manifest do not develop a gap.
+        let steps = collector.steps();
+        assert_eq!(steps.len(), 3);
+        assert_eq!(steps[1].index, 1);
+        assert_eq!(steps[1].screen, "recovered");
+        assert_eq!(steps[1].attributed.to_text(true), "recovered");
+        assert_eq!(steps[2].kind, CaptureKind::Failure);
+        // Nothing to ask for a log, so there is none — even for a failure.
+        assert!(steps[2].raw_output.is_none());
     }
 
     #[test]

--- a/rust/crates/termproof/src/evidence/collector.rs
+++ b/rust/crates/termproof/src/evidence/collector.rs
@@ -245,10 +245,61 @@ impl CapturedStep {
     }
 }
 
+/// A recording of a whole session, as against one screen out of it.
+///
+/// Captures are instants; this is the span between them. Keeping the two apart
+/// is deliberate — a recording has no grid, cannot be deduplicated against its
+/// neighbours and does not belong in capture order — but they are published
+/// together because a reader wants the video and the stills side by side.
+///
+/// `error` is one field rather than separate conversion and upload errors:
+/// they are mutually exclusive, since a conversion that failed leaves nothing
+/// to upload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Recording {
+    /// Caller-supplied label.
+    pub label: String,
+    /// Path to the terminal recording itself, normally an asciinema cast.
+    pub cast: String,
+    /// Path to the encoded video, when one was produced.
+    pub video: Option<String>,
+    /// Shareable URL for `video`, when an uploader was configured and worked.
+    pub url: Option<String>,
+    /// Why there is no video, or no URL for one.
+    pub error: Option<String>,
+}
+
+impl Recording {
+    /// A recording of `cast` with nothing derived from it yet.
+    pub fn new(label: impl Into<String>, cast: impl Into<String>) -> Self {
+        Recording {
+            label: label.into(),
+            cast: cast.into(),
+            video: None,
+            url: None,
+            error: None,
+        }
+    }
+
+    /// The same recording, carrying the video that was encoded from it.
+    pub fn with_video(mut self, video: impl Into<String>, url: Option<String>) -> Self {
+        self.video = Some(video.into());
+        self.url = url;
+        self
+    }
+
+    /// The same recording, carrying why it produced no video or no URL.
+    pub fn with_error(mut self, error: impl Into<String>) -> Self {
+        self.error = Some(error.into());
+        self
+    }
+}
+
 /// An ordered, labelled record of what the screen looked like during a run.
 #[derive(Debug, Clone)]
 pub struct EvidenceCollector {
     steps: Vec<CapturedStep>,
+    recordings: Vec<Recording>,
     columns: usize,
     rows: usize,
 }
@@ -257,6 +308,7 @@ impl Default for EvidenceCollector {
     fn default() -> Self {
         EvidenceCollector {
             steps: Vec::new(),
+            recordings: Vec::new(),
             columns: DEFAULT_COLUMNS,
             rows: DEFAULT_ROWS,
         }
@@ -329,6 +381,22 @@ impl EvidenceCollector {
             attributed,
             raw_output: capture.raw_output,
         });
+    }
+
+    /// Attach a whole-session recording.
+    ///
+    /// The collector does not produce recordings — encoding a cast is a
+    /// tool-shelling job with its own failure modes, and which tool is the
+    /// caller's business. It carries them so that
+    /// [`publish`](Self::publish) can put the stills and the video in one
+    /// manifest, which is how a reader wants to find them.
+    pub fn attach_recording(&mut self, recording: Recording) {
+        self.recordings.push(recording);
+    }
+
+    /// The attached recordings, in the order they were attached.
+    pub fn recordings(&self) -> &[Recording] {
+        &self.recordings
     }
 
     /// The captured steps, in capture order.
@@ -437,6 +505,7 @@ impl EvidenceCollector {
             manifest_version: EVIDENCE_MANIFEST_VERSION,
             run: publisher.identity.clone(),
             steps: published,
+            recordings: self.recordings.clone(),
             path: publisher.manifest_path(),
         };
         atomic_write_text(&manifest.path, &manifest.to_json_pretty()).map_err(|e| e.to_string())?;
@@ -603,6 +672,15 @@ pub struct EvidenceManifest {
     pub run: RunIdentity,
     /// Published steps, in capture order.
     pub steps: Vec<PublishedStep>,
+    /// Whole-session recordings, in the order they were attached.
+    ///
+    /// Omitted from the JSON entirely when there are none, so a run that
+    /// records nothing writes the same document it wrote before this field
+    /// existed. That is what lets it be added without a
+    /// [`EVIDENCE_MANIFEST_VERSION`] bump, and what keeps the Python
+    /// implementation reading manifests it does not yet write.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recordings: Vec<Recording>,
     /// Where the manifest was written. Not serialized: a file does not need to
     /// record its own location, and baking it in would make the document
     /// wrong the moment the directory moved.
@@ -910,6 +988,52 @@ mod tests {
         assert_eq!(steps[2].kind, CaptureKind::Failure);
         // Nothing to ask for a log, so there is none — even for a failure.
         assert!(steps[2].raw_output.is_none());
+    }
+
+    #[test]
+    fn recordings_reach_the_manifest_alongside_the_steps() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut s = session("screen");
+        let mut collector = EvidenceCollector::new();
+        collector.capture("one", &mut s);
+        collector.attach_recording(
+            Recording::new("full-session", "/tmp/session.cast")
+                .with_video("/tmp/session.mp4", Some("https://x/v".into())),
+        );
+
+        let mut publisher = EvidencePublisher::new(dir.path(), identity());
+        let manifest = collector.publish(&mut publisher).unwrap();
+
+        assert_eq!(1, manifest.steps.len());
+        assert_eq!(1, manifest.recordings.len());
+        assert_eq!("full-session", manifest.recordings[0].label);
+        assert_eq!(Some("https://x/v".to_string()), manifest.recordings[0].url);
+        assert!(manifest.to_json_pretty().contains("\"recordings\""));
+    }
+
+    #[test]
+    fn a_run_with_no_recordings_writes_the_document_it_always_wrote() {
+        // The field is additive precisely because it disappears when empty.
+        // If this breaks, `EVIDENCE_MANIFEST_VERSION` has to move with it.
+        let dir = tempfile::tempdir().unwrap();
+        let mut s = session("screen");
+        let mut collector = EvidenceCollector::new();
+        collector.capture("one", &mut s);
+
+        let mut publisher = EvidencePublisher::new(dir.path(), identity());
+        let manifest = collector.publish(&mut publisher).unwrap();
+
+        assert!(manifest.recordings.is_empty());
+        assert!(!manifest.to_json_pretty().contains("recordings"));
+    }
+
+    #[test]
+    fn a_recording_carries_why_it_produced_no_video() {
+        let recording =
+            Recording::new("full-session", "/tmp/s.cast").with_error("video conversion failed");
+        assert!(recording.video.is_none());
+        assert!(recording.url.is_none());
+        assert_eq!(Some("video conversion failed".to_string()), recording.error);
     }
 
     #[test]

--- a/rust/crates/termproof/src/evidence/collector.rs
+++ b/rust/crates/termproof/src/evidence/collector.rs
@@ -1037,6 +1037,25 @@ mod tests {
     }
 
     #[test]
+    fn a_recordings_debug_reaches_nothing_but_its_own_strings() {
+        // `Recording` derives `Debug`, and a derive is a door: it renders every
+        // field, so a field whose type came from a dependency would publish
+        // that dependency's formatting — which is how `PyRegex` ended up
+        // printing an engine-version-dependent pattern (see `pyregex`, #177).
+        //
+        // Deriving is safe *here* only because all five fields are `String` or
+        // `Option<String>`. Pinning the exact string is what makes that a
+        // checked property rather than a claim: adding a field of any other
+        // type fails this test rather than silently widening the public API.
+        let recording = Recording::new("full-session", "/tmp/s.cast")
+            .with_video("/tmp/s.mp4", Some("https://x/v".to_string()));
+        assert_eq!(
+            format!("{recording:?}"),
+            r#"Recording { label: "full-session", cast: "/tmp/s.cast", video: Some("/tmp/s.mp4"), url: Some("https://x/v"), error: None }"#
+        );
+    }
+
+    #[test]
     fn captures_keep_their_order_and_labels() {
         let mut s = session("a");
         let mut collector = EvidenceCollector::new();

--- a/rust/crates/termproof/src/evidence/mod.rs
+++ b/rust/crates/termproof/src/evidence/mod.rs
@@ -32,7 +32,7 @@ pub mod video;
 
 pub use collector::{
     CaptureKind, CapturedStep, EvidenceCollector, EvidenceManifest, EvidencePublisher,
-    PublishedStep, RawOutput, ReusedFrom, RunIdentity, ScreenCapture, ScreenSource,
+    PublishedStep, RawOutput, Recording, ReusedFrom, RunIdentity, ScreenCapture, ScreenSource,
     EVIDENCE_MANIFEST_VERSION,
 };
 pub use diff::apply_visual_diff;

--- a/rust/crates/termproof/src/selection.rs
+++ b/rust/crates/termproof/src/selection.rs
@@ -79,16 +79,58 @@ pub fn changed_files_from_file(path: &str) -> std::io::Result<Vec<String>> {
         .collect())
 }
 
+/// What selection needs to know about a recipe.
+///
+/// Selection is a function of a name and a glob list; it never runs anything.
+/// Requiring a [`Recipe`] therefore excluded the callers most likely to want
+/// it — a suite whose recipes branch on what the screen shows cannot be
+/// expressed as a declarative [`Recipe`], but it still has names and
+/// `ci_paths`, and it still has the problem of running everything on every
+/// change.
+///
+/// [`Recipe`] implements this, so existing callers are unaffected and type
+/// inference keeps their calls compiling unchanged. `(String, Vec<String>)`
+/// implements it too, for callers who would rather not write a trait impl to
+/// ask a question — that pairing is what the Python implementation's
+/// `select_names` has always taken.
+pub trait Selectable {
+    /// The recipe's name.
+    fn name(&self) -> &str;
+
+    /// Globs for the sources this recipe covers, repo-relative.
+    fn ci_paths(&self) -> &[String];
+}
+
+impl Selectable for Recipe {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn ci_paths(&self) -> &[String] {
+        &self.ci_paths
+    }
+}
+
+impl Selectable for (String, Vec<String>) {
+    fn name(&self) -> &str {
+        &self.0
+    }
+
+    fn ci_paths(&self) -> &[String] {
+        &self.1
+    }
+}
+
 /// The recipes to run for `changed_files`, in their original order.
-pub fn select<'a>(
-    recipes: &'a [Recipe],
+pub fn select<'a, R: Selectable>(
+    recipes: &'a [R],
     changed_files: &[String],
     config: &SelectionConfig<'_>,
-) -> Vec<&'a Recipe> {
+) -> Vec<&'a R> {
     let mut chosen: HashSet<&str> = config
         .smoke
         .iter()
-        .filter(|name| recipes.iter().any(|r| r.name == **name))
+        .filter(|name| recipes.iter().any(|r| r.name() == **name))
         .copied()
         .collect();
 
@@ -100,27 +142,27 @@ pub fn select<'a>(
     let touches_harness = paths.iter().any(|p| p.starts_with(config.harness_root));
     if !touches_harness {
         for r in recipes {
-            if matches_any_path(&r.ci_paths, &paths, config.repo_marker) {
-                chosen.insert(r.name.as_str());
+            if matches_any_path(r.ci_paths(), &paths, config.repo_marker) {
+                chosen.insert(r.name());
             }
         }
     }
 
     recipes
         .iter()
-        .filter(|r| chosen.contains(r.name.as_str()))
+        .filter(|r| chosen.contains(r.name()))
         .collect()
 }
 
 /// Names of the recipes [`select`] would run.
-pub fn select_names(
-    recipes: &[Recipe],
+pub fn select_names<R: Selectable>(
+    recipes: &[R],
     changed_files: &[String],
     config: &SelectionConfig<'_>,
 ) -> Vec<String> {
     select(recipes, changed_files, config)
         .into_iter()
-        .map(|r| r.name.clone())
+        .map(|r| r.name().to_string())
         .collect()
 }
 
@@ -306,5 +348,81 @@ mod tests {
     #[test]
     fn an_empty_changeset_still_runs_smoke() {
         assert_eq!(select_names(&all(), &[], &cfg()), vec!["smoke".to_string()]);
+    }
+
+    /// A recipe type that is not `Recipe` — the case the trait exists for.
+    struct ImperativeRecipe {
+        name: String,
+        ci_paths: Vec<String>,
+    }
+
+    impl Selectable for ImperativeRecipe {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn ci_paths(&self) -> &[String] {
+            &self.ci_paths
+        }
+    }
+
+    #[test]
+    fn a_foreign_recipe_type_can_be_selected() {
+        let recipes = vec![
+            ImperativeRecipe {
+                name: "smoke".into(),
+                ci_paths: vec![],
+            },
+            ImperativeRecipe {
+                name: "payments".into(),
+                ci_paths: vec!["src/payments/**".into()],
+            },
+            ImperativeRecipe {
+                name: "search".into(),
+                ci_paths: vec!["src/search/**".into()],
+            },
+        ];
+        let changed = vec!["src/payments/api.rs".to_string()];
+        assert_eq!(
+            select_names(&recipes, &changed, &cfg()),
+            vec!["smoke".to_string(), "payments".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_name_and_paths_pair_is_selectable_without_a_trait_impl() {
+        // The shape Python's `select_names` takes, so the two implementations
+        // can be called the same way.
+        let recipes = vec![
+            ("smoke".to_string(), Vec::<String>::new()),
+            ("payments".to_string(), vec!["src/payments/**".to_string()]),
+        ];
+        let changed = vec!["src/payments/api.rs".to_string()];
+        assert_eq!(
+            select_names(&recipes, &changed, &cfg()),
+            vec!["smoke".to_string(), "payments".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_harness_change_suppresses_matches_for_a_foreign_type_too() {
+        let recipes = vec![
+            ImperativeRecipe {
+                name: "smoke".into(),
+                ci_paths: vec![],
+            },
+            ImperativeRecipe {
+                name: "payments".into(),
+                ci_paths: vec!["src/payments/**".into()],
+            },
+        ];
+        let changed = vec![
+            "verify/runner.rs".to_string(),
+            "src/payments/api.rs".to_string(),
+        ];
+        assert_eq!(
+            select_names(&recipes, &changed, &cfg()),
+            vec!["smoke".to_string()]
+        );
     }
 }

--- a/rust/crates/termproof/tests/differential_evidence_manifest.rs
+++ b/rust/crates/termproof/tests/differential_evidence_manifest.rs
@@ -1,0 +1,198 @@
+//! Port half of the evidence-manifest differential harness.
+//!
+//! Builds the scenario `conformance/probe_evidence_manifest.py` builds, in the
+//! same order, publishes it, and compares both the resulting `evidence.json`
+//! and the contents of every file the publish wrote against what the oracle
+//! recorded in `conformance/corpus/evidence_manifest.expected.json`.
+//!
+//! # Why this exists
+//!
+//! The two implementations claim to produce one document format, and until
+//! this test the claim was checked by a Python unit test that spelled the Rust
+//! field names out from having read the Rust structs. That catches a rename on
+//! the Python side. It cannot catch a rename on the Rust side, a field added to
+//! one and not the other, or a value the two spell differently — and it was
+//! never run against a Rust manifest at all.
+//!
+//! Comparing whole documents catches all of those, and it fails on the side
+//! that changed rather than in whatever reads both.
+//!
+//! The file contents are compared as well as the manifest, because the manifest
+//! is a set of paths and agreeing on paths is not agreeing on files. The first
+//! run of this harness found exactly that: byte-identical manifests pointing at
+//! step text that differed by a trailing newline.
+//!
+//! # Determinism
+//!
+//! Two things about the scenario are properties of the machine rather than of
+//! either implementation, and both halves neutralise them the same way:
+//!
+//! - The rasteriser. `ScreenshotRenderer` shells out to `rsvg-convert`, so on a
+//!   host without it every step would record a render error whose text is the
+//!   operating system's. Both halves stub the tool and write a fixed byte.
+//! - The publish directory, which is a fresh temporary directory. Both halves
+//!   substitute it for `@DIR` before comparing.
+
+// The collector is the `evidence` module, so there is no manifest to compare
+// without it. The oracle has no equivalent switch — Python builds one package —
+// so this is a feature gate on the port half only.
+#![cfg(feature = "evidence")]
+
+use std::path::Path;
+
+use termproof::evidence::collector::{
+    CaptureKind, EvidenceCollector, EvidencePublisher, Recording, RunIdentity,
+};
+use termproof::evidence::screenshot::ScreenshotRenderer;
+use termproof::evidence::uploader::ArtifactUploader;
+use termproof::terminal::inmemory::InMemorySession;
+
+/// Stands in for the publish directory. Matches the oracle's placeholder.
+const DIRECTORY_PLACEHOLDER: &str = "@DIR";
+
+/// The document the oracle recorded. Loaded at runtime, as the other
+/// differential tests load their corpora.
+fn expected_path() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../conformance/corpus/evidence_manifest.expected.json")
+}
+
+/// The identity both halves publish under.
+fn identity() -> RunIdentity {
+    RunIdentity::new("login", "default", "20240101-000000-000000-login-default-1")
+}
+
+/// Returns a deterministic URL derived from the filename.
+struct StubUploader;
+
+impl ArtifactUploader for StubUploader {
+    fn upload(&mut self, path: &str) -> Option<String> {
+        let name = Path::new(path).file_name()?.to_string_lossy().to_string();
+        Some(format!("https://example.invalid/{name}"))
+    }
+
+    fn last_error(&self) -> Option<&str> {
+        None
+    }
+}
+
+/// A session serving `screen` and `raw`, the Rust equivalent of the oracle's
+/// `static_source`.
+fn source(screen: &str, raw: &str) -> InMemorySession {
+    let mut session = InMemorySession::new(vec![], "/tmp/x.cast".into(), 80, 24);
+    session.set_screen(screen);
+    session.set_raw(raw);
+    session
+}
+
+/// A renderer that writes a fixed byte instead of shelling out.
+fn stub_renderer() -> ScreenshotRenderer {
+    ScreenshotRenderer::with_runner(Box::new(|_tool, args, _timeout| {
+        // `--output <png> <svg>`: the path to write is the argument after
+        // `--output`, which is how the real rasteriser is invoked.
+        let png = args
+            .iter()
+            .position(|a| a == "--output")
+            .and_then(|i| args.get(i + 1))
+            .ok_or_else(|| "stub renderer: no --output argument".to_string())?;
+        std::fs::write(png, b"png").map_err(|e| e.to_string())
+    }))
+}
+
+/// Replace the publish directory with [`DIRECTORY_PLACEHOLDER`] everywhere it
+/// appears, and sort object keys so the two halves are comparable as text.
+fn normalize(value: &serde_json::Value, directory: &str) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), normalize(v, directory)))
+                .collect(),
+        ),
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(|v| normalize(v, directory)).collect())
+        }
+        serde_json::Value::String(s) => {
+            serde_json::Value::String(s.replace(directory, DIRECTORY_PLACEHOLDER))
+        }
+        other => other.clone(),
+    }
+}
+
+#[test]
+fn the_published_manifest_matches_the_python_document() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let directory = tmp.path().join("evidence");
+
+    let mut collector = EvidenceCollector::new();
+
+    // A plain checkpoint read from a source.
+    collector.capture("menu-open", &mut source("MENU\nitem one", ""));
+    // The same screen again: dedup, so `same_as` points back at step 0 and no
+    // second image is written.
+    collector.capture("menu-open-again", &mut source("MENU\nitem one", ""));
+    // A screen the caller already held, with no source to read it from.
+    collector.capture_text("from-log", "RECOVERED", CaptureKind::Checkpoint);
+    // A text capture marked as a failure still carries no raw output: there is
+    // no source to ask for one.
+    collector.capture_text("post-mortem", "LAST SCREEN", CaptureKind::Failure);
+    // A failure read from a source does carry the log.
+    collector.capture_failure("boom", &mut source("ERROR", "log bytes"));
+    // Two screens whose text differs only by SGR escapes. Both sides build the
+    // grid for a text capture from plain lines rather than by parsing ANSI, so
+    // whether these dedupe together is a statement about that choice — and one
+    // the two implementations have to make the same way, since the dedup
+    // verdict reaches the manifest.
+    collector.capture_text("styled", "\x1b[31mALERT\x1b[0m", CaptureKind::Checkpoint);
+    collector.capture_text("unstyled", "ALERT", CaptureKind::Checkpoint);
+
+    collector.attach_recording(
+        Recording::new("full-session", "/tmp/session.cast").with_video(
+            "/tmp/session.mp4",
+            Some("https://example.invalid/session.mp4".to_string()),
+        ),
+    );
+    collector.attach_recording(
+        Recording::new("failed-encode", "/tmp/broken.cast").with_error("video conversion failed"),
+    );
+
+    let mut publisher = EvidencePublisher::new(&directory, identity())
+        .with_renderer(stub_renderer())
+        .with_uploader(Box::new(StubUploader));
+    let manifest = collector.publish(&mut publisher).expect("published");
+
+    let written = std::fs::read_to_string(manifest.path()).expect("manifest readable");
+    let document: serde_json::Value = serde_json::from_str(&written).expect("manifest is JSON");
+
+    // `evidence.json` is excluded: it is `document`, and recording it twice
+    // would let the two copies disagree.
+    let mut files = serde_json::Map::new();
+    let mut entries: Vec<_> = std::fs::read_dir(&directory)
+        .expect("publish directory readable")
+        .map(|e| e.expect("entry readable").path())
+        .collect();
+    entries.sort();
+    for path in entries {
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        if !path.is_file() || name == "evidence.json" {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path).expect("artifact readable");
+        files.insert(name, serde_json::Value::String(content));
+    }
+
+    let actual = normalize(
+        &serde_json::json!({ "manifest": document, "files": files }),
+        &directory.to_string_lossy(),
+    );
+    let recorded = std::fs::read_to_string(expected_path()).expect("oracle document readable");
+    let expected: serde_json::Value =
+        serde_json::from_str(&recorded).expect("recorded oracle document is JSON");
+
+    assert_eq!(
+        serde_json::to_string_pretty(&expected).unwrap(),
+        serde_json::to_string_pretty(&actual).unwrap(),
+        "the Rust manifest diverged from the recorded Python document; \
+         regenerate the oracle only if the Python side is the one that changed \
+         — see conformance/README.md"
+    );
+}


### PR DESCRIPTION
Additive API for a consumer whose recipes are **imperative** — they branch on what the screen shows, so they cannot be expressed as the declarative `Recipe` this crate models. Today such a consumer maintains a parallel copy of the evidence, selection and before/after layers; these are the seams that let it use the library instead.

**Goes into 0.4.0**, which main already carries in both manifests and has not yet tagged. Based on `main`; nothing here bumps a version.

---

## The Rust half was written without a toolchain

The branch this came from was authored on a host where `cargo` could not be installed: `static.rust-lang.org` and `sh.rustup.rs` were both unreachable. The Rust code was compiled — by copying the sources over a vendored checkout and building that — but **no Rust test, lint, format check or semver check on it had ever run.** The `#[cfg(test)]` blocks were unexecuted code. Python was fully tested (757 tests, ruff and mypy clean) and reproduced identically here.

Everything below is what running those gates found. Reviewers should not have to infer which parts were verified.

### What a compile-only check missed

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | **1 violation**, in the never-run test code. Fixed. |
| `cargo test --workspace` | **All 9 new tests passed first run.** No fix needed. |
| `cargo clippy --all-targets --all-features -D warnings` | Clean. The `#[allow(dead_code)]` the author was unsure about is correct. |
| 16-combination feature powerset | Green on the branch as written. *I* broke 8 of them by adding an integration test that names `evidence`; gated and fixed in the same commit. |
| Dependency-floor run | Green. |
| `cargo deny` | Clean. |
| **`cargo semver-checks`** | **Failed.** One major-version finding — see below. |

The honest summary is that the unexecuted test code was *nearly* fine: one formatting nit, and no logic error. What the compile could not see was the API compatibility question.

### The finding: this is a breaking change

`cargo semver-checks` reports `function_requires_different_generic_type_params` against `select`, `select_names`, `compute_deltas` and `build_before_after`, and asks for a major bump. A control run on the then-current `main` (`a729c71`, 0.3.4) was clean at 196/196, so the finding is this branch's and not inherited.

I did not take the tool's word for it, because a green semver check is [not trustworthy](https://github.com/obi1kenobi/cargo-semver-checks) as a sole gate. Compiling real consumers against both `main` and this branch:

- **`BeforeAfterResult<R = RunResult>` is fine.** A consumer naming the bare type in a struct field, a return position, an argument, a `let` annotation, a struct literal and nested inside another generic compiles unchanged. The default type parameter does its job.
- **The four functions are not.** These compile on `main` and fail here:
  ```rust
  compute_deltas(&[], &[])
  build_before_after(vec![], vec![])
  select_names(&[], &[], cfg)
  ```
  `error[E0283]: type annotations needed`. The element type used to be fixed by the signature and is now inferred; an untyped empty literal gives inference nothing to work with. A consumer with such a call annotates the slice. There are none in this repository.

Rust has no default type parameter for a *function* — that is an unstable feature — so no arrangement of defaults avoids this. The alternative is keeping the concrete functions and adding generic twins under new names, which is a worse API than the one the commit argues for at length.

### Why this rides on 0.4.0

Because of the above, this cannot land as a patch. #186 has merged and cut **0.4.0** as a breaking release for the dependency-wrapping work; 0.4.0 is not yet tagged, so this ships in it. That means one breaking release instead of two, and it is why `cargo semver-checks` is green: at 0.3.4 → 0.4.0 it reports *major change* and skips all 254 checks.

**That green is worth reading carefully.** It does not mean "nothing broke" — it means "the version already accounts for a break". The evidence that the break is real and bounded is the consumer compile above, not the check.

I did not touch the version. It is already 0.4.0 on `main`.

---

## What is in it

| Commit | What |
|---|---|
| `9844269` | `EvidenceCollector::capture_text` — record a screen the caller already holds |
| `127eabc` | `Recording`, `attach_recording`, `recordings` on the manifest |
| `fed1953` | `selection::Selectable`, `before_after::Comparable` — generic over the caller's types |
| `548a845` | `python/termproof/collector.py` |
| `65b8e08` | Python `attach_to`, and which of `collector`/`evidence` is for what |
| `459392f` | The cross-implementation manifest harness, and the divergence it found |
| `cb41c43` | Changelog, merged into `## [0.4.0]` |
| `b3d2451` | Pin `Recording`'s derived `Debug`, and the four-door audit |

Each commit message carries its own reasoning; `fed1953`'s was amended with the semver finding above.

Changelog entries are merged into `## [0.4.0]`'s existing per-implementation sections rather than appended as new ones — the file's header says a heading is split by implementation, and a second `### Rust — Added` under one version is two lists nobody reads as one. The breaking generics entry sits under `### Rust — Changed (breaking)` beside the dependency wrapping, which is where a reader of the 0.4.0 notes needs to find it.

### Dropped from the original branch

The branch also narrowed `fancy-regex` to `>=0.16, <0.17`. **Dropped.** #179 reaches the same constraint (`^0.16`) from the same evidence, independently, and was stacked on #186 — which existed because narrowing that requirement is a breaking change on its own while a public function returns the dependency's type. Landing the narrowing here, without the wrapping, would have reintroduced the defect two PRs were spent removing. The reasoning is preserved in #179; nothing is lost by dropping it here.

The scratch handoff note the branch carried is deleted rather than landed.

---

## No new public API names a third-party type

Re-audited against 0.4.0's stricter policy, which names **four** doors a dependency can reach the public API through — return type, argument, re-export, and trait impl — and removed the `pub use fancy_regex` / `jsonschema` / `vt100` re-exports I had originally cited as precedent. Done with rustdoc JSON rather than by eye:

- **Return type and argument.** No non-`std`, non-`termproof` type is reachable from any signature this branch adds. `Selectable` and `Comparable` have no associated types and no bounds naming a dependency; their accessors return `&str`, `&[String]` and `bool`. `Recording`'s five fields are all `String`/`Option<String>`.
- **Re-export.** None added. 0.4.0 removed three, and nothing here reinstates them.
- **Trait impl.** `Recording`'s *declared* trait set — `Debug`, `Clone`, `PartialEq`, `Eq`, `Serialize`, `Deserialize` — is byte-identical to `PublishedStep`'s, which predates this branch and sits in the same manifest. serde is the sanctioned exception (1.x, so cargo unifies every consumer onto one copy). `BeforeAfterResult` declares only `Debug` and `Clone`.

One caveat worth stating because it looks alarming in raw rustdoc output: `Recording` renders blanket impls from `zerocopy`, `tracing`, `tower_http`, `downcast_rs`, `typenum`, `dyn_clone`, `hashbrown` and `indexmap`. Those are blanket impls those crates provide for every `T`, not something this branch declares — the list is byte-identical on `PublishedStep`, so it is a property of the dependency graph and not a door anything here opens.

`Recording` derives `Debug`, and 0.4.0's fourth door is exactly that: `PyRegex`'s derive was printing a pattern whose rendering moves across `fancy-regex` *patch* releases. The derive is safe here only because every field is a `String` — which was an argument rather than a check, so `8271e82` pins the exact `Debug` string the way #186 pinned `PyRegex`'s. Adding a field of any other type now fails a test instead of silently widening the surface.

`ScreenCapture`, `CaptureKind` and `RawOutput` are unchanged by this branch; `ScreenCapture.attributed` is `Option<AttributedScreen>`, this crate's own type.

## The cross-implementation manifest diff

`CrossImplementationShapeTest` asserted the manifest key set matched Rust's *by spelling the keys out* — a list derived by reading the Rust structs, never by running them. With a toolchain available, I generated a manifest from each implementation against the same input and diffed.

**The manifests agree byte-for-byte.** Every key, every value, the `step-NN-label` filename scheme, the dedup verdict and its `same_as` back-reference, the `kind` spelling, both recordings, and the omission of `recordings` when empty. The hand-written list was right.

**The files they point at did not.** Python appended a trailing newline to every `step-NN.txt`; Rust writes the screen verbatim. Four files differed underneath manifests that agreed exactly.

Python is the side that changed, per the rule that Python is wrong when the two disagree — and on the merits: the screen is what an assertion was evaluated against, and Rust records it unaltered. Only reachable through `termproof.collector`, which is new in the same release, so no published artifact changes shape.

The check now lives in `conformance/` as the third differential harness, same two-half shape as the step and assertion ones, and it compares **the written file contents as well as the document** — that is what caught the newline, and a manifest is a set of paths, so agreeing on paths is not agreeing on files. Two machine-dependent things are neutralised identically on both sides (the `rsvg-convert` shell-out, and the temporary publish directory). Verified to fail before being trusted: perturbing one label in the recorded document turns it red.

`EVIDENCE_MANIFEST_VERSION` does not move. Both tests that pin the empty-`recordings` omission pass.

---

## The Python collector overlap

`collector.py` is new and unused, and `termproof.evidence` still does an overlapping job with its own step-screenshot dedup sharing no code. **Documented rather than consolidated**, and the docstring says why rather than leaving it implied.

The two are not the same job. A table in `collector.py` now sets out what each is driven by, what it writes, how it fingerprints for dedup and what it records, what a render failure does to each, and which Rust module each corresponds to — they differ in every row. I read #181's change to `evidence`'s dedup first, as instructed; it is further from the collector's than the branch assumed (`evidence` parses ANSI to build its grid and is config-gated off by default; the collector's is unconditional and uses the source's own grid).

Folding `evidence` onto `collector` would change the file layout `render_artifacts` has always written — `steps/`, `steps-manifest.json`, `unchanged_from_previous` — which every existing reader of a run directory depends on. That is a separate change with its own compatibility question, not a tidy-up to fold into this one.

**Python's `EvidenceManifest` gained `attach_to`.** Python's `RunResult` carries the same `recipe_name`/`renderer`/`artifacts` contract Rust's `RunIdentity::matches` compares, so it ports exactly, raising `ValueError` where Rust returns `Err`. Five tests, including that another run's evidence is refused and that the result's existing artifacts survive. `RunIdentity`'s docstring already promised the method existed.

---

## Not done, deliberately

- **`ScreenSource` is not widened to three methods.** Three getters against a live program describe three different instants. The consumer adapts.
- **`Recipe` stays declarative.** No convergence of the recipe model.
- **`EVIDENCE_MANIFEST_VERSION` is not bumped.**
- Nothing merged, tagged or published.

## Verification

Every gate, on the final stack:

```
cargo fmt --all --check                                          clean
cargo test --workspace                                           555 passed, 0 failed
cargo clippy --workspace --all-targets --all-features -Dwarnings  clean
16-combination feature powerset (clippy + test each)             16/16 green
dependency-floor run (fancy-regex =0.16.2, jsonschema =0.32.0)   547 passed
cargo deny check                                                 advisories/bans/licenses/sources ok
cargo semver-checks check-release -p termproof                   no update required (major change)
uv run coverage run -m unittest discover -s tests                779 passed
uv run ruff check . && uv run mypy termproof                     clean
scripts/check_schema_copies.py && scripts/check_version.py       clean
```

Python matched the authoring machine exactly (757 → 762 with the new tests), so no environmental divergence to report.
