### PR TITLE
evidence: one step-screenshot dedup for the Python package, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,30 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   in `test_text_can_be_captured_without_a_source` rather than only being
   exercised.
 
+### Python — Changed
+
+- **evidence:** the step-screenshot dedup was written out twice — once in
+  `EvidenceCollector.publish` and once in `evidence._render_step_screens` —
+  and the two copies shared no code, so nothing stopped them drifting on what
+  counts as a changed screen. Both now ask the new `termproof.dedup.Deduper`,
+  which is the single copy of the rule. `termproof.dedup` mirrors
+  `termproof::evidence::dedup`, where the Rust implementation has kept the rule
+  in one place since the consolidation; the Python package flattens the Rust
+  `evidence::` namespace into top-level modules, so it lands beside
+  `termproof.collector` rather than inside `termproof.evidence`.
+
+  Nothing observable moved. `render_artifacts` writes the same `steps/` layout
+  and the same `steps-manifest.json`, still gated on
+  `evidence.dedup_step_screenshots` and still off by default; `publish` writes
+  the same `evidence.json`, byte-for-byte — `conformance/probe_evidence_manifest.py`
+  reproduces the committed corpus unchanged. The two file layouts are still
+  separate, and folding one into the other is still a compatibility question of
+  its own rather than something to smuggle into a dedup fix.
+
+  Both module docstrings now say plainly which type owns what:
+  `EvidenceCollector` owns capture-while-running, `render_artifacts` owns
+  rendering a finished `RunResult`, and neither owns the dedup.
+
 ## [0.4.0] — 2026-08-19
 
 ### Rust — Changed

--- a/python/termproof/collector.py
+++ b/python/termproof/collector.py
@@ -24,9 +24,18 @@ picture cannot answer that question.
 Which of this and :mod:`termproof.evidence` to use
 --------------------------------------------------
 
-Both render screens and both dedupe them, and they are **not** layered on one
-another. They answer different questions and produce different documents, so
-the split is deliberate rather than pending cleanup:
+Who owns what:
+
+* :class:`EvidenceCollector` owns capture — deciding *while a run is going on*
+  which moments are worth keeping — and publishing what it captured.
+* :func:`termproof.evidence.render_artifacts` owns rendering the artifacts a
+  finished :class:`RunResult` already carries, whose step list the recipe fixed
+  before the run started.
+* :class:`termproof.dedup.Deduper` owns the "has this screen changed?" rule, for
+  both of them. Neither implements it; there is one copy in the package.
+
+They still write different documents, and that is why one is not a thin wrapper
+over the other:
 
 ===============  =================================  ===============================
                  :mod:`termproof.evidence`          this module
@@ -35,8 +44,7 @@ Driven by        a finished :class:`RunResult`      a caller, while it runs
 Step list        the recipe's, fixed in advance     whatever the caller captured
 Writes           ``final.*``, ``steps/``,           ``step-NN-label.*`` and
                  ``steps-manifest.json``, video     ``evidence.json``
-Dedup fingerprint the step's grid, or one parsed    the grid the source reported,
-                 from its ANSI text                 or one built from plain lines
+Dedup verdict    :class:`~termproof.dedup.Deduper`  :class:`~termproof.dedup.Deduper`
 Dedup records    ``unchanged_from_previous``        ``same_as: {index, label}``
 Dedup is         off unless configured              always on
 A render failure fails the run                      is recorded on the step
@@ -48,10 +56,10 @@ Use :mod:`termproof.evidence` for a declarative recipe run by
 this module when the caller decides what to capture as it goes, which a
 declarative recipe cannot express.
 
-Consolidating the two would mean changing the file layout
+Folding one of the two *file layouts* into the other is a different change from
+sharing the dedup, and not one to smuggle in here: it would move the paths
 :func:`termproof.evidence.render_artifacts` has always written, which every
