### PR TITLE
ci: bound every job, and take the package mirror off the critical path (#183)

### DIFF
--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Run a command with a per-attempt timeout and bounded retries.
+#
+# A step-level `timeout-minutes:` bounds the whole step, which is enough to
+# stop a stall burning the six-hour job ceiling but not enough to recover from
+# one: the first attempt hangs, eats the entire budget, and the step dies with
+# no retry ever reached. The timeout has to sit on each *attempt* for a retry
+# to be worth having. That is what this exists for — `timeout-minutes:` stays
+# on the step as the outer backstop.
+#
+# Usage:
+#   retry.sh [--attempts N] [--timeout SECONDS] [--delay SECONDS] -- cmd [args...]
+#
+# Defaults: 3 attempts, 300s per attempt, 15s base delay (linear backoff).
+# Exit status is the last attempt's, or 124 if the last attempt timed out.
+
+set -uo pipefail
+
+attempts=3
+per_attempt_timeout=300
+delay=15
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --attempts) attempts="$2"; shift 2 ;;
+    --timeout) per_attempt_timeout="$2"; shift 2 ;;
+    --delay) delay="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) echo "retry.sh: unknown option '$1'" >&2; exit 2 ;;
+  esac
+done
+
+if [ $# -eq 0 ]; then
+  echo "retry.sh: no command given" >&2
+  exit 2
+fi
+
+# `timeout` is coreutils and is absent on the macOS runners, where Homebrew
+# coreutils installs it as `gtimeout`. Fall back to a shell watchdog so this
+# behaves the same on every runner we use rather than silently running
+# unbounded on one of them.
+run_with_timeout() {
+  local limit="$1"; shift
+  # `-k 5` escalates to SIGKILL five seconds after SIGTERM, matching what the
+  # watchdog below does, so a command that ignores TERM cannot outlive its
+  # bound on either path.
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k 5 "$limit" "$@"
+    return $?
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout -k 5 "$limit" "$@"
+    return $?
+  fi
+
+  # The watchdog marks the file immediately before signalling. Liveness is not
+  # usable as the signal here: after `kill -TERM` the watchdog is still in its
+  # grace sleep, so it looks alive while the command it just killed reports
+  # 143. The marker distinguishes "timed out" from "died on its own" exactly.
+  local marker
+  marker="$(mktemp)"
+  rm -f "$marker"
+
+  "$@" &
+  local cmd_pid=$!
+  (
+    sleep "$limit"
+    : > "$marker"
+    kill -TERM "$cmd_pid" 2>/dev/null && sleep 5 && kill -KILL "$cmd_pid" 2>/dev/null
+  ) >/dev/null 2>&1 &
+  local watchdog_pid=$!
+
+  local status=0
+  wait "$cmd_pid" 2>/dev/null || status=$?
+  kill -TERM "$watchdog_pid" 2>/dev/null
+  wait "$watchdog_pid" 2>/dev/null || true
+  # Report 124 the way coreutils `timeout` does, so both paths agree.
+  if [ -f "$marker" ]; then
+    status=124
+  fi
+  rm -f "$marker"
+  return "$status"
+}
+
+status=0
+attempt=1
+while [ "$attempt" -le "$attempts" ]; do
+  status=0
+  run_with_timeout "$per_attempt_timeout" "$@" || status=$?
+
+  if [ "$status" -eq 0 ]; then
+    if [ "$attempt" -gt 1 ]; then
+      echo "retry.sh: succeeded on attempt ${attempt}/${attempts}"
+    fi
+    exit 0
+  fi
+
+  if [ "$status" -eq 124 ]; then
+    reason="timed out after ${per_attempt_timeout}s"
+  else
+    reason="exited ${status}"
+  fi
+
+  if [ "$attempt" -eq "$attempts" ]; then
+    echo "::error::retry.sh: attempt ${attempt}/${attempts} ${reason}; no attempts left"
+    break
+  fi
+
+  backoff=$((delay * attempt))
+  echo "::warning::retry.sh: attempt ${attempt}/${attempts} ${reason}; retrying in ${backoff}s"
+  sleep "$backoff"
+  attempt=$((attempt + 1))
+done
+
+exit "$status"

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -35,6 +35,7 @@ jobs:
   build:
     name: Build VitePress docs
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository
@@ -55,6 +56,9 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Install docs dependencies
+        # The npm registry can go quiet the same way a package mirror can, and
+        # an unbounded install step is what #183 was.
+        timeout-minutes: 10
         run: npm ci --prefix python/docs-site
 
       - name: Validate case-study scaffolding (RUST-030 / #35)
@@ -88,6 +92,7 @@ jobs:
     name: Deploy docs to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: |
       vars.ENABLE_PAGES == 'true' &&
       ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -109,6 +114,7 @@ jobs:
     name: Docs Pages deploy skipped (ENABLE_PAGES not true)
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: |
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,6 +37,7 @@ jobs:
   build:
     name: Build Pages site preview
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -86,6 +86,14 @@ jobs:
     # stays green. Runs in seconds and needs no toolchain, so it goes first.
     name: Stdlib-only modules
     runs-on: ubuntu-latest
+    # Every job here carries a `timeout-minutes`. Without one the ceiling is
+    # GitHub's six hours, which is what #183 burned eighteen job-hours against:
+    # a quiet package mirror stalled the install step and nothing bounded it.
+    # The values are sized off measured duration, not guessed — see the table
+    # in `test_ci_timeouts.py`. They are backstops against a hang, not budgets,
+    # so they sit far above the observed maximum; a timeout tight enough to
+    # trip on ordinary variance would trade one flake for another.
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -101,6 +109,7 @@ jobs:
   lint:
     name: Lint, type-check and version drift
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -114,6 +123,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: uv sync
 
       - name: Ruff lint
@@ -141,6 +151,7 @@ jobs:
   test:
     name: Unit tests and coverage (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -170,13 +181,23 @@ jobs:
             ~/.cargo/git
           key: cargo-agg-v1.9.0-${{ runner.os }}
 
-      - name: Install system render dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      # There is deliberately no `apt-get install ffmpeg` here any more (#183).
+      # `termproof.evidence.find_ffmpeg` prefers an ffmpeg on PATH and falls
+      # back to `imageio_ffmpeg.get_ffmpeg_exe()`, and `imageio-ffmpeg` is a
+      # hard runtime dependency in `pyproject.toml` whose Linux wheel carries
+      # the binary. `uv sync` therefore already puts a working ffmpeg on this
+      # runner, and the apt step only added a package mirror to the critical
+      # path of a job that spawns ffmpeg once. `test_ffmpeg_needs_no_mirror.py`
+      # is what holds that dependency in place.
 
       - name: Install agg
+        # Bounds the step; `retry.sh` bounds each attempt inside it, which is
+        # the part that lets a retry survive a stall rather than a plain error.
+        timeout-minutes: 20
         run: |
           if ! command -v agg >/dev/null 2>&1; then
-            cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0
+            "$GITHUB_WORKSPACE/.github/scripts/retry.sh" --attempts 3 --timeout 480 -- \
+              cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0
           fi
 
       - name: Run unit tests with coverage
@@ -187,6 +208,7 @@ jobs:
   verify:
     name: Build, verify TUI evidence and publish it
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       # `contents: write` pushes screenshots to the `termproof-evidence`
       # branch; the other two are the sticky PR comment. Nothing else in this
@@ -219,13 +241,31 @@ jobs:
             ~/.cargo/git
           key: cargo-agg-v1.9.0-${{ runner.os }}
 
-      - name: Install system render dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      # This job is the one that actually renders video, so rather than install
+      # ffmpeg from a mirror it confirms the one `imageio-ffmpeg` already ships
+      # resolves and runs (#183). No network, about a second, and it fails here
+      # with a clear message instead of thirty steps later inside a render.
+      - name: Confirm ffmpeg resolves without a package mirror
+        # This is the job's first `uv run`, so it absorbs the dependency sync;
+        # bounded like the other installs rather than like a one-second check.
+        timeout-minutes: 10
+        run: |
+          uv run python -c "
+          import subprocess
+          from termproof.evidence import find_ffmpeg
+          ffmpeg = find_ffmpeg()
+          banner = subprocess.run(
+              [ffmpeg, '-version'], capture_output=True, text=True, check=True
+          ).stdout.splitlines()[0]
+          print(f'{ffmpeg}\n{banner}')
+          "
 
       - name: Install agg
+        timeout-minutes: 20
         run: |
           if ! command -v agg >/dev/null 2>&1; then
-            cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0
+            "$GITHUB_WORKSPACE/.github/scripts/retry.sh" --attempts 3 --timeout 480 -- \
+              cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0
           fi
 
       - name: Run unit tests
@@ -244,6 +284,8 @@ jobs:
           (cd plugin-template && uv build)
 
       - name: Smoke-test plugin-template installed wheel
+        # Resolves from PyPI, so it is bounded like the other installs (#183).
+        timeout-minutes: 10
         run: |
           (cd plugin-template && python -m venv .pkg-test)
           uv pip install --python plugin-template/.pkg-test/bin/python .
@@ -271,6 +313,8 @@ jobs:
         run: uv build
 
       - name: Smoke-test installed wheel
+        # `pip install` resolves the wheel's dependencies from PyPI (#183).
+        timeout-minutes: 10
         run: |
           python -m venv .pkg-test
           .pkg-test/bin/pip install dist/*.whl
@@ -496,10 +540,14 @@ jobs:
             os: ubuntu-latest
             smoke: inspect
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - name: Build pinned agg and platform wheel
+        # Compiles agg from a git checkout, so it reaches the network the same
+        # way the `Install agg` steps do and is bounded the same way (#183).
+        timeout-minutes: 25
         env:
           TERMPROOF_AGG_TARGET: ${{ matrix.target }}
         run: |
@@ -507,6 +555,8 @@ jobs:
           uv build --wheel
       - name: Smoke-test installed wheel
         if: matrix.smoke == 'native'
+        # `pip install` resolves the wheel's dependencies from PyPI (#183).
+        timeout-minutes: 10
         run: |
           python3 -m venv .wheel-test
           .wheel-test/bin/pip install dist/*.whl

--- a/.github/workflows/python-docker-image.yml
+++ b/.github/workflows/python-docker-image.yml
@@ -41,6 +41,7 @@ jobs:
   docker:
     name: Build and publish the image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -25,6 +25,10 @@ jobs:
   release:
     name: Build, verify TUI evidence and release
     runs-on: ubuntu-latest
+    # See the note in CI (Python): unbounded jobs run to GitHub's six-hour
+    # ceiling when a network step stalls (#183). A release renders the full
+    # evidence suite at 60fps, so it gets more headroom than the CI job.
+    timeout-minutes: 45
     environment: pypi
     permissions:
       # `contents: write` creates the GitHub release; `id-token: write` is
@@ -56,13 +60,31 @@ jobs:
             ~/.cargo/git
           key: cargo-agg-v1.9.0-${{ runner.os }}
 
-      - name: Install system render dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      # No `apt-get install ffmpeg` here either (#183) — `imageio-ffmpeg` is a
+      # hard runtime dependency and ships the binary, so this confirms what is
+      # already installed instead of putting a package mirror in front of a
+      # release. See the longer note in CI (Python).
+      - name: Confirm ffmpeg resolves without a package mirror
+        # This is the job's first `uv run`, so it absorbs the dependency sync;
+        # bounded like the other installs rather than like a one-second check.
+        timeout-minutes: 10
+        run: |
+          uv run python -c "
+          import subprocess
+          from termproof.evidence import find_ffmpeg
+          ffmpeg = find_ffmpeg()
+          banner = subprocess.run(
+              [ffmpeg, '-version'], capture_output=True, text=True, check=True
+          ).stdout.splitlines()[0]
+          print(f'{ffmpeg}\n{banner}')
+          "
 
       - name: Install agg
+        timeout-minutes: 20
         run: |
           if ! command -v agg >/dev/null 2>&1; then
-            cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0
+            "$GITHUB_WORKSPACE/.github/scripts/retry.sh" --attempts 3 --timeout 480 -- \
+              cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0
           fi
 
       - name: Run unit tests
@@ -80,6 +102,8 @@ jobs:
         run: uv build
 
       - name: Smoke-test installed wheel
+        # `pip install` resolves the wheel's dependencies from PyPI (#183).
+        timeout-minutes: 10
         run: |
           python -m venv .pkg-test
           .pkg-test/bin/pip install dist/*.whl

--- a/.github/workflows/rust-auto-release.yml
+++ b/.github/workflows/rust-auto-release.yml
@@ -109,6 +109,7 @@ jobs:
   decide:
     name: Decide
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       release: ${{ steps.decide.outputs.release }}
       version: ${{ steps.decide.outputs.version }}
@@ -227,6 +228,7 @@ jobs:
     needs: decide
     if: needs.decide.outputs.release == 'true' && !inputs.dry_run
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
@@ -247,6 +249,7 @@ jobs:
     needs: [decide, gate]
     if: needs.decide.outputs.release == 'true' && !inputs.dry_run
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       # Kept at write even though the pushes below authenticate as
       # RELEASE_TOKEN: actions/checkout still needs to read the repository, and

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)

--- a/.github/workflows/rust-docker-image.yml
+++ b/.github/workflows/rust-docker-image.yml
@@ -57,6 +57,7 @@ jobs:
     # name (docs/engineering-baseline.md §11).
     name: Build, smoke-test and publish the image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/rust-publish-crates.yml
+++ b/.github/workflows/rust-publish-crates.yml
@@ -54,6 +54,7 @@ jobs:
     name: Plan
     if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'rs-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.plan.outputs.version }}
       order: ${{ steps.plan.outputs.order }}
@@ -104,6 +105,7 @@ jobs:
     name: Gate
     if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'rs-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
@@ -136,6 +138,7 @@ jobs:
     needs: [plan, gate]
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
@@ -153,6 +156,7 @@ jobs:
     needs: [plan, gate]
     if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'rs-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: crates-io
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -77,6 +77,7 @@ jobs:
             os: macos-14
             archive: termproof-macos-arm64.tar.gz
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
@@ -168,6 +169,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/rs-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -45,6 +45,7 @@ jobs:
   deny:
     name: Dependency and licence policy (cargo deny)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
@@ -60,6 +61,7 @@ jobs:
     # and the check is cheap enough to run on every PR.
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
@@ -79,6 +81,7 @@ jobs:
     name: Package contents (cargo package)
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,27 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 [#175]: https://github.com/md-mt/termproof/issues/175
 
+### CI
+
+- **Every workflow job is bounded, and the Python jobs no longer install
+  ffmpeg from a package mirror.** A quiet Ubuntu mirror stalled
+  `apt-get install ffmpeg` in three jobs of one run; nothing carried a
+  `timeout-minutes`, so all three ran to GitHub's six-hour ceiling — 18
+  job-hours from one commit — and reported `cancelled` with no test output,
+  which reads as a broken pull request rather than as infrastructure. The
+  install turned out to be redundant everywhere it appeared:
+  `termproof.evidence.find_ffmpeg` falls back to
+  `imageio_ffmpeg.get_ffmpeg_exe()`, and `imageio-ffmpeg` is a hard runtime
+  dependency whose Linux wheel carries the binary, so `uv sync` had already
+  put a working ffmpeg on every one of those runners. All three apt steps are
+  gone, the jobs that render video assert the bundled binary resolves instead,
+  and `cargo install` — the remaining step that reaches the network — runs
+  under `.github/scripts/retry.sh`, which bounds each *attempt* so a retry can
+  survive a stall rather than only a plain error. All 25 jobs across the 12
+  workflows now declare a `timeout-minutes`, and `test_ci_timeouts.py` fails if
+  a new one does not. Affects CI only; neither published artifact changes.
+  ([#183](https://github.com/md-mt/termproof/issues/183))
+
 ## [0.3.4] — 2026-08-17
 
 One project, one version. The two repositories became one: the Rust

--- a/python/tests/test_ci_timeouts.py
+++ b/python/tests/test_ci_timeouts.py
@@ -1,0 +1,140 @@
+"""Every CI job is bounded, and every package install inside one is bounded.
+
+Issue #183: a quiet Ubuntu mirror stalled `apt-get install ffmpeg` in three
+jobs of one run. Nothing carried a ``timeout-minutes``, so all three ran to
+GitHub's six-hour ceiling — 18 job-hours from one commit — and surfaced as
+`cancelled` with no test output, which reads as a broken pull request rather
+than as infrastructure.
+
+The fix is only durable if a new job cannot be added without a bound, which is
+what this asserts. It is a structural contract, not a performance budget: the
+numbers below are deliberately far above the observed maximum, because a
+timeout tight enough to trip on ordinary variance would swap one flake for
+another.
+
+Measured on 404 successful job runs sampled from CI history (minutes):
+
+    workflow               job                          median    p95     max
+    CI (Python)            Stdlib-only modules             0.1    0.2     0.2
+    CI (Python)            Lint, type-check, drift         0.2    0.3     0.3
+    CI (Python)            Unit tests and coverage         2.5   27.3    44.9
+    CI (Python)            Build, verify TUI evidence      3.5   10.3    18.9
+    CI (Python)            Bundled-agg wheel               0.3    0.4     0.4
+    CI (Rust)              Lint, type-check and test      10.4   12.8    13.3
+    Docker Image (Python)  Build and publish              1.0    4.5     4.6
+    Docker Image (Rust)    Build, smoke-test, publish     3.0    3.6     3.8
+    Docs site              Build VitePress docs           0.3    0.4     0.4
+    Publish crates (Rust)  Gate                           3.2    3.5     3.5
+    Security (Rust)        Public API compatibility       1.1    1.1     1.2
+
+The two outliers are exactly the two jobs that ran `apt-get`: their tails are
+the mirror, not the work. With the mirror off the critical path the unit-test
+job's own steps total under two minutes, so 20 is roughly a tenfold headroom.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Commands that reach a package index, registry or mirror. These are the steps
+# that stall, so they carry their own bound as well as the job's.
+INSTALL_MARKERS = (
+    "apt-get",
+    "cargo install",
+    "npm ci",
+    "npm install",
+    "uv sync",
+    "uv pip install",
+    "pip install",
+)
+
+# A job bound has to leave room for the slowest legitimate run. Anything under
+# this is likely a budget mistaken for a backstop.
+MIN_JOB_TIMEOUT_MINUTES = 10
+# And anything over this is not really a bound: the point is to fail in
+# minutes, not to shave an hour off the six-hour ceiling.
+MAX_JOB_TIMEOUT_MINUTES = 60
+
+
+def _workflows() -> list[tuple[str, dict]]:
+    return [
+        (path.name, yaml.safe_load(path.read_text(encoding="utf-8")))
+        for path in sorted(WORKFLOWS.glob("*.yml"))
+    ]
+
+
+class EveryJobIsBoundedTest(unittest.TestCase):
+    def test_every_job_declares_a_timeout(self) -> None:
+        unbounded = [
+            f"{name}:{job_name}"
+            for name, doc in _workflows()
+            for job_name, job in (doc.get("jobs") or {}).items()
+            if job.get("timeout-minutes") is None
+        ]
+        self.assertEqual(
+            [],
+            unbounded,
+            "these jobs run to GitHub's six-hour ceiling when a step stalls (#183); "
+            "give each a `timeout-minutes`",
+        )
+
+    def test_job_timeouts_are_backstops_not_budgets(self) -> None:
+        for name, doc in _workflows():
+            for job_name, job in (doc.get("jobs") or {}).items():
+                with self.subTest(workflow=name, job=job_name):
+                    minutes = job["timeout-minutes"]
+                    self.assertIsInstance(minutes, int)
+                    self.assertGreaterEqual(minutes, MIN_JOB_TIMEOUT_MINUTES)
+                    self.assertLessEqual(minutes, MAX_JOB_TIMEOUT_MINUTES)
+
+    def test_every_package_install_step_is_bounded(self) -> None:
+        """A step bound is what makes a stall fail in minutes rather than hours.
+
+        The job bound alone would still let one stalled install consume the
+        whole job, and — because `retry.sh` needs somewhere to stand — the
+        install steps are the ones worth naming individually.
+        """
+        unbounded = []
+        for name, doc in _workflows():
+            for job_name, job in (doc.get("jobs") or {}).items():
+                for step in job.get("steps") or []:
+                    run = step.get("run") or ""
+                    if not any(marker in run for marker in INSTALL_MARKERS):
+                        continue
+                    if step.get("timeout-minutes") is None:
+                        unbounded.append(f"{name}:{job_name}:{step.get('name')}")
+        self.assertEqual([], unbounded, "unbounded package-install steps (#183)")
+
+
+class RetriedInstallsUseTheHelperTest(unittest.TestCase):
+    """`cargo install` compiles from a git checkout, so it can stall too.
+
+    Each one goes through `retry.sh`, which bounds every *attempt*. A bare
+    `timeout-minutes:` on the step cannot do that: the first attempt would eat
+    the whole budget and the step would die having never retried.
+    """
+
+    def test_cargo_installs_are_retried(self) -> None:
+        for name, doc in _workflows():
+            for job_name, job in (doc.get("jobs") or {}).items():
+                for step in job.get("steps") or []:
+                    run = step.get("run") or ""
+                    if "cargo install" not in run:
+                        continue
+                    with self.subTest(workflow=name, job=job_name):
+                        self.assertIn("retry.sh", run)
+
+    def test_the_retry_helper_exists_and_is_executable(self) -> None:
+        helper = REPO_ROOT / ".github" / "scripts" / "retry.sh"
+        self.assertTrue(helper.is_file(), helper)
+        self.assertTrue(helper.stat().st_mode & 0o111, f"{helper} is not executable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_ffmpeg_needs_no_mirror.py
+++ b/python/tests/test_ffmpeg_needs_no_mirror.py
@@ -1,0 +1,75 @@
+"""CI gets ffmpeg from the package's own dependency, not from a mirror.
+
+Issue #183 stalled on `sudo apt-get update && sudo apt-get install -y ffmpeg`,
+which ran in three jobs. It turned out to be redundant in all three:
+:func:`termproof.evidence.find_ffmpeg` prefers an ffmpeg on ``PATH`` and falls
+back to ``imageio_ffmpeg.get_ffmpeg_exe()``, and ``imageio-ffmpeg`` is a hard
+runtime dependency whose Linux wheel carries the binary. `uv sync` therefore
+already put a working ffmpeg on every one of those runners, and the apt step
+bought nothing but exposure to a mirror.
+
+Deleting the step is only safe while the fallback stays real, so this holds the
+two halves of that argument in place: the dependency stays declared, and the
+workflows stay off the mirror. Whether the resolved binary actually runs is
+checked on the runner itself, by the `Confirm ffmpeg resolves without a package
+mirror` step in the jobs that render video.
+"""
+
+from __future__ import annotations
+
+import tomllib
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parent
+PYPROJECT = ROOT / "pyproject.toml"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+class FfmpegComesFromTheDependencyTest(unittest.TestCase):
+    def test_imageio_ffmpeg_is_a_hard_runtime_dependency(self) -> None:
+        """Not an extra and not a dev dependency — the fallback must always be there."""
+        data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+        dependencies = data["project"]["dependencies"]
+        self.assertTrue(
+            any(dep.split(">=")[0].split("[")[0].strip() == "imageio-ffmpeg" for dep in dependencies),
+            f"imageio-ffmpeg must stay in project.dependencies (#183); got {dependencies}",
+        )
+
+    def test_find_ffmpeg_falls_back_to_the_bundled_binary(self) -> None:
+        """The PATH lookup is a preference; the dependency is the guarantee."""
+        import inspect
+
+        from termproof.evidence import find_ffmpeg
+
+        source = inspect.getsource(find_ffmpeg)
+        self.assertIn("shutil.which", source)
+        self.assertIn("imageio_ffmpeg", source)
+
+    def test_the_resolved_ffmpeg_exists_on_this_machine(self) -> None:
+        from termproof.evidence import find_ffmpeg
+
+        self.assertTrue(Path(find_ffmpeg()).is_file())
+
+
+class WorkflowsStayOffTheMirrorTest(unittest.TestCase):
+    def test_no_workflow_installs_ffmpeg_from_a_package_mirror(self) -> None:
+        offenders = []
+        for path in sorted(WORKFLOWS.glob("*.yml")):
+            for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue
+                if "apt-get" in stripped:
+                    offenders.append(f"{path.name}:{number}: {stripped}")
+        self.assertEqual(
+            [],
+            offenders,
+            "ffmpeg comes from imageio-ffmpeg; an apt install puts a mirror back on "
+            "the critical path (#183)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_retry_script.py
+++ b/python/tests/test_retry_script.py
@@ -1,0 +1,212 @@
+"""`.github/scripts/retry.sh` recovers from a transient failure and from a stall.
+
+Issue #183 was a *stall*, not an error, and that distinction drives the design.
+A `timeout-minutes:` on the step bounds the step, so the six-hour burn stops —
+but it cannot make a retry useful, because the first attempt hangs, consumes
+the whole budget, and the step dies having never reached attempt two. The
+timeout has to sit on each attempt. These tests pin both halves: the retry
+recovers, and the per-attempt bound is what lets it.
+
+The script prefers coreutils ``timeout`` and falls back to a shell watchdog for
+the macOS runners, which have neither ``timeout`` nor ``gtimeout``. Both paths
+are exercised here, because a fallback nobody runs is a fallback that rots.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RETRY = REPO_ROOT / ".github" / "scripts" / "retry.sh"
+
+# A faithful stand-in for coreutils `timeout`: SIGTERM at expiry, SIGKILL five
+# seconds later, exit 124. Used to exercise the branch that the macOS runners
+# never take, and vice versa.
+FAKE_TIMEOUT = """\
+#!/usr/bin/env python3
+import subprocess, sys
+argv = sys.argv[1:]
+if argv[0] == "-k":            # coreutils' escalate-to-KILL flag
+    argv = argv[2:]
+limit = float(argv[0]); cmd = argv[1:]
+p = subprocess.Popen(cmd)
+try:
+    sys.exit(p.wait(timeout=limit))
+except subprocess.TimeoutExpired:
+    p.terminate()
+    try:
+        p.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        p.kill(); p.wait()
+    sys.exit(124)
+"""
+
+
+def _write_executable(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+class RetryScriptTest(unittest.TestCase):
+    """Each test runs under both timeout implementations."""
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    # What the watchdog path needs beyond shell builtins. Hiding `timeout` by
+    # emptying PATH would hide `bash` with it, so the sanitised PATH is built
+    # by name from this list instead — which also documents the fallback's
+    # actual dependencies.
+    WATCHDOG_TOOLCHAIN = ("bash", "sh", "env", "sleep", "mktemp", "rm", "cat", "touch", "kill")
+
+    def _env(self, *, coreutils: bool) -> dict[str, str]:
+        env = dict(os.environ)
+        if coreutils:
+            fake_bin = self.tmp / "bin"
+            fake_bin.mkdir(exist_ok=True)
+            _write_executable(fake_bin / "timeout", FAKE_TIMEOUT)
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+        else:
+            sanitised = self.tmp / "no-timeout-bin"
+            sanitised.mkdir(exist_ok=True)
+            for tool in self.WATCHDOG_TOOLCHAIN:
+                found = shutil.which(tool)
+                link = sanitised / tool
+                if found and not link.exists():
+                    link.symlink_to(found)
+            env["PATH"] = str(sanitised)
+        return env
+
+    def test_the_sanitised_path_really_hides_timeout(self) -> None:
+        """Guards the test rig itself: a leaky PATH would silently test one path twice."""
+        env = self._env(coreutils=False)
+        for tool in ("timeout", "gtimeout"):
+            self.assertIsNone(shutil.which(tool, path=env["PATH"]), tool)
+        self.assertIsNotNone(shutil.which("bash", path=env["PATH"]))
+
+    def _run(self, args: list[str], *, coreutils: bool) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(RETRY), *args],
+            capture_output=True,
+            text=True,
+            env=self._env(coreutils=coreutils),
+            timeout=120,
+        )
+
+    def _both_paths(self):
+        for coreutils in (True, False):
+            with self.subTest(timeout_impl="coreutils" if coreutils else "watchdog"):
+                yield coreutils
+
+    def test_a_command_that_succeeds_runs_once(self) -> None:
+        for coreutils in self._both_paths():
+            counter = self.tmp / f"once-{coreutils}"
+            script = _write_executable(
+                self.tmp / f"once-{coreutils}.sh",
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    echo run >> {counter}
+                    exit 0
+                    """
+                ),
+            )
+            result = self._run(
+                ["--attempts", "3", "--timeout", "10", "--", str(script)],
+                coreutils=coreutils,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(1, len(counter.read_text().splitlines()))
+
+    def test_it_recovers_from_a_single_transient_failure(self) -> None:
+        """The mirror fails once, then answers. No human should see this."""
+        for coreutils in self._both_paths():
+            marker = self.tmp / f"flaky-{coreutils}"
+            script = _write_executable(
+                self.tmp / f"flaky-{coreutils}.sh",
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    if [ ! -f {marker} ]; then touch {marker}; exit 1; fi
+                    exit 0
+                    """
+                ),
+            )
+            result = self._run(
+                ["--attempts", "3", "--timeout", "10", "--delay", "1", "--", str(script)],
+                coreutils=coreutils,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("attempt 1/3 exited 1", result.stdout + result.stderr)
+            self.assertIn("succeeded on attempt 2/3", result.stdout)
+
+    def test_a_stalled_attempt_is_cut_short_and_the_next_one_succeeds(self) -> None:
+        """The #183 failure mode: attempt one hangs, and the retry still helps.
+
+        Without a per-attempt bound this is the case that cannot be recovered,
+        so the assertion that matters is the elapsed time — the hang is 600s
+        and the whole invocation has to finish in a small multiple of the 3s
+        per-attempt limit.
+        """
+        for coreutils in self._both_paths():
+            counter = self.tmp / f"hang-{coreutils}"
+            script = _write_executable(
+                self.tmp / f"hang-{coreutils}.sh",
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    n=$(cat {counter} 2>/dev/null || echo 0); n=$((n+1)); echo $n > {counter}
+                    if [ "$n" -eq 1 ]; then exec sleep 600; fi
+                    exit 0
+                    """
+                ),
+            )
+            started = time.monotonic()
+            result = self._run(
+                ["--attempts", "3", "--timeout", "3", "--delay", "1", "--", str(script)],
+                coreutils=coreutils,
+            )
+            elapsed = time.monotonic() - started
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("timed out after 3s", result.stdout + result.stderr)
+            self.assertIn("succeeded on attempt 2/3", result.stdout)
+            self.assertLess(elapsed, 60, "the stalled attempt was not bounded")
+
+    def test_a_permanent_stall_exhausts_its_attempts_and_reports_124(self) -> None:
+        for coreutils in self._both_paths():
+            started = time.monotonic()
+            result = self._run(
+                ["--attempts", "2", "--timeout", "2", "--delay", "1", "--", "sleep", "600"],
+                coreutils=coreutils,
+            )
+            elapsed = time.monotonic() - started
+            self.assertEqual(124, result.returncode)
+            self.assertIn("no attempts left", result.stdout + result.stderr)
+            self.assertLess(elapsed, 60)
+
+    def test_a_permanent_error_propagates_its_exit_status(self) -> None:
+        for coreutils in self._both_paths():
+            result = self._run(
+                ["--attempts", "2", "--timeout", "10", "--delay", "1", "--", "bash", "-c", "exit 7"],
+                coreutils=coreutils,
+            )
+            self.assertEqual(7, result.returncode)
+
+    def test_it_refuses_an_empty_command(self) -> None:
+        result = self._run(["--attempts", "2"], coreutils=True)
+        self.assertEqual(2, result.returncode)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #183.

## What was happening

Run [32226489311](https://github.com/md-mt/termproof/actions/runs/32226489311) attempt 1, the one in the issue:

| job | apt started | apt ended | duration |
|---|---|---|---|
| py3.12 | 07:09:04 | 13:09:24 | **6h00m** |
| py3.13 | 07:09:06 | 13:09:25 | **6h00m** |
| verify | 07:09:11 | 13:09:50 | **6h00m** |
| py3.11 | 07:09:11 | 07:11:33 | 2m22s ✅ |

18 job-hours from one commit. Attempt 2, re-run ten hours later on the same tree, cleared apt in 18–52s. The code was never at fault.

This is not confined to the kills. Across **214 apt-step samples** from CI history, the step *succeeded* at up to **43.4 minutes**:

| | median | p90 | p95 | p99 | max |
|---|---|---|---|---|---|
| apt step (n=197 successes) | **28s** | 498s | 766s | 2264s | **2601s** |

The six-hour kills are the tail of that distribution, not a separate phenomenon.

## What ffmpeg was actually for

I checked before bounding it, and the install was **redundant in all three places it appeared**.

`termproof.evidence.find_ffmpeg` prefers an ffmpeg on `PATH` and falls back to `imageio_ffmpeg.get_ffmpeg_exe()`. `imageio-ffmpeg` is a **hard runtime dependency** in `pyproject.toml`, and its `manylinux2014_x86_64` wheel is 29.5 MB because it carries the binary. `uv sync` had already put a working ffmpeg on every one of those runners.

Verified on a machine with no system ffmpeg at all:

```
system ffmpeg on PATH: None
find_ffmpeg()        -> .../imageio_ffmpeg/binaries/ffmpeg-macos-aarch64-v7.1
                        ffmpeg version 7.1
```

and it does the real job, not just answer `-version` — a full `render_mp4` through the actual code path:

```
Stream #0:0 Video: h264 (High) (avc1), yuv420p(progressive), 790x560, 12 fps
```

Per job, by instrumenting `subprocess` across the whole suite:

| job | invokes ffmpeg? | needed apt? |
|---|---|---|
| `test` (×3 interpreters) | once, and it resolved to the **bundled** binary | no |
| `verify` | yes, renders evidence video | no — bundled binary is sufficient |
| `release` | yes, renders evidence video | no — same |

741 tests passed in 73s with no system ffmpeg present, matching CI's own 67–87s.

So all three apt steps are **deleted** rather than retried. The two jobs that render video now assert the bundled binary resolves and runs — no network, and it fails there with a clear message instead of thirty steps later inside a render.

## The three layers

**1. Bound it.** All **25 jobs across 12 workflows** now declare `timeout-minutes` — not one did before, so every job in this repo could burn six hours. Every package-install step declares its own too.

Sized off **404 successful job runs**. The two apt jobs were the *only* ones with a pathological tail; every other job maxes at 13.3m:

| job | median | p95 | max | chosen |
|---|---|---|---|---|
| Unit tests and coverage | 2.5m | 27.3m | 44.9m | **20m** |
| Build, verify TUI evidence | 3.5m | 10.3m | 18.9m | **30m** |
| CI (Rust) lint/test | 10.4m | 12.8m | 13.3m | **45m** |
| Docker Image (Rust) | 3.0m | 3.6m | 3.8m | **30m** |

With the mirror gone the unit-test job's own steps total under two minutes, so 20m is roughly tenfold headroom. **These are backstops, not budgets** — a timeout tight enough to trip on ordinary variance would trade one flake for another.

**2. Retry it.** `cargo install` is the remaining step that reaches the network, so it runs under `.github/scripts/retry.sh` (3 attempts, 480s each, linear backoff).

The per-attempt bound is the whole point. **A bare `timeout-minutes:` cannot make a retry useful against a stall** — the first attempt hangs, consumes the entire step budget, and the step dies having never reached attempt two. The bound has to sit on each attempt. `timeout-minutes:` stays on the step as the outer backstop.

**3. Off the mirror.** Covered above.

## Evidence that it works

`test_retry_script.py`, run against **both** timeout implementations (coreutils `timeout`, and the shell watchdog the macOS runners fall back to):

- **retry recovers from a single simulated failure** — command fails once then succeeds; exit 0, log shows `attempt 1/3 exited 1` → `succeeded on attempt 2/3`
- **the timeout fires on a hang and still retries** — attempt 1 sleeps **600s**, per-attempt limit 3s; whole invocation finishes in **4s** with exit 0. This is the #183 failure mode, recovered.
- **a permanent stall exhausts its attempts** — exits **124** in ~5s rather than running to the ceiling
- **a permanent error propagates its status** — exits 7, not 124
- a self-check asserts the sanitised PATH really hides `timeout`, so the watchdog branch cannot silently test the same path twice

Locally green: **757 tests** (741 + 16 new), `ruff`, `mypy`, the stdlib-only job, version drift, schema drift. The new `Confirm ffmpeg` step body was extracted from the YAML and executed verbatim.

## Guards so it cannot come back

- `test_ci_timeouts.py` — fails if any job or install step is added without a bound, and carries the measured table the numbers came from
- `test_ffmpeg_needs_no_mirror.py` — keeps `imageio-ffmpeg` a hard dependency and fails if `apt-get` reappears in any workflow
- `test_retry_script.py` — pins the retry and the per-attempt bound on both implementations

## Notes for the reviewer

- Affects CI only. Neither published artifact changes.
- No repository settings, secrets or variables touched.
- Two follow-ups I deliberately left out of scope: the `test` job invokes `agg` **zero** times, so its `Install agg` step may be removable (it is a 0s cache hit today); and `README.md` still tells consumers to `apt-get install ffmpeg`, which the bundled dependency arguably makes stale — that is claims-sweep territory, and #185 is already in that area.
