### PR TITLE
docs: say plainly that capture_text's signature differs across implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,18 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ## [Unreleased]
 
-Nothing yet.
+### Docs
+
+- **Both READMEs now say that `EvidenceCollector.capture_text` is the one
+  collector signature the two implementations do not share.** Rust takes the
+  `CaptureKind` positionally and Python defaults it to
+  `CaptureKind.CHECKPOINT`; each is idiomatic where it sits, and neither README
+  mentioned the method at all, so a reader carrying the symmetry the rest of
+  the surface has would have carried it here too and been wrong. Reported by a
+  consumer running both implementations against the same collector code. The
+  signatures are unchanged — the Python default is now covered by an assertion
+  in `test_text_can_be_captured_without_a_source` rather than only being
+  exercised.
 
 ## [0.4.0] — 2026-08-19
 

--- a/python/README.md
+++ b/python/README.md
@@ -96,6 +96,23 @@ Each run writes under `.termproof/runs/<run-id>/` (or the `--out` you provide):
 - `report.md` — per-run review summary
 - `latest-report.md` — aggregate report for multi-recipe runs
 
+## Evidence collector
+
+`termproof.collector.EvidenceCollector` is the ordered step model for a caller
+driving its own run rather than a recipe. `capture` and `capture_failure` pull
+from a `ScreenSource`; `capture_text` records a screen you already hold — text
+recovered from a log, or a golden file in a test:
+
+```python
+collector.capture_text("from-log", recovered)
+collector.capture_text("post-mortem", last_screen, CaptureKind.FAILURE)
+```
+
+**This is the one collector signature the two implementations do not share.**
+Here `kind` defaults to `CaptureKind.CHECKPOINT`; Rust takes it positionally,
+as `capture_text(label, screen, CaptureKind::Checkpoint)`. The meaning, the
+ordering and the resulting manifest are identical.
+
 ## Recipe example
 
 ```json

--- a/python/tests/test_collector.py
+++ b/python/tests/test_collector.py
@@ -127,6 +127,9 @@ class CaptureTest(unittest.TestCase):
         self.assertEqual(3, len(steps))
         self.assertEqual(1, steps[1].index)
         self.assertEqual("recovered", steps[1].screen)
+        # The default the READMEs document as the difference from Rust, which
+        # takes the kind positionally.
+        self.assertEqual(CaptureKind.CHECKPOINT, steps[1].kind)
         self.assertEqual(CaptureKind.FAILURE, steps[2].kind)
         self.assertIsNone(steps[2].raw_output)
 

--- a/rust/crates/termproof/README.md
+++ b/rust/crates/termproof/README.md
@@ -137,6 +137,14 @@ a comment on each one that sits above the oldest workable version.
 
 ### `evidence` — screenshots, video, reports
 
+- `EvidenceCollector` — an ordered step model for a caller driving its own run.
+  `capture` and `capture_failure` pull from a `ScreenSource`;
+  `capture_text(label, screen, kind)` records a screen the caller already
+  holds, and takes the `CaptureKind` positionally. **This is the one collector
+  signature the two implementations do not share**: Python's is
+  `capture_text(label, screen, kind=CaptureKind.CHECKPOINT)`, so the Rust call
+  spells out `CaptureKind::Checkpoint` where the Python one may omit it. The
+  meaning, the ordering and the resulting manifest are identical.
 - `render_svg` / `render_by_extension` — plain screen text to an SVG, in
   default colours.
 - `ScreenshotRenderer` — an attributed grid to a PNG, with the colours the


### PR DESCRIPTION
## What

`EvidenceCollector.capture_text` takes the `CaptureKind` positionally in Rust and defaults it to `CaptureKind.CHECKPOINT` in Python. Neither is wrong — each is idiomatic where it sits — but neither README mentioned the method at all, and everywhere else the two surfaces mirror each other, so a reader would have carried that symmetry here and been wrong.

Both READMEs now name the difference, in the same words, and give both spellings:

- `rust/crates/termproof/README.md` gains an `EvidenceCollector` bullet in the `evidence` surface list.
- `python/README.md` gains a short **Evidence collector** section — it had no library-API section at all, and the collector is new in 0.4.0.

## Why documentation rather than an API change

The other option was a Rust `capture_text_checkpoint` helper. That gives Rust the convenience Python gets from a default argument, but it does so under a name Python has no reason to grow — trading a signature asymmetry for a *name* asymmetry, plus a new abstraction, for a difference the feedback itself calls "not wrong". Documenting it is the smaller honest fix.

## Parity

No public surface was added, so the conformance pair (`conformance/probe_evidence_manifest.py` / `rust/crates/termproof/tests/differential_evidence_manifest.rs`) needs no extension — both already exercise `capture_text` with an explicit kind, which is the spelling that is identical on both sides.

The Python default it documents was exercised but never asserted; `test_text_can_be_captured_without_a_source` now asserts it, so the documented behaviour has a test holding it.

## Verification

`uv run --frozen python -m unittest tests.test_collector` — 21 tests, OK. No Rust code changed. No version bumped; the entry sits under the existing `[Unreleased]` → `Docs` convention.