-existing reader of a run directory depends on. That is a separate change with
-its own compatibility question, not a tidy-up to fold in here.
+existing reader of a run directory depends on.
 """
 
 from __future__ import annotations
@@ -63,6 +71,7 @@ from pathlib import Path
 from typing import Protocol
 
 from .attributed import DEFAULT_COLUMNS, DEFAULT_ROWS, AttributedScreen, attributed_screen_from_lines
+from .dedup import Deduper
 from .models import RunResult
 
 #: Schema version of the published manifest. Shared with the Rust
@@ -441,10 +450,12 @@ class EvidenceCollector:
         publisher.directory.mkdir(parents=True, exist_ok=True)
         extension = getattr(publisher.renderer, "extension", "png")
         published: list[PublishedStep] = []
-        # The image the dedup verdict refers to. Tracked as a step rather than
-        # a label because labels are caller-supplied and may repeat.
+        deduper = Deduper()
+        # The image the deduper's answer refers to. `Deduper.check` reports a
+        # label, and labels are caller-supplied and may repeat; tracking the
+        # step alongside is exact, because the deduper only ever looks back one
+        # rendered step and this is it.
         last_rendered: tuple[ReusedFrom, str, str | None] | None = None
-        previous_fingerprint: str | None = None
 
         for step in self._steps:
             stem = step.file_stem()
@@ -470,17 +481,17 @@ class EvidenceCollector:
                 raw_output=raw_output_path,
             )
 
-            # Fingerprint the grid the image is rendered from, not the text, so
-            # that a colour-only change counts as a change.
-            fingerprint = step.attributed.render_fingerprint()
-            if fingerprint == previous_fingerprint and last_rendered is not None:
-                source, image, url = last_rendered
-                entry.same_as = source
-                entry.screenshot = image
-                entry.url = url
-            elif publisher.renderer is None:
-                previous_fingerprint = None
-            else:
+            # The deduper fingerprints the grid the image is rendered from, not
+            # the text, so that a colour-only change counts as a change.
+            if deduper.check(step.label, step.attributed) is not None:
+                # Nothing to point at when there is no renderer: no image was
+                # ever made, so the step keeps its text and no screenshot.
+                if last_rendered is not None:
+                    source, image, url = last_rendered
+                    entry.same_as = source
+                    entry.screenshot = image
+                    entry.url = url
+            elif publisher.renderer is not None:
                 image_path = publisher.directory / f"{stem}.{extension}"
                 try:
                     publisher.renderer.render_attributed(
@@ -491,21 +502,19 @@ class EvidenceCollector:
                     )
                 except Exception as exc:  # noqa: BLE001 - best effort by contract
                     entry.error = str(exc)
-                    # Without this, the next identical screen is told to reuse
-                    # an image that was never produced.
+                    # `Deduper.forget`'s contract. Without it the next identical
+                    # screen is told to reuse an image that was never produced.
+                    deduper.forget()
                     last_rendered = None
-                    previous_fingerprint = None
-                    published.append(entry)
-                    continue
-                url = _upload(publisher, image_path)
-                entry.screenshot = str(image_path)
-                entry.url = url
-                last_rendered = (
-                    ReusedFrom(index=step.index, label=step.label),
-                    str(image_path),
-                    url,
-                )
-            previous_fingerprint = fingerprint
+                else:
+                    url = _upload(publisher, image_path)
+                    entry.screenshot = str(image_path)
+                    entry.url = url
+                    last_rendered = (
+                        ReusedFrom(index=step.index, label=step.label),
+                        str(image_path),
+                        url,
+                    )
             published.append(entry)
 
         manifest = EvidenceManifest(

--- a/python/termproof/dedup.py
+++ b/python/termproof/dedup.py
@@ -1,0 +1,115 @@
+"""Not re-rendering a screen that has not changed.
+
+A recipe captures evidence either side of an action, and plenty of actions turn
+out not to change the screen — a key that was already pressed, a wait that had
+nothing to wait for, a step that failed to do anything. Rendering and uploading
+a byte-identical image for each of those is pure cost, and a reviewer scrolling
+twelve identical images is worse off than one reading four distinct ones.
+
+:class:`Deduper` is where that rule lives, once, for the whole package. Both
+callers ask it the question and neither answers it itself:
+
+* :meth:`termproof.collector.EvidenceCollector.publish`, which publishes what a
+  caller captured while the run was going on;
+* :func:`termproof.evidence.render_artifacts`, which renders the steps a
+  finished :class:`~termproof.models.RunResult` already carries.
+
+The two write different documents — ``evidence.json`` with ``same_as`` against
+``steps-manifest.json`` with ``unchanged_from_previous`` — but "has this screen
+changed since the last one I rendered?" is one question, and answering it in two
+places is how the two answers drift apart.
+
+Mirrors ``termproof::evidence::dedup::Deduper``. The Python package flattens the
+Rust ``evidence::`` namespace into top-level modules, which is why
+``evidence::dedup`` lands here rather than inside :mod:`termproof.evidence`.
+
+Attributes count
+----------------
+
+Deduplication keys on
+:meth:`~termproof.attributed.AttributedScreen.render_fingerprint`, not on text.
+Two screens with the same characters but a different highlight are *different
+screenshots*, and a text-keyed cache would silently collapse them — losing
+exactly the frame where a selection moved.
+
+It only ever looks backwards one step
+-------------------------------------
+
+A run of identical screens all point at the first of them, but a screen that
+matches one from earlier — after something else in between — renders again. That
+is deliberate: evidence is read in order, and a caption saying "same as step 2"
+nine steps later costs the reader more than the image saves.
+
+.. code-block:: python
+
+    from termproof.attributed import attributed_screen_from_text
+    from termproof.dedup import Deduper
+
+    deduper = Deduper()
+    menu = attributed_screen_from_text("menu open", columns=20, rows=2)
+    same = attributed_screen_from_text("menu open", columns=20, rows=2)
+    gone = attributed_screen_from_text("menu closed", columns=20, rows=2)
+
+    assert deduper.check("opened", menu) is None
+    assert deduper.check("still-open", same) == "opened"
+    assert deduper.check("closed", gone) is None
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .attributed import AttributedScreen
+
+
+@dataclass(frozen=True)
+class _Rendered:
+    """The screen a reuse verdict would point at."""
+
+    label: str
+    fingerprint: str
+
+
+class Deduper:
+    """Decides whether a screen needs rendering, or matches the previous one."""
+
+    def __init__(self) -> None:
+        self._previous: _Rendered | None = None
+
+    def check(self, label: str, screen: AttributedScreen) -> str | None:
+        """Whether ``screen`` duplicates the previously rendered one.
+
+        Returns the ``label`` the caller gave the step to reuse, or ``None``
+        when this screen needs rendering. A ``None`` answer records the screen
+        as the new previous, so a run of identical screens all point at the
+        first.
+
+        The caller renders on ``None`` and, if that render *fails*, should call
+        :meth:`forget` — otherwise the next identical screen would be told to
+        reuse an image that does not exist.
+        """
+        fingerprint = screen.render_fingerprint()
+        previous = self._previous
+        if previous is not None and previous.fingerprint == fingerprint:
+            # Deliberately not updating `_previous`: every screen in a run of
+            # identical ones points at the first, not at its neighbour.
+            return previous.label
+        self._previous = _Rendered(label=label, fingerprint=fingerprint)
+        return None
+
+    def forget(self) -> None:
+        """Drop the remembered screen, so the next one renders afresh.
+
+        For the case where the caller was told to render and could not. Without
+        this, a failed render leaves a fingerprint pointing at an image that was
+        never produced, and the next identical screen reuses nothing.
+        """
+        self._previous = None
+
+    @property
+    def last_rendered(self) -> str | None:
+        """The label of the last screen that needed rendering, if any."""
+        return None if self._previous is None else self._previous.label
+
+
+__all__ = ["Deduper"]

--- a/python/termproof/evidence.py
+++ b/python/termproof/evidence.py
@@ -1,10 +1,22 @@
 """Rendering the artifacts a finished run produced.
 
 Driven by a completed :class:`~termproof.models.RunResult`, whose step list the
-recipe fixed before the run started. A caller that decides what to capture
-*while* running — branching on what the screen shows — wants
-:mod:`termproof.collector` instead; see :ref:`collector-versus-evidence` there
-for what each writes and why they are not layered on one another.
+recipe fixed before the run started. This module owns the ``final.*``,
+``steps/`` and ``steps-manifest.json`` layout that
+:class:`~termproof.runner.TermProofRunner` writes and every existing reader of a
+run directory expects.
+
+A caller that decides what to capture *while* running — branching on what the
+screen shows — wants :class:`termproof.collector.EvidenceCollector` instead,
+which owns capture-as-you-go and writes its own ``evidence.json``. See
+:ref:`collector-versus-evidence` there for what each writes.
+
+Neither module owns the step-screenshot dedup: both ask
+:class:`termproof.dedup.Deduper`, which is the single copy of the rule in the
+package. This module additionally gates it on
+:attr:`~termproof.config.EvidenceConfig.dedup_step_screenshots` and records the
+verdict as ``unchanged_from_previous``; the collector dedupes unconditionally
+and records ``same_as``.
 """
 
 from __future__ import annotations
@@ -20,6 +32,7 @@ from typing import Any
 from .agg_bundle import resolve_agg
 from .attributed import AttributedScreen, attributed_screen_from_ansi_text
 from .config import EvidenceConfig, SvgRenderConfig, VideoConfig
+from .dedup import Deduper
 from .models import RunResult, StepResult
 from .screen import replay_cast_both
 
@@ -168,34 +181,36 @@ def _render_step_screens(
     step_dir = run_dir / "steps"
     step_dir.mkdir(parents=True, exist_ok=True)
     manifest: list[dict[str, Any]] = []
-    previous_fingerprint: str | None = None
-    previous_screenshot = ""
+    # The one implementation of the rule, shared with
+    # `EvidenceCollector.publish`. It fingerprints the grid the screenshot is
+    # rendered from rather than the text, so two steps share an image exactly
+    # when the image would be identical — a colour-only change is a change,
+    # which comparing `step.screen` as a string cannot express. Never consulted
+    # when dedup is off, so it holds no state to leak into that path.
+    deduper = Deduper()
     for index, step in enumerate(steps, start=1):
         safe_name = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in step.name)
         path_base = step_dir / f"{index:02d}-{safe_name}"
         (path_base.with_suffix(".txt")).write_text(step.screen + "\n", encoding="utf-8")
         screenshot_path = path_base.with_suffix(f".{screenshot_ext}")
-        # Fingerprint the grid the screenshot is rendered from, not the text.
-        # Two steps then share an image exactly when the image would be
-        # identical — a colour-only change is a change, which comparing
-        # `step.screen` as a string cannot express.
-        #
         # `step.screen_attributed` is the grid the session reported at the
-        # moment of the step, and is what makes that distinction reachable: a
-        # grid rebuilt from `step.screen` can only be as colourful as the text,
-        # which for a flattened screen is not at all. Sessions that report no
-        # grid still land on the fallback, and still get their screenshot.
+        # moment of the step, and is what makes the colour distinction
+        # reachable: a grid rebuilt from `step.screen` can only be as colourful
+        # as the text, which for a flattened screen is not at all. Sessions that
+        # report no grid still land on the fallback, and still get their
+        # screenshot.
         screen = step.screen_attributed or attributed_screen_from_ansi_text(
             step.screen, columns=cols, rows=rows
         )
-        fingerprint = screen.render_fingerprint()
-        unchanged = dedup and fingerprint == previous_fingerprint
-        if unchanged:
+        # The label is the image filename, so the deduper's answer is directly
+        # the image this step reuses.
+        reused = deduper.check(screenshot_path.name, screen) if dedup else None
+        if reused is not None:
             # The step still happened and still has a screen; the manifest says
             # which already-written image represents it. Not dropped (that would
             # lose the step) and not symlinked (links do not survive artifact
             # upload).
-            screenshot_name = previous_screenshot
+            screenshot_name = reused
         else:
             _render_screen(
                 step.screen,
@@ -211,11 +226,9 @@ def _render_step_screens(
             {
                 "step": path_base.name,
                 "screenshot": screenshot_name,
-                "unchanged_from_previous": unchanged,
+                "unchanged_from_previous": reused is not None,
             }
         )
-        previous_fingerprint = fingerprint
-        previous_screenshot = screenshot_name
     if dedup:
         (step_dir / STEPS_MANIFEST_NAME).write_text(
             json.dumps(manifest, indent=2) + "\n", encoding="utf-8"

--- a/python/tests/test_collector.py
+++ b/python/tests/test_collector.py
@@ -11,7 +11,10 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
+from termproof import collector as collector_module
+from termproof import evidence as evidence_module
 from termproof.attributed import AttributedCell, AttributedScreen
 from termproof.collector import (
     CaptureKind,
@@ -24,7 +27,9 @@ from termproof.collector import (
     ScreenCapture,
     static_source,
 )
-from termproof.models import RunResult
+from termproof.config import EvidenceConfig
+from termproof.dedup import Deduper
+from termproof.models import RunResult, StepResult
 
 
 def _identity() -> RunIdentity:
@@ -399,6 +404,159 @@ class AttachToTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest = self._manifest(tmpdir, _identity())
             self.assertEqual({"evidence_manifest": str(manifest.path)}, manifest.artifacts())
+
+
+class _NeverReuses:
+    """A deduper that says every screen needs rendering.
+
+    Substituted for the real one so that a caller keeping its own fingerprint
+    comparison on the side would still dedupe, and be caught doing it.
+    """
+
+    def __init__(self) -> None:
+        self.checked: list[str] = []
+
+    def check(self, label: str, screen: AttributedScreen) -> str | None:
+        self.checked.append(label)
+        return None
+
+    def forget(self) -> None:
+        pass
+
+
+class _AlwaysReuses:
+    """A deduper that says every screen matches, naming an image nothing wrote.
+
+    Nothing in the package could reach this verdict on its own — the screens it
+    is asked about differ — so a caller that reports it is taking the deduper's
+    word rather than deciding for itself.
+    """
+
+    SENTINEL = "sentinel.svg"
+
+    def __init__(self) -> None:
+        self.checked: list[str] = []
+
+    def check(self, label: str, screen: AttributedScreen) -> str | None:
+        self.checked.append(label)
+        return self.SENTINEL
+
+    def forget(self) -> None:
+        raise AssertionError("nothing was asked to render, so nothing can have failed")
+
+
+class SharedDedupTest(unittest.TestCase):
+    """Both publishing paths take their dedup verdict from :mod:`termproof.dedup`.
+
+    The rule used to be written out twice — once in ``EvidenceCollector.publish``
+    and once in ``evidence._render_step_screens`` — which is how the two could
+    disagree about what counts as a changed screen. These pin the delegation
+    itself, not just its current answers, so re-inlining either copy fails here
+    even if the re-inlined copy happens to be correct today.
+    """
+
+    DISTINCT_STEPS = [
+        StepResult("one", True, "", "screen one"),
+        StepResult("two", True, "", "screen two"),
+    ]
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_neither_module_has_a_deduper_of_its_own(self) -> None:
+        self.assertIs(Deduper, collector_module.Deduper)
+        self.assertIs(Deduper, evidence_module.Deduper)
+
+    def test_the_collector_dedupes_only_when_the_deduper_says_so(self) -> None:
+        stub = _NeverReuses()
+        renderer = _RecordingRenderer()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("before", "same")
+            collector.capture_text("after", "same")
+            with mock.patch.object(collector_module, "Deduper", lambda: stub):
+                manifest = collector.publish(
+                    EvidencePublisher(
+                        directory=Path(tmpdir), identity=_identity(), renderer=renderer
+                    )
+                )
+
+        # Two byte-identical screens: the real deduper collapses them, and this
+        # one does not. Both images exist and neither step claims to reuse.
+        self.assertEqual(["before", "after"], stub.checked)
+        self.assertEqual(2, len(renderer.rendered))
+        self.assertEqual([], manifest.deduped())
+
+    def test_a_failed_render_forgets_through_the_deduper(self) -> None:
+        # `Deduper.forget` is how the collector says "the image you were told to
+        # make does not exist". Asserted here as a call, because the observable
+        # consequence is already covered above and would survive an inlined copy.
+        forgotten: list[bool] = []
+
+        class _Recording(Deduper):
+            def forget(self) -> None:
+                forgotten.append(True)
+                super().forget()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collector = EvidenceCollector()
+            collector.capture_text("one", "same")
+            collector.capture_text("two", "same")
+            with mock.patch.object(collector_module, "Deduper", _Recording):
+                manifest = collector.publish(
+                    EvidencePublisher(
+                        directory=Path(tmpdir),
+                        identity=_identity(),
+                        renderer=_FailingRenderer(),
+                    )
+                )
+
+        self.assertEqual([True, True], forgotten)
+        self.assertIsNone(manifest.steps[1].same_as)
+
+    def test_render_artifacts_reports_the_deduper_verdict(self) -> None:
+        stub = _AlwaysReuses()
+        renderer = _RecordingRenderer()
+        run_dir = Path(self._tmp.name)
+        with mock.patch.object(evidence_module, "Deduper", lambda: stub):
+            evidence_module._render_step_screens(
+                run_dir,
+                self.DISTINCT_STEPS,
+                80,
+                24,
+                renderer,
+                "svg",
+                EvidenceConfig(dedup_step_screenshots=True),
+            )
+
+        manifest = json.loads(
+            (run_dir / "steps" / evidence_module.STEPS_MANIFEST_NAME).read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(["01-one.svg", "02-two.svg"], stub.checked)
+        # The screens differ, so a module deciding for itself would render both.
+        self.assertEqual([], renderer.rendered)
+        self.assertEqual(
+            [_AlwaysReuses.SENTINEL] * 2, [entry["screenshot"] for entry in manifest]
+        )
+        self.assertEqual([True, True], [entry["unchanged_from_previous"] for entry in manifest])
+
+    def test_dedup_off_never_asks_the_deduper(self) -> None:
+        # `dedup_step_screenshots` is off by default and must stay a hard skip:
+        # a deduper consulted-then-ignored is a state machine advancing on a
+        # path where nothing reads it.
+        stub = _AlwaysReuses()
+        renderer = _RecordingRenderer()
+        run_dir = Path(self._tmp.name)
+        with mock.patch.object(evidence_module, "Deduper", lambda: stub):
+            evidence_module._render_step_screens(
+                run_dir, self.DISTINCT_STEPS, 80, 24, renderer, "svg", EvidenceConfig()
+            )
+
+        self.assertEqual([], stub.checked)
+        self.assertEqual(2, len(renderer.rendered))
 
 
 class CrossImplementationShapeTest(unittest.TestCase):

--- a/python/tests/test_dedup.py
+++ b/python/tests/test_dedup.py
@@ -1,0 +1,99 @@
+"""Tests for the shared screenshot deduper.
+
+Mirrors ``rust/crates/termproof/src/evidence/dedup.rs``'s test module, so a
+divergence between the two implementations of the rule shows up as a failing
+test on one side rather than as two run directories that disagree about which
+screens changed.
+
+The two Python callers are covered where they live: ``test_collector.py`` for
+:meth:`termproof.collector.EvidenceCollector.publish`, and
+``test_evidence_config.py`` / ``test_step_attributed_screens.py`` for
+:func:`termproof.evidence.render_artifacts`.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from termproof.attributed import (
+    AttributedScreen,
+    attributed_screen_from_ansi_text,
+    attributed_screen_from_text,
+)
+from termproof.dedup import Deduper
+
+
+def _text(value: str) -> AttributedScreen:
+    return attributed_screen_from_text(value, columns=20, rows=2)
+
+
+def _ansi(value: str) -> AttributedScreen:
+    return attributed_screen_from_ansi_text(value, columns=20, rows=2)
+
+
+class DeduperTest(unittest.TestCase):
+    def test_the_first_screen_always_renders(self) -> None:
+        deduper = Deduper()
+        self.assertIsNone(deduper.check("first", _text("hello")))
+
+    def test_an_unchanged_screen_reuses_the_previous(self) -> None:
+        deduper = Deduper()
+        deduper.check("first", _text("hello"))
+        self.assertEqual("first", deduper.check("second", _text("hello")))
+
+    def test_a_changed_screen_renders(self) -> None:
+        deduper = Deduper()
+        deduper.check("first", _text("hello"))
+        self.assertIsNone(deduper.check("second", _text("goodbye")))
+
+    def test_a_run_of_identical_screens_all_point_at_the_first(self) -> None:
+        # Not at their immediate neighbour — a chain of "same as the one
+        # before" is useless to a reader following it back.
+        deduper = Deduper()
+        deduper.check("first", _text("hello"))
+        self.assertEqual("first", deduper.check("second", _text("hello")))
+        self.assertEqual("first", deduper.check("third", _text("hello")))
+
+    def test_same_text_different_colour_is_a_different_screenshot(self) -> None:
+        # The reason this keys on attributes. A text-keyed cache collapses
+        # these two and loses the frame where the selection moved.
+        deduper = Deduper()
+        deduper.check("red", _ansi("\x1b[31mhi"))
+        self.assertIsNone(deduper.check("green", _ansi("\x1b[32mhi")))
+
+    def test_identical_colour_and_text_still_dedupes(self) -> None:
+        deduper = Deduper()
+        deduper.check("red", _ansi("\x1b[31mhi"))
+        self.assertEqual("red", deduper.check("red-again", _ansi("\x1b[31mhi")))
+
+    def test_only_the_immediately_previous_screen_counts(self) -> None:
+        # A screen matching one from earlier, with something else in between,
+        # renders again: evidence is read in order, and "same as step 2" nine
+        # steps later costs the reader more than the image saves.
+        deduper = Deduper()
+        deduper.check("a", _text("one"))
+        deduper.check("b", _text("two"))
+        self.assertIsNone(deduper.check("c", _text("one")))
+
+    def test_forgetting_makes_the_next_identical_screen_render(self) -> None:
+        # The failed-render path. Without `forget`, the next identical screen
+        # is told to reuse an image that was never produced.
+        deduper = Deduper()
+        deduper.check("first", _text("hello"))
+        deduper.forget()
+        self.assertIsNone(deduper.check("second", _text("hello")))
+
+    def test_last_rendered_tracks_the_reusable_label(self) -> None:
+        deduper = Deduper()
+        self.assertIsNone(deduper.last_rendered)
+        deduper.check("first", _text("hello"))
+        self.assertEqual("first", deduper.last_rendered)
+        deduper.check("second", _text("hello"))
+        # Unchanged: the run still points at the first.
+        self.assertEqual("first", deduper.last_rendered)
+        deduper.check("third", _text("other"))
+        self.assertEqual("third", deduper.last_rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`python/termproof/collector.py` and `python/termproof/evidence.py` each carried
their own copy of the step-screenshot dedup. Both now ask
`termproof.dedup.Deduper`, the single copy of the rule in the package.

The collector is not decorative. It is the imperative capture path, and it now
shares the one piece of logic it genuinely had in common with the declarative
one. The queued `record_session` work can build on `EvidenceCollector` as the
real path.

## Why not `evidence` → `EvidenceCollector.publish` verbatim

The brief prefers wiring `evidence`'s module-level functions on top of
`EvidenceCollector` "so the step-screenshot dedup exists exactly once". That
purpose is met. Routing `_render_step_screens` through `publish()` itself is
not, because the two disagree on six things that are public behaviour and that
existing tests pin:

| | `render_artifacts` | `publish` |
|---|---|---|
| Filenames | `steps/NN-name.svg`, 1-based | `step-NN-label.png`, 0-based, label truncated to 40 |
| Step text | `step.screen + "\n"` | verbatim, no trailing newline |
| Manifest | `steps-manifest.json`, `{step, screenshot, unchanged_from_previous}`, screenshot is a bare name | `evidence.json`, `same_as: {index, label}`, screenshot is a full path |
| Dedup | off unless `evidence.dedup_step_screenshots` | always on |
| Renderer | text-only `render(text, path, cols, rows)` still supported for third-party renderers | requires `render_attributed` |
| Render failure | propagates, fails the run | recorded on the step as `error` |

Plus `publish` needs a `RunIdentity`, which `_render_step_screens` has no
recipe/renderer/run-id to build.

Making `publish` absorb those would mean six strategy knobs on the collector,
which is a worse collector for the sake of a wrapper — and every knob is a
chance to change the `evidence.json` a downstream consumer already reads. The
genuinely shared part is the dedup, and that is what got extracted.

This is not the documentation-only fallback: the duplicated logic is gone, not
annotated.

## Rust parity

**Rust does not have this split, and needs no change.**

- `rust/crates/termproof/src/evidence/dedup.rs` already holds a `Deduper`, and
  `evidence/collector.rs:428` is its only caller. Rust factored the rule out at
  consolidation.
- `evidence::report` is a Markdown/JUnit generator over `RunResult`. It has no
  step-screenshot rendering, no `steps/` layout, and no `unchanged_from_previous`
  — `grep` for those turns up Python only. So there was no second Rust copy to
  reconcile.

`python/termproof/dedup.py` mirrors `dedup.rs`, including its API
(`check` / `forget` / `last_rendered`). It sits at top level rather than inside
`termproof/evidence.py` because the Python package flattens the Rust
`evidence::` namespace into top-level modules — the same mapping that puts
`crate::evidence::collector` at `termproof/collector.py` and
`crate::terminal::attributed` at `termproof/attributed.py`.

The wider Python/Rust divergence — Rust has no `render_artifacts` equivalent at
all — is pre-existing and out of scope here.

## Conformance

No new cross-implementation surface, so the conformance pair is unextended, and
that is deliberate: it compares *documents*, and this change produces the same
documents. `probe_evidence_manifest.py` already exercises the dedup (it captures
`menu-open` twice, and `styled`/`unstyled` for the colour-only case), so the
shared rule is already differentially covered through `evidence.json`.

`Deduper`'s own behaviour is pinned by mirrored unit tests instead:
`python/tests/test_dedup.py` transcribes `dedup.rs`'s test module case for case.

## Behaviour

Unchanged, and not by weakening anything:

- 793/793 Python tests pass, including `test_evidence_config.py`'s
  `StepScreenshotDedupTest` and `test_step_attributed_screens.py`'s dedup cases,
  untouched.
- `conformance/probe_evidence_manifest.py` reproduces
  `conformance/corpus/evidence_manifest.expected.json` byte for byte (`diff`
  clean), so the published `evidence.json` and every file it points at are
  identical.
- `ruff check .` and `mypy termproof` clean.

The one place the code got tighter rather than equivalent: the old `publish`
had a dead `previous_fingerprint = None` in its no-renderer branch, overwritten
two lines later. Its effect was already nil (the reuse branch was separately
guarded on `last_rendered is not None`), and the no-renderer path is covered by
`test_text_is_written_even_with_no_renderer`.

## Tests

- `python/tests/test_dedup.py` (new) — mirrors `dedup.rs`'s tests: first screen
  renders, run of identical screens all point at the *first* not the neighbour,
  colour-only change is a change, lookback is one step only, `forget` on a
  failed render.
- `python/tests/test_collector.py` — new `SharedDedupTest` covers the delegation
  path on both sides by substituting the deduper, so it fails if either module
  re-grows its own copy *even if that copy is correct*:
  - collector with a never-matching deduper renders two identical screens twice;
  - `render_artifacts` with an always-matching deduper reports a sentinel image
    for two *different* screens — a verdict nothing could reach on its own;
  - a failed render calls `Deduper.forget`;
  - dedup off never consults the deduper at all.

## Not done

No version bump. `CHANGELOG.md` entry is under `[Unreleased]` → `Python — Changed`.

Local note: Rust test binaries are SIGKILLed on startup in this worktree
(sandbox/Gatekeeper), on a clean tree as well as this one, so
`differential_evidence_manifest` was verified from the oracle side only — the
Python half, which is the half this PR could have moved, reproduces the corpus
exactly. CI runs the Rust half.
