### PR TITLE
evidence: record_session, the five-step whole-session recording, in both implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,39 +258,6 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   "must be a positive integer" was wrong for them, and `0.5` satisfies
   "positive" while still being refused.
 
-### Rust — Changed (breaking)
-
-- **`evidence::collector::EvidencePublisher` gained a fifth public field,
-  `video_converter: Option<CastVideoConverter>`, which stops the struct being
-  constructible by literal.** Every field of `EvidencePublisher` is `pub` and
-  the struct is not `#[non_exhaustive]`, so an external crate writing
-  `EvidencePublisher { dir, identity, renderer, uploader }` no longer compiles;
-  `cargo semver-checks` reports it as `constructible_struct_adds_field`. Nothing
-  else about the type moved — the four existing fields keep their names, types
-  and meanings, and `EvidencePublisher::new` plus the `with_*` builders
-  (`with_renderer`, `with_uploader`, and the new `with_video_converter`) compile
-  unchanged.
-
-  **To fix a literal, build through the constructor**, which is what every
-  in-tree caller and every doc example already does:
-
-  ```rust
-  // was
-  let publisher = EvidencePublisher { dir, identity, renderer, uploader: Some(u) };
-  // now
-  let publisher = EvidencePublisher::new(dir, identity)
-      .with_renderer(renderer)
-      .with_uploader(u);
-  ```
-
-  Filed as breaking rather than as an addition because the pre-1.0 rule in this
-  file's preamble is about what a consumer's source does, not about what the
-  crate meant to offer. The seam had to hang somewhere, and the alternative
-  shape — passing the converter to `record_session` instead of the publisher —
-  would have avoided the break at the cost of putting one of the publisher's
-  three seams somewhere other than the publisher. That trade is worth stating;
-  it is not free either way.
-
 ### Rust — Added
 
 - **`result::score_from` and `result::assertion_map`:** the same two functions
@@ -349,6 +316,39 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   status quo rather than changing it. Giving `SvgMetrics` a raster floor to
   match is worth doing and is deliberately not done here — it would change what
   Rust renders, in a release that changes no other Rust rendering behaviour.
+
+### Rust — Changed (breaking)
+
+- **`evidence::collector::EvidencePublisher` gained a fifth public field,
+  `video_converter: Option<CastVideoConverter>`, which stops the struct being
+  constructible by literal.** Every field of `EvidencePublisher` is `pub` and
+  the struct is not `#[non_exhaustive]`, so an external crate writing
+  `EvidencePublisher { dir, identity, renderer, uploader }` no longer compiles;
+  `cargo semver-checks` reports it as `constructible_struct_adds_field`. Nothing
+  else about the type moved — the four existing fields keep their names, types
+  and meanings, and `EvidencePublisher::new` plus the `with_*` builders
+  (`with_renderer`, `with_uploader`, and the new `with_video_converter`) compile
+  unchanged.
+
+  **To fix a literal, build through the constructor**, which is what every
+  in-tree caller and every doc example already does:
+
+  ```rust
+  // was
+  let publisher = EvidencePublisher { dir, identity, renderer, uploader: Some(u) };
+  // now
+  let publisher = EvidencePublisher::new(dir, identity)
+      .with_renderer(renderer)
+      .with_uploader(u);
+  ```
+
+  Filed as breaking rather than as an addition because the pre-1.0 rule in this
+  file's preamble is about what a consumer's source does, not about what the
+  crate meant to offer. The seam had to hang somewhere, and the alternative
+  shape — passing the converter to `record_session` instead of the publisher —
+  would have avoided the break at the cost of putting one of the publisher's
+  three seams somewhere other than the publisher. That trade is worth stating;
+  it is not free either way.
 
 ## [0.4.0] — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,12 +87,23 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   one non-fatal step; **a conversion that failed leaves nothing to upload, so no
   upload is attempted** — reporting a store error for a video that was never
   encoded is exactly what two independent consumer implementations got wrong.
-  Nothing raises: a recording is evidence about a run, not part of its verdict.
-  Every failure instead lands on the `Recording`'s `error`, prefixed with the
-  name of the step that produced it — `save cast`, `append checkpoint frames`,
-  `convert` or `upload` — and two failures in one call are joined with `"; "` so
-  neither is lost. A callable that reports success and writes no cast is
-  reported as step 1 failing, not left for step 2 to discover as a missing file.
+  No failure a step *reports* raises: a recording is evidence about a run, not
+  part of its verdict. Every failure instead lands on the `Recording`'s `error`,
+  prefixed with the name of the step that produced it — `save cast`,
+  `append checkpoint frames`, `convert` or `upload` — and two failures in one
+  call are joined with `"; "` so neither is lost. The promise stops where
+  `Exception` does: a `KeyboardInterrupt` or `SystemExit` from one of the three
+  caller-supplied seams propagates and the recording is lost rather than
+  degraded, which the docstring now says outright.
+
+  **A step is not believed, it is checked.** Each of the three seams is
+  caller-supplied, and the outcome worse than any recorded failure is a
+  `Recording` that reports none — no `error`, a `video` that is not on disk, and
+  a `url` for it. So a `save_cast` that returns having written no file, a
+  converter that returns a path it did not write, and an uploader that returns
+  an empty string are each recorded as *that* step failing
+  (`convert: reported success but wrote no file at <path>`, and so on), rather
+  than left for the next step to trip over and take the blame.
 
 - **`termproof.collector.EvidencePublisher.video_converter`**, beside the
   existing `renderer` and `uploader`, with `termproof.collector.VideoConverterLike`
@@ -247,6 +258,39 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   "must be a positive integer" was wrong for them, and `0.5` satisfies
   "positive" while still being refused.
 
+### Rust — Changed (breaking)
+
+- **`evidence::collector::EvidencePublisher` gained a fifth public field,
+  `video_converter: Option<CastVideoConverter>`, which stops the struct being
+  constructible by literal.** Every field of `EvidencePublisher` is `pub` and
+  the struct is not `#[non_exhaustive]`, so an external crate writing
+  `EvidencePublisher { dir, identity, renderer, uploader }` no longer compiles;
+  `cargo semver-checks` reports it as `constructible_struct_adds_field`. Nothing
+  else about the type moved — the four existing fields keep their names, types
+  and meanings, and `EvidencePublisher::new` plus the `with_*` builders
+  (`with_renderer`, `with_uploader`, and the new `with_video_converter`) compile
+  unchanged.
+
+  **To fix a literal, build through the constructor**, which is what every
+  in-tree caller and every doc example already does:
+
+  ```rust
+  // was
+  let publisher = EvidencePublisher { dir, identity, renderer, uploader: Some(u) };
+  // now
+  let publisher = EvidencePublisher::new(dir, identity)
+      .with_renderer(renderer)
+      .with_uploader(u);
+  ```
+
+  Filed as breaking rather than as an addition because the pre-1.0 rule in this
+  file's preamble is about what a consumer's source does, not about what the
+  crate meant to offer. The seam had to hang somewhere, and the alternative
+  shape — passing the converter to `record_session` instead of the publisher —
+  would have avoided the break at the cost of putting one of the publisher's
+  three seams somewhere other than the publisher. That trade is worth stating;
+  it is not free either way.
+
 ### Rust — Added
 
 - **`result::score_from` and `result::assertion_map`:** the same two functions
@@ -259,15 +303,15 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   steps with the same semantics and the same rule about which of them run after
   a failure, taking `save_cast: FnOnce(&Path) -> Result<(), String>` where
   Python takes a callable that raises. It returns nothing rather than a
-  `Result`, for the reason nothing on the Python side raises: no failure may
-  fail the run. `&mut self`, because it appends a `Recording`; `publish` stays
-  `&self`. The four step names it prefixes an error with are the same four
-  strings both implementations write, which the conformance pair now compares.
+  `Result`, for the reason nothing on the Python side raises: no failure a step
+  reports may fail the run. `&mut self`, because it appends a `Recording`;
+  `publish` stays `&self`. The four step names it prefixes an error with are the
+  same four strings both implementations write, which the conformance pair now
+  compares.
 
-- **`evidence::collector::EvidencePublisher::video_converter`** and
-  `with_video_converter`, beside the existing `renderer` and `uploader` and in
-  the same builder style. Holds a `CastVideoConverter`, and is `Option` for the
-  reason the Python field is.
+- `with_video_converter`, beside the existing `with_renderer` and
+  `with_uploader` and in the same builder style. The field it sets is the
+  breaking part above.
 
 - **`evidence::cast_video::append_checkpoint_frames`:** the same capability with
   the same semantics, taking `hold_seconds: Option<f64>` where Python takes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,44 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   same rule; the difference between the two shapes is that a list weighs
   duplicate names once each and a mapping folds them into one entry.
 
+- **`termproof.collector.EvidenceCollector.record_session`:** the wiring 0.4.0
+  left out. `Recording`, `attach_recording`, the cast-to-video backends and the
+  upload seam all existed; nothing joined them, so every consumer that wanted a
+  video of a whole run wrote the same five-step sequence itself. This is that
+  sequence: save the live session's cast through a caller-supplied callable,
+  append the captured checkpoints to it with `append_checkpoint_frames`,
+  convert it to a video, upload the video, and attach a `Recording` that
+  `publish` then writes into the manifest.
+
+  **The error handling is the part worth having upstream, and it is a stated
+  rule rather than an accident of control flow: a step runs only when the step
+  before it produced the thing it works on.** A cast that could not be saved
+  leaves nothing to append to, convert or upload, so steps 2–4 are skipped; an
+  append that failed leaves the cast on disk and still convertible, so it is the
+  one non-fatal step; **a conversion that failed leaves nothing to upload, so no
+  upload is attempted** — reporting a store error for a video that was never
+  encoded is exactly what two independent consumer implementations got wrong.
+  Nothing raises: a recording is evidence about a run, not part of its verdict.
+  Every failure instead lands on the `Recording`'s `error`, prefixed with the
+  name of the step that produced it — `save cast`, `append checkpoint frames`,
+  `convert` or `upload` — and two failures in one call are joined with `"; "` so
+  neither is lost. A callable that reports success and writes no cast is
+  reported as step 1 failing, not left for step 2 to discover as a missing file.
+
+- **`termproof.collector.EvidencePublisher.video_converter`**, beside the
+  existing `renderer` and `uploader`, with `termproof.collector.VideoConverterLike`
+  as its protocol. Optional rather than defaulted, because a converter is two
+  more binaries on the host; a `record_session` against a publisher without one
+  records that as the `convert` step failing, since converting is what it was
+  called to do.
+
+- **`termproof.cast_video.RsvgFfmpegBackend.convert`** and `output_path_for`,
+  which satisfy that protocol: `render` is the `VideoBackend` method and is
+  unchanged, and `convert` supplies the two things it makes a caller invent — an
+  output path and a frame rate. The rate is the configured
+  `evidence.video.fps`, or `DEFAULT_FPS` when the backend was not built from a
+  config, which is the rate Rust's `CastVideoConverter` defaults to.
+
 - **`termproof.cast_video.append_checkpoint_frames`:** appends the captured
   checkpoint screens to a cast as held trailing frames, so a recording ends by
   replaying the evidence sequence instead of stopping on whatever the last
@@ -216,6 +254,20 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   `assertion_map` collecting `(impl Into<String>, bool)` pairs. The empty-map
   case is `1.0` here too, and is documented on `RunResult::score` — the field
   the number ends up in — rather than only on the function that computes it.
+
+- **`evidence::collector::EvidenceCollector::record_session`:** the same five
+  steps with the same semantics and the same rule about which of them run after
+  a failure, taking `save_cast: FnOnce(&Path) -> Result<(), String>` where
+  Python takes a callable that raises. It returns nothing rather than a
+  `Result`, for the reason nothing on the Python side raises: no failure may
+  fail the run. `&mut self`, because it appends a `Recording`; `publish` stays
+  `&self`. The four step names it prefixes an error with are the same four
+  strings both implementations write, which the conformance pair now compares.
+
+- **`evidence::collector::EvidencePublisher::video_converter`** and
+  `with_video_converter`, beside the existing `renderer` and `uploader` and in
+  the same builder style. Holds a `CastVideoConverter`, and is `Option` for the
+  reason the Python field is.
 
 - **`evidence::cast_video::append_checkpoint_frames`:** the same capability with
   the same semantics, taking `hold_seconds: Option<f64>` where Python takes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,27 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   three seams somewhere other than the publisher. That trade is worth stating;
   it is not free either way.
 
+  **The version does not move for it.** The pre-1.0 rule above says a breaking
+  change bumps the minor digit; the decision on [#196](https://github.com/md-mt/termproof/pull/196)
+  is that termproof stays on 0.4.x and this break is waived instead. So
+  `constructible_struct_adds_field` is set to `allow` in
+  `[package.metadata.cargo-semver-checks.lints]` in
+  `rust/crates/termproof/Cargo.toml` — the tool's own scoped mechanism, one
+  lint, rather than a version bump or a disabled CI job. **This entry is not
+  rewritten to match:** a waiver decides what the version does about a break,
+  not whether the break happened, and a consumer whose literal stopped
+  compiling needs the paragraphs above whatever the digit says.
+
+  The waiver is scoped in two directions, because at lint granularity it would
+  otherwise also cover field additions nobody has decided about:
+  `every_public_field_of_the_publisher_is_accounted_for` builds
+  `EvidencePublisher` from an exhaustive literal, so a sixth field fails to
+  compile, and
+  `the_semver_waiver_is_scoped_to_the_release_it_was_granted_for` fails the
+  build if the version leaves 0.4.x while the waiver is still in place. The
+  release checklist in `rust/docs/publishing.md` now says to read the waiver
+  list before reading the green check.
+
 ## [0.4.0] — 2026-08-19
 
 ### Rust — Changed

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -432,15 +432,44 @@ base of `0.5000005` — which is what a Rust-recorded cast ends on, since
 `CastRecorder` writes `as_secs_f64()` unrounded — separates them at three of the
 eight appended frames.
 
+The same reasoning brought `record_session` in. Its outcome is a string in the
+manifest — the `error` field of a `Recording`, prefixed with the name of the
+step that failed — and "which step failed" is only useful to a reader if it does
+not depend on which implementation produced the run. Each half drives it once
+per outcome, over publishers that differ only in the seam under test:
+
+| recording | what it pins |
+|---|---|
+| `recorded` | all five steps succeed: the cast, the evidence appended to it, the video, the URL |
+| `unsaveable` | step 1 refusing — Python raises, Rust returns `Err`, both write `save cast: disk on fire` |
+| `silent-save` | step 1 reporting success and writing nothing, which is still step 1 |
+| `no-converter` | a publisher with no video converter, which is the `convert` step failing |
+| `bad-encode` | a conversion that fails, and the upload that must not follow it |
+| `no-url` | an upload that declines, which costs the URL and not the video |
+
+The recordings' own casts and videos land in the publish directory, so they are
+compared as files too, not only as paths.
+
+One failure is deliberately absent: an append that fails. Its message comes from
+`append_checkpoint_frames`, which words its complaints differently in the two
+languages — `empty cast file` against `<path> is empty: a cast has a header
+line` — so recording it here would freeze a divergence in the corpus rather than
+check a shared surface. Each implementation covers it in its own unit tests.
+
 ## What is deliberately neutralised
 
-Two things in the scenario are properties of the machine rather than of either
+Three things in the scenario are properties of the machine rather than of either
 implementation, and both halves handle them the same way:
 
 - **The rasteriser.** `ScreenshotRenderer` shells out to `rsvg-convert`, so on a
   host without it every step would record a render error whose text belongs to
   the operating system. Both halves stub the tool and write a fixed byte, so a
   screenshot is recorded on every host.
+- **The video encoder.** Rust's `CastVideoConverter` shells out to
+  `rsvg-convert` and `ffmpeg`; the Rust half stubs the tool runner and the
+  Python half stands in a converter that writes the same fixed byte. Neither the
+  frame count nor the encoder reaches the manifest — the video path and the file
+  at it are what have to agree.
 - **The publish directory**, which is a fresh temporary directory. Both halves
   substitute it for `@DIR` before comparing.
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -445,16 +445,41 @@ per outcome, over publishers that differ only in the seam under test:
 | `silent-save` | step 1 reporting success and writing nothing, which is still step 1 |
 | `no-converter` | a publisher with no video converter, which is the `convert` step failing |
 | `bad-encode` | a conversion that fails, and the upload that must not follow it |
+| `silent-encode` | step 3 reporting success and writing nothing — the `silent-save` guard, one step down |
 | `no-url` | an upload that declines, which costs the URL and not the video |
+| `blank-url` | an upload that returns `""`, which both sides have to reject rather than record |
+| *(empty label)* | the one input on which the two filename schemes could part |
 
 The recordings' own casts and videos land in the publish directory, so they are
 compared as files too, not only as paths.
 
-One failure is deliberately absent: an append that fails. Its message comes from
-`append_checkpoint_frames`, which words its complaints differently in the two
-languages — `empty cast file` against `<path> is empty: a cast has a header
-line` — so recording it here would freeze a divergence in the corpus rather than
-check a shared surface. Each implementation covers it in its own unit tests.
+The empty-label case is there because a recording's `cast` and `video` are
+strings in the manifest and the two implementations build them differently at
+exactly one input: Rust goes through `store::sanitize_component`, which
+substitutes `default` for a component that sanitises to nothing, and Python's
+`_sanitize` returns `""`. `_recording_file_stem` applies the same fallback so
+the two agree, and this case is what holds it there. `CapturedStep.file_stem`
+still differs the same way for the same input — pre-existing, not driven by this
+scenario, and listed under "outside" below.
+
+Two failures are deliberately absent:
+
+- **An append that fails.** Its message comes from `append_checkpoint_frames`,
+  which words its complaints differently in the two languages — `empty cast
+  file` against `<path> is empty: a cast has a header line` — so recording it
+  here would freeze a divergence in the corpus rather than check a shared
+  surface. Each implementation covers it in its own unit tests.
+- **An upload that declines *with a reason*.** Rust reads
+  `ArtifactUploader::last_error()`; Python's `UploaderLike` has no such
+  accessor, so a Python uploader says why by raising. `no-url` and `blank-url`
+  therefore pin the *shared fallback* — `upload: uploader returned no URL`,
+  emitted when there is no reason to be had — and not the shipped behaviour:
+  `FallbackUploader`,
+  the only non-test `ArtifactUploader` in the crate, sets `last_error` on every
+  failure, so in practice Rust writes `upload: all uploaders returned no URL`
+  where Python writes `upload: uploader returned no URL`. That disagreement is
+  real and is recorded here rather than in the corpus, because pinning it would
+  make the harness certify a divergence.
 
 ## What is deliberately neutralised
 

--- a/conformance/corpus/evidence_manifest.expected.json
+++ b/conformance/corpus/evidence_manifest.expected.json
@@ -1,5 +1,11 @@
 {
   "files": {
+    "recording-02-recorded.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
+    "recording-02-recorded.mp4": "mp4",
+    "recording-05-no-converter.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
+    "recording-06-bad-encode.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
+    "recording-07-no-url.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
+    "recording-07-no-url.mp4": "mp4",
     "session-with-checkpoints.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
     "session-with-fractional-hold.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5000005,\"o\",\"MENU\"]\n[0.700001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[0.900001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[1.100001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[1.300001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[1.500001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[1.700001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[1.900001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[2.100001,\"o\",\"\\u001b[m\"]\n",
     "step-00-menu-open.png": "png",
@@ -33,6 +39,48 @@
         "label": "failed-encode",
         "url": null,
         "video": null
+      },
+      {
+        "cast": "@DIR/recording-02-recorded.cast",
+        "error": null,
+        "label": "recorded",
+        "url": "https://example.invalid/recording-02-recorded.mp4",
+        "video": "@DIR/recording-02-recorded.mp4"
+      },
+      {
+        "cast": "@DIR/recording-03-unsaveable.cast",
+        "error": "save cast: disk on fire",
+        "label": "unsaveable",
+        "url": null,
+        "video": null
+      },
+      {
+        "cast": "@DIR/recording-04-silent-save.cast",
+        "error": "save cast: reported success but wrote no file at @DIR/recording-04-silent-save.cast",
+        "label": "silent-save",
+        "url": null,
+        "video": null
+      },
+      {
+        "cast": "@DIR/recording-05-no-converter.cast",
+        "error": "convert: no video converter configured",
+        "label": "no-converter",
+        "url": null,
+        "video": null
+      },
+      {
+        "cast": "@DIR/recording-06-bad-encode.cast",
+        "error": "convert: encoder exploded",
+        "label": "bad-encode",
+        "url": null,
+        "video": null
+      },
+      {
+        "cast": "@DIR/recording-07-no-url.cast",
+        "error": "upload: uploader returned no URL",
+        "label": "no-url",
+        "url": null,
+        "video": "@DIR/recording-07-no-url.mp4"
       }
     ],
     "run": {

--- a/conformance/corpus/evidence_manifest.expected.json
+++ b/conformance/corpus/evidence_manifest.expected.json
@@ -4,8 +4,13 @@
     "recording-02-recorded.mp4": "mp4",
     "recording-05-no-converter.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
     "recording-06-bad-encode.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
-    "recording-07-no-url.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
-    "recording-07-no-url.mp4": "mp4",
+    "recording-07-silent-encode.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
+    "recording-08-no-url.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
+    "recording-08-no-url.mp4": "mp4",
+    "recording-09-blank-url.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
+    "recording-09-blank-url.mp4": "mp4",
+    "recording-10-default.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
+    "recording-10-default.mp4": "mp4",
     "session-with-checkpoints.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5,\"o\",\"\\u001b[3;20rMENU\"]\n[1.25,\"o\",\"\\r\\nitem one\"]\n[4.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[7.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[10.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[13.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[16.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[19.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[22.25,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[25.25,\"o\",\"\\u001b[m\"]\n",
     "session-with-fractional-hold.cast": "{\"version\":2,\"width\":80,\"height\":24}\n[0.5000005,\"o\",\"MENU\"]\n[0.700001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[0.900001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JMENU\\r\\nitem one\"]\n[1.100001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JRECOVERED\"]\n[1.300001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JLAST SCREEN\"]\n[1.500001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JERROR\"]\n[1.700001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2J\\u001b[31mALERT\\u001b[0m\"]\n[1.900001,\"o\",\"\\u001b[m\\u001b[r\\u001b[H\\u001b[2JALERT\"]\n[2.100001,\"o\",\"\\u001b[m\"]\n",
     "step-00-menu-open.png": "png",
@@ -76,11 +81,32 @@
         "video": null
       },
       {
-        "cast": "@DIR/recording-07-no-url.cast",
+        "cast": "@DIR/recording-07-silent-encode.cast",
+        "error": "convert: reported success but wrote no file at @DIR/recording-07-silent-encode.mp4",
+        "label": "silent-encode",
+        "url": null,
+        "video": null
+      },
+      {
+        "cast": "@DIR/recording-08-no-url.cast",
         "error": "upload: uploader returned no URL",
         "label": "no-url",
         "url": null,
-        "video": "@DIR/recording-07-no-url.mp4"
+        "video": "@DIR/recording-08-no-url.mp4"
+      },
+      {
+        "cast": "@DIR/recording-09-blank-url.cast",
+        "error": "upload: uploader returned no URL",
+        "label": "blank-url",
+        "url": null,
+        "video": "@DIR/recording-09-blank-url.mp4"
+      },
+      {
+        "cast": "@DIR/recording-10-default.cast",
+        "error": null,
+        "label": "",
+        "url": "https://example.invalid/recording-10-default.mp4",
+        "video": "@DIR/recording-10-default.mp4"
       }
     ],
     "run": {

--- a/conformance/probe_evidence_manifest.py
+++ b/conformance/probe_evidence_manifest.py
@@ -17,6 +17,15 @@ manifest agreeing about a recording's path is not agreeing about the recording,
 and once ``append_checkpoint_frames`` puts the evidence sequence on the end of
 one, the cast is the artifact a reviewer actually watches.
 
+The scenario also drives ``record_session`` down each of its outcomes, because
+the ``error`` it writes onto a ``Recording`` is a string in the manifest and
+has to be the *same* string on both sides — "which step failed" is only useful
+to a reader if it does not depend on which implementation produced the run. One
+failure is deliberately left out: an append that fails. Its message comes from
+``append_checkpoint_frames`` itself, which words its complaints differently in
+the two languages, so it is covered by unit tests on each side rather than
+recorded here as a divergence.
+
 The scenario is not a corpus file, unlike the step and assertion harnesses.
 There is only one document shape to compare and it is built by calling an API
 rather than by replaying data, so the cases are the code below and the Rust
@@ -121,6 +130,52 @@ class _StubUploader:
         return f"https://example.invalid/{path.name}"
 
 
+class _RefusingUploader:
+    """Declines without saying why, which is all the Python protocol allows.
+
+    The Rust half's counterpart reports no ``last_error`` either, so both
+    implementations fall back on the same shared message.
+    """
+
+    def upload(self, path: Path) -> str | None:
+        return None
+
+
+class _StubConverter:
+    """Writes a fixed byte instead of shelling out to rsvg-convert and ffmpeg.
+
+    The Rust half is a real ``CastVideoConverter`` whose tool runner is stubbed,
+    which replays the cast and renders every frame before writing the same byte.
+    Neither the frame count nor the encoder reaches the manifest — the video
+    *path* and the file at it are what the two sides have to agree on.
+    """
+
+    def convert(self, cast_path: Path, video_path: Path | None = None) -> Path:
+        output = cast_path.with_suffix(".mp4") if video_path is None else video_path
+        output.write_text("mp4", encoding="utf-8")
+        return output
+
+
+class _BrokenConverter:
+    """Fails with a message neither language contributes to."""
+
+    def convert(self, cast_path: Path, video_path: Path | None = None) -> Path:
+        raise RuntimeError("encoder exploded")
+
+
+def _save_base_cast(dest: Path) -> None:
+    dest.write_text(BASE_CAST, encoding="utf-8")
+
+
+def _refuse_to_save(dest: Path) -> None:
+    """Raises where the Rust half returns ``Err`` — the house pattern."""
+    raise RuntimeError("disk on fire")
+
+
+def _save_nothing(dest: Path) -> None:
+    """Reports success and writes no file, which is step 1 lying."""
+
+
 def build(directory: Path) -> tuple[dict[str, object], dict[str, str]]:
     collector = EvidenceCollector()
 
@@ -158,6 +213,41 @@ def build(directory: Path) -> tuple[dict[str, object], dict[str, str]]:
             cast="/tmp/broken.cast",
             error="video conversion failed",
         )
+    )
+
+    # `record_session`, once per outcome. Every publisher writes into the same
+    # directory and differs only in the seam under test, so the recordings are
+    # numbered consecutively and their artifacts all land in `files`.
+    def publisher(**seams: object) -> EvidencePublisher:
+        return EvidencePublisher(
+            directory=directory,
+            identity=IDENTITY,
+            renderer=_StubRenderer(),
+            **seams,  # type: ignore[arg-type]
+        )
+
+    working = publisher(uploader=_StubUploader(), video_converter=_StubConverter())
+    # All five steps succeed: cast, appended evidence, video, URL.
+    collector.record_session("recorded", working, _save_base_cast)
+    # Step 1 fails, so nothing downstream runs.
+    collector.record_session("unsaveable", working, _refuse_to_save)
+    # Step 1 fails quietly, which is still step 1.
+    collector.record_session("silent-save", working, _save_nothing)
+    # Step 3 has nothing to convert with.
+    collector.record_session(
+        "no-converter", publisher(uploader=_StubUploader()), _save_base_cast
+    )
+    # Step 3 fails, so step 4 is not attempted: no URL, and no upload error.
+    collector.record_session(
+        "bad-encode",
+        publisher(uploader=_StubUploader(), video_converter=_BrokenConverter()),
+        _save_base_cast,
+    )
+    # Step 4 fails, which costs the URL and not the video.
+    collector.record_session(
+        "no-url",
+        publisher(uploader=_RefusingUploader(), video_converter=_StubConverter()),
+        _save_base_cast,
     )
 
     manifest = collector.publish(

--- a/conformance/probe_evidence_manifest.py
+++ b/conformance/probe_evidence_manifest.py
@@ -20,11 +20,17 @@ one, the cast is the artifact a reviewer actually watches.
 The scenario also drives ``record_session`` down each of its outcomes, because
 the ``error`` it writes onto a ``Recording`` is a string in the manifest and
 has to be the *same* string on both sides — "which step failed" is only useful
-to a reader if it does not depend on which implementation produced the run. One
-failure is deliberately left out: an append that fails. Its message comes from
-``append_checkpoint_frames`` itself, which words its complaints differently in
-the two languages, so it is covered by unit tests on each side rather than
-recorded here as a divergence.
+to a reader if it does not depend on which implementation produced the run.
+
+Two failures are deliberately left out, both because the two implementations
+word them differently and pinning either would make this harness certify a
+divergence. An **append that fails** takes its message from
+``append_checkpoint_frames`` itself (``empty cast file`` against ``<path> is
+empty: a cast has a header line``). An **upload that declines with a reason**
+takes its message from Rust's ``ArtifactUploader::last_error``, which Python's
+``UploaderLike`` has no counterpart for. ``no-url`` and ``blank-url`` therefore
+pin the *shared fallback*, not the shipped behaviour — see
+``conformance/README.md``. Each side covers the rest in its own unit tests.
 
 The scenario is not a corpus file, unlike the step and assertion harnesses.
 There is only one document shape to compare and it is built by calling an API
@@ -130,6 +136,18 @@ class _StubUploader:
         return f"https://example.invalid/{path.name}"
 
 
+class _BlankUploader:
+    """Returns an empty string, which is no URL.
+
+    A distinct scenario from :class:`_RefusingUploader` even though both produce
+    the same message: the two implementations reject the empty string in their
+    own code, so this is what stops one of them keeping it.
+    """
+
+    def upload(self, path: Path) -> str | None:
+        return ""
+
+
 class _RefusingUploader:
     """Declines without saying why, which is all the Python protocol allows.
 
@@ -161,6 +179,19 @@ class _BrokenConverter:
 
     def convert(self, cast_path: Path, video_path: Path | None = None) -> Path:
         raise RuntimeError("encoder exploded")
+
+
+class _SilentConverter:
+    """Reports success and writes nothing.
+
+    The Rust half's counterpart is a tool runner whose every invocation exits
+    cleanly and produces no file, which is what a real ``ffmpeg`` misconfigured
+    for its output looks like. Both implementations have to refuse it, and to
+    refuse it with the same words.
+    """
+
+    def convert(self, cast_path: Path, video_path: Path | None = None) -> Path:
+        return cast_path.with_suffix(".mp4") if video_path is None else video_path
 
 
 def _save_base_cast(dest: Path) -> None:
@@ -243,12 +274,31 @@ def build(directory: Path) -> tuple[dict[str, object], dict[str, str]]:
         publisher(uploader=_StubUploader(), video_converter=_BrokenConverter()),
         _save_base_cast,
     )
+    # Step 3 reports success and writes nothing, which is step 3 lying -- the
+    # same guard as `silent-save`, one step further down.
+    collector.record_session(
+        "silent-encode",
+        publisher(uploader=_StubUploader(), video_converter=_SilentConverter()),
+        _save_base_cast,
+    )
     # Step 4 fails, which costs the URL and not the video.
     collector.record_session(
         "no-url",
         publisher(uploader=_RefusingUploader(), video_converter=_StubConverter()),
         _save_base_cast,
     )
+    # Step 4 returning an empty string, which is no URL.
+    collector.record_session(
+        "blank-url",
+        publisher(uploader=_BlankUploader(), video_converter=_StubConverter()),
+        _save_base_cast,
+    )
+    # An empty label, the one input on which the two filename schemes could
+    # part: Rust builds the stem through `sanitize_component`, which substitutes
+    # "default" for a component that sanitises to nothing, and Python's
+    # `_sanitize` does not. `_recording_file_stem` applies the same fallback, and
+    # this is what holds it there.
+    collector.record_session("", working, _save_base_cast)
 
     manifest = collector.publish(
         EvidencePublisher(

--- a/python/README.md
+++ b/python/README.md
@@ -113,6 +113,33 @@ Here `kind` defaults to `CaptureKind.CHECKPOINT`; Rust takes it positionally,
 as `capture_text(label, screen, CaptureKind::Checkpoint)`. The meaning, the
 ordering and the resulting manifest are identical.
 
+### Recording the whole session
+
+`record_session` is the five-step sequence around a video: save the live
+session's cast through the callable you pass, append the captured checkpoints
+to it as held trailing frames, convert it, upload it, and attach a `Recording`
+that `publish` writes into the manifest.
+
+```python
+publisher = EvidencePublisher(
+    directory=run_dir / "evidence",
+    identity=identity,
+    video_converter=RsvgFfmpegBackend(),
+    uploader=my_uploader,
+)
+collector.record_session("full-session", publisher, lambda dest: session.save_cast(dest))
+manifest = collector.publish(publisher)
+```
+
+**No step may fail the run**, so nothing here raises: a recording is evidence
+about a run, not part of its verdict. Each failure lands on the `Recording`'s
+`error` instead, prefixed with the step that produced it — `save cast`,
+`append checkpoint frames`, `convert` or `upload` — and two of them in one call
+are joined with `"; "`. A step runs only when the step before it produced what
+it works on, so a failed save skips everything after it and **a failed
+conversion is never uploaded**; a failed append is the one non-fatal case,
+because the cast is on disk and still convertible either way.
+
 ## Recipe example
 
 ```json

--- a/python/README.md
+++ b/python/README.md
@@ -121,24 +121,43 @@ to it as held trailing frames, convert it, upload it, and attach a `Recording`
 that `publish` writes into the manifest.
 
 ```python
+import shutil
+
+from termproof.cast_video import RsvgFfmpegBackend
+from termproof.collector import EvidencePublisher
+
 publisher = EvidencePublisher(
     directory=run_dir / "evidence",
     identity=identity,
     video_converter=RsvgFfmpegBackend(),
     uploader=my_uploader,
 )
-collector.record_session("full-session", publisher, lambda dest: session.save_cast(dest))
+# `session` here is a `TerminalSession`, which records to `session.cast_path`;
+# the callable's job is to put a copy of that cast at the path it is handed.
+collector.record_session(
+    "full-session", publisher, lambda dest: shutil.copyfile(session.cast_path, dest)
+)
 manifest = collector.publish(publisher)
 ```
 
-**No step may fail the run**, so nothing here raises: a recording is evidence
-about a run, not part of its verdict. Each failure lands on the `Recording`'s
-`error` instead, prefixed with the step that produced it — `save cast`,
+**No failure a step reports fails the run**: a recording is evidence about a
+run, not part of its verdict. Each failure lands on the `Recording`'s `error`
+instead, prefixed with the step that produced it — `save cast`,
 `append checkpoint frames`, `convert` or `upload` — and two of them in one call
-are joined with `"; "`. A step runs only when the step before it produced what
-it works on, so a failed save skips everything after it and **a failed
-conversion is never uploaded**; a failed append is the one non-fatal case,
-because the cast is on disk and still convertible either way.
+are joined with `"; "`. (The boundary is where `Exception` stops: a
+`KeyboardInterrupt` from one of the seams propagates and the recording is lost
+rather than degraded.)
+
+A step runs only when the step before it produced what it works on, so a failed
+save skips everything after it and **a failed conversion is never uploaded**; a
+failed append is the one non-fatal case, because the cast is on disk and still
+convertible either way.
+
+**And a step is not believed, it is checked.** A `save_cast` that returns having
+written no file, a converter that returns a path it did not write, and an
+uploader that returns an empty string are all recorded as that step failing.
+The alternative is the one outcome worse than a recorded failure: a `Recording`
+with no `error`, a `video` that is not on disk, and a `url` for it.
 
 ## Recipe example
 

--- a/python/termproof/cast_video.py
+++ b/python/termproof/cast_video.py
@@ -419,6 +419,27 @@ class RsvgFfmpegBackend:
             str(output_path),
         ]
 
+    def output_path_for(self, cast_path: Path) -> Path:
+        """The default video path for *cast_path*: the same path as an ``.mp4``."""
+        return cast_path.with_suffix(".mp4")
+
+    def convert(self, cast_path: Path, video_path: Path | None = None) -> Path:
+        """Render *cast_path* to MP4 and return where the video landed.
+
+        The seam :meth:`termproof.collector.EvidenceCollector.record_session`
+        drives, and the counterpart of Rust's ``CastVideoConverter::convert``.
+        :meth:`render` is the :class:`~termproof.protocols.VideoBackend`
+        protocol method and is unchanged; this one supplies the two things that
+        protocol makes a caller invent — an output path and a frame rate.
+
+        The frame rate is the configured ``evidence.video.fps`` when this
+        backend was built from a config, and :data:`DEFAULT_FPS` otherwise,
+        which is the rate Rust's converter defaults to.
+        """
+        output = self.output_path_for(cast_path) if video_path is None else video_path
+        self.render(cast_path, output, DEFAULT_FPS if self.video is None else self.video.fps)
+        return output
+
     def render(self, cast_path: Path, output_path: Path, fps: int) -> None:
         rsvg = self._resolve(self.rsvg_path, RSVG_CONVERT)
         ffmpeg = self._resolve(self.ffmpeg_path, FFMPEG)

--- a/python/termproof/collector.py
+++ b/python/termproof/collector.py
@@ -60,11 +60,25 @@ Folding one of the two *file layouts* into the other is a different change from
 sharing the dedup, and not one to smuggle in here: it would move the paths
 :func:`termproof.evidence.render_artifacts` has always written, which every
 existing reader of a run directory depends on.
+
+A whole-session recording is five steps, and four of them can fail
+-------------------------------------------------------------------
+
+:meth:`EvidenceCollector.record_session` is the wiring between the pieces
+around it: it saves the live session's cast through a caller-supplied callable,
+appends the captured checkpoints to it with
+:func:`termproof.cast_video.append_checkpoint_frames`, converts it to a video,
+uploads the video, and records the outcome on a :class:`Recording`. Every
+consumer that wanted a video of the whole run wrote that sequence itself, and
+what they got wrong was never the happy path — it was which step is allowed to
+fail, and what the run is told when one does. See
+:meth:`EvidenceCollector.record_session` for the rule.
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -83,6 +97,24 @@ MANIFEST_FILE = "evidence.json"
 
 #: Longest label fragment allowed in a generated filename.
 MAX_LABEL_IN_FILENAME = 40
+
+# Names of the four fallible steps of `EvidenceCollector.record_session`, as
+# they appear at the front of a `Recording.error`.
+#
+# Spelled once each, and asserted literally in the tests, because "which step
+# failed" is the whole point of the field: a report that says only that
+# something went wrong sends a reader back to the machine that produced it. The
+# Rust implementation writes the same four strings.
+_STEP_SAVE_CAST = "save cast"
+_STEP_APPEND_FRAMES = "append checkpoint frames"
+_STEP_CONVERT = "convert"
+_STEP_UPLOAD = "upload"
+
+# Step 3's failure when the publisher was never given a converter.
+_NO_VIDEO_CONVERTER = "no video converter configured"
+
+# Step 4's failure when the uploader declined without saying why.
+_NO_URL = "uploader returned no URL"
 
 
 class RawOutput(Enum):
@@ -236,6 +268,21 @@ class UploaderLike(Protocol):
     def upload(self, path: Path) -> str | None: ...
 
 
+class VideoConverterLike(Protocol):
+    """Turns a cast into a video and says where the video landed.
+
+    Mirrors Rust's ``CastVideoConverter::convert``, and is satisfied by
+    :class:`termproof.cast_video.RsvgFfmpegBackend`. Deliberately not the
+    :class:`termproof.protocols.VideoBackend` shape: that one takes an ``fps``
+    and returns nothing, so every caller would have to invent an output path
+    and a frame rate before it could ask for a video.
+
+    Raises on failure — the counterpart of Rust's ``Err``.
+    """
+
+    def convert(self, cast_path: Path, video_path: Path | None = None) -> Path: ...
+
+
 @dataclass
 class EvidencePublisher:
     """Where published evidence goes and how it gets there."""
@@ -250,6 +297,16 @@ class EvidencePublisher:
     #: Uploads are best-effort: a failure leaves the step's ``url`` empty
     #: rather than failing the publish.
     uploader: UploaderLike | None = None
+    #: Encodes a session recording, for
+    #: :meth:`EvidenceCollector.record_session` and for nothing else —
+    #: :meth:`EvidenceCollector.publish` renders stills and does not encode.
+    #:
+    #: Optional rather than defaulted because a converter is two more binaries
+    #: on the host (``rsvg-convert`` and ``ffmpeg``), and a publisher that is
+    #: only ever going to write stills should not imply them. A
+    #: ``record_session`` against a publisher without one records that as the
+    #: ``convert`` step failing.
+    video_converter: VideoConverterLike | None = None
 
     def manifest_path(self) -> Path:
         return self.directory / MANIFEST_FILE
@@ -428,6 +485,134 @@ class EvidenceCollector:
         """
         self._recordings.append(recording)
 
+    def record_session(
+        self,
+        label: str,
+        publisher: EvidencePublisher,
+        save_cast: Callable[[Path], None],
+    ) -> None:
+        """Save the session's cast, derive a video from it, upload it, and
+        record the outcome.
+
+        The five steps, in order:
+
+        1. write the live session's cast, by calling *save_cast* with the path
+           to write to — the collector picks the path so the cast lands beside
+           the stills it belongs with;
+        2. append the captured checkpoints to that cast as held trailing
+           frames, through
+           :func:`termproof.cast_video.append_checkpoint_frames`;
+        3. convert the cast to a video, through the publisher's
+           :attr:`~EvidencePublisher.video_converter`;
+        4. upload the video, through the publisher's
+           :attr:`~EvidencePublisher.uploader`;
+        5. attach a :class:`Recording` describing what came of all that, which
+           :meth:`publish` then writes into the manifest.
+
+        **No failure fails the run.** Nothing here raises, on purpose: a
+        recording is evidence *about* a run, not part of its verdict, so a
+        missing video degrades the report and nothing else. Every failure lands
+        on the ``Recording`` instead, prefixed with the name of the step that
+        produced it — ``save cast``, ``append checkpoint frames``, ``convert``
+        or ``upload`` — and reaches the report from there. Two failures in one
+        call are joined with ``"; "``, so neither is lost to the other. Step 5
+        is the only one that cannot fail: it appends to a list.
+
+        **Which later steps run after a failure.** A step runs only when the
+        step before it produced the thing it works on. That is the whole rule,
+        and it decides every case:
+
+        ==================  =================  ==========================================
+        step that failed    what still runs    why
+        ==================  =================  ==========================================
+        1, save cast        nothing            no cast to append to, convert or upload
+        2, append frames    3 and 4            the cast is still on disk and still
+                                               convertible; it just ends on the session
+                                               instead of on the evidence
+        3, convert          nothing after it   there is no video to upload
+        4, upload           —                  it is last; ``video`` is still recorded,
+                                               only ``url`` is missing
+        ==================  =================  ==========================================
+
+        The case worth naming is the one a hand-written version gets wrong: **an
+        upload is never attempted after a failed conversion.** Uploading the
+        path a conversion did not produce is how a run ends up reporting a store
+        error for a video that was never encoded.
+
+        A publisher with no uploader is not a failure — it is a publisher that
+        was not asked to upload, exactly as in :meth:`publish`. A publisher with
+        no *converter* is a failure, because converting is what this method was
+        called to do.
+
+        *save_cast* writes a cast to the path it is handed, and raises to say it
+        could not; the exception's text becomes the step-1 message, where Rust
+        takes an ``Err(String)``. A callable that returns normally and writes
+        nothing is treated as step 1 failing, rather than left for step 2 to
+        discover as a missing file: the step that lied is the one worth naming.
+        """
+        # Imported here, not at module scope: `cast_video` imports
+        # `CapturedStep` from this module, so a top-level import would close
+        # the cycle. Nothing else in the collector needs the video path.
+        from .cast_video import append_checkpoint_frames
+
+        stem = _recording_file_stem(len(self._recordings), label)
+        cast_path = publisher.directory / f"{stem}.cast"
+        recording = Recording(label=label, cast=str(cast_path))
+        errors: list[str] = []
+
+        # 1. Write the cast. The directory is created here rather than left to
+        #    the callable: the collector chose the path, so the collector owes
+        #    it somewhere to be written.
+        try:
+            publisher.directory.mkdir(parents=True, exist_ok=True)
+            save_cast(cast_path)
+        except Exception as exc:  # noqa: BLE001 - no failure may fail the run
+            recording.error = f"{_STEP_SAVE_CAST}: {exc}"
+            self._recordings.append(recording)
+            return
+        if not cast_path.is_file():
+            recording.error = (
+                f"{_STEP_SAVE_CAST}: reported success but wrote no file at {cast_path}"
+            )
+            self._recordings.append(recording)
+            return
+
+        # 2. Put the evidence sequence on the end of it. Non-fatal: the cast is
+        #    on disk either way, and a recording that stops on the session is
+        #    worth more than no recording at all.
+        try:
+            append_checkpoint_frames(cast_path, self._steps)
+        except Exception as exc:  # noqa: BLE001 - no failure may fail the run
+            errors.append(f"{_STEP_APPEND_FRAMES}: {exc}")
+
+        # 3. Encode it.
+        video_path = publisher.directory / f"{stem}.mp4"
+        if publisher.video_converter is None:
+            errors.append(f"{_STEP_CONVERT}: {_NO_VIDEO_CONVERTER}")
+        else:
+            try:
+                video = Path(publisher.video_converter.convert(cast_path, video_path))
+            except Exception as exc:  # noqa: BLE001 - no failure may fail the run
+                errors.append(f"{_STEP_CONVERT}: {exc}")
+            else:
+                recording.video = str(video)
+                # 4. Share it. Only reachable with a video in hand.
+                if publisher.uploader is not None:
+                    try:
+                        url = publisher.uploader.upload(video)
+                    except Exception as exc:  # noqa: BLE001 - no failure may fail the run
+                        errors.append(f"{_STEP_UPLOAD}: {exc}")
+                    else:
+                        if url is None:
+                            errors.append(f"{_STEP_UPLOAD}: {_NO_URL}")
+                        else:
+                            recording.url = url
+
+        # 5. Record what happened, including which step it happened in.
+        if errors:
+            recording.error = "; ".join(errors)
+        self._recordings.append(recording)
+
     @property
     def steps(self) -> list[CapturedStep]:
         return list(self._steps)
@@ -541,6 +726,16 @@ def _sanitize(value: str) -> str:
     return "".join(c if c.isalnum() or c in "-_" else "-" for c in value)
 
 
+def _recording_file_stem(index: int, label: str) -> str:
+    """Filename stem shared by a recording's cast and video.
+
+    Numbered like :meth:`CapturedStep.file_stem` and for the same reason: labels
+    are caller-supplied and may repeat, and two recordings called
+    ``full-session`` must not overwrite each other's cast.
+    """
+    return f"recording-{index:02d}-{_sanitize(label[:MAX_LABEL_IN_FILENAME])}"
+
+
 #: A source built from a screen the caller already has. Useful in tests and for
 #: replaying a cast, neither of which has a live program to read from.
 def static_source(screen: str, raw_output: str = "") -> ScreenSource:
@@ -570,5 +765,6 @@ __all__ = [
     "RunIdentity",
     "ScreenCapture",
     "ScreenSource",
+    "VideoConverterLike",
     "static_source",
 ]

--- a/python/termproof/collector.py
+++ b/python/termproof/collector.py
@@ -509,14 +509,23 @@ class EvidenceCollector:
         5. attach a :class:`Recording` describing what came of all that, which
            :meth:`publish` then writes into the manifest.
 
-        **No failure fails the run.** Nothing here raises, on purpose: a
-        recording is evidence *about* a run, not part of its verdict, so a
-        missing video degrades the report and nothing else. Every failure lands
-        on the ``Recording`` instead, prefixed with the name of the step that
-        produced it — ``save cast``, ``append checkpoint frames``, ``convert``
-        or ``upload`` — and reaches the report from there. Two failures in one
-        call are joined with ``"; "``, so neither is lost to the other. Step 5
-        is the only one that cannot fail: it appends to a list.
+        **No failure a step reports fails the run.** A recording is evidence
+        *about* a run, not part of its verdict, so a missing video degrades the
+        report and nothing else. Every failure lands on the ``Recording``
+        instead, prefixed with the name of the step that produced it —
+        ``save cast``, ``append checkpoint frames``, ``convert`` or ``upload`` —
+        and reaches the report from there. Two failures in one call are joined
+        with ``"; "``, so neither is lost to the other. Step 5 is the only one
+        that cannot fail: it appends to a list.
+
+        That promise has a boundary, and it is where ``Exception`` stops. A
+        ``KeyboardInterrupt`` or ``SystemExit`` from any of the three
+        caller-supplied seams propagates, and because the ``Recording`` is
+        attached at the end, it is lost rather than degraded. That is
+        deliberate — those are not failed steps, they are the process being
+        told to stop — and Rust draws the line in the same place: a panic in
+        the closure, the converter or the uploader unwinds through
+        ``record_session`` like any other.
 
         **Which later steps run after a failure.** A step runs only when the
         step before it produced the thing it works on. That is the whole rule,
@@ -544,11 +553,27 @@ class EvidenceCollector:
         no *converter* is a failure, because converting is what this method was
         called to do.
 
+        **A step is not believed, it is checked.** Every step here is a
+        caller-supplied seam, and the outcome worse than any recorded failure is
+        a ``Recording`` that reports none: no ``error``, a ``video`` that is not
+        on disk, and a ``url`` for it. So each step that claims to have produced
+        something is asked for the thing:
+
+        * step 1 returning normally with no file at the path is
+          ``save cast: reported success but wrote no file at <path>``;
+        * step 3 returning a path it did not write is
+          ``convert: reported success but wrote no file at <path>``;
+        * step 4 returning an empty string is treated as having returned
+          nothing, because a ``url`` of ``""`` is a link no reader can follow.
+
+        In each case the step that lied is the one named, rather than leaving
+        the next step to trip over the absence and take the blame. Step 2
+        produces nothing to check — it edits the cast in place — and step 5
+        appends to a list.
+
         *save_cast* writes a cast to the path it is handed, and raises to say it
         could not; the exception's text becomes the step-1 message, where Rust
-        takes an ``Err(String)``. A callable that returns normally and writes
-        nothing is treated as step 1 failing, rather than left for step 2 to
-        discover as a missing file: the step that lied is the one worth naming.
+        takes an ``Err(String)``.
         """
         # Imported here, not at module scope: `cast_video` imports
         # `CapturedStep` from this module, so a top-level import would close
@@ -585,7 +610,11 @@ class EvidenceCollector:
         except Exception as exc:  # noqa: BLE001 - no failure may fail the run
             errors.append(f"{_STEP_APPEND_FRAMES}: {exc}")
 
-        # 3. Encode it.
+        # 3. Encode it, and check it. A converter that returns a path it did not
+        #    write is step 3 lying in exactly the way a `save_cast` that writes
+        #    nothing is step 1 lying; taken on trust it produces the one outcome
+        #    worse than a recorded failure, a `Recording` with no error, a video
+        #    that is not there and a URL for it.
         video_path = publisher.directory / f"{stem}.mp4"
         if publisher.video_converter is None:
             errors.append(f"{_STEP_CONVERT}: {_NO_VIDEO_CONVERTER}")
@@ -595,18 +624,26 @@ class EvidenceCollector:
             except Exception as exc:  # noqa: BLE001 - no failure may fail the run
                 errors.append(f"{_STEP_CONVERT}: {exc}")
             else:
-                recording.video = str(video)
-                # 4. Share it. Only reachable with a video in hand.
-                if publisher.uploader is not None:
-                    try:
-                        url = publisher.uploader.upload(video)
-                    except Exception as exc:  # noqa: BLE001 - no failure may fail the run
-                        errors.append(f"{_STEP_UPLOAD}: {exc}")
-                    else:
-                        if url is None:
-                            errors.append(f"{_STEP_UPLOAD}: {_NO_URL}")
+                if not video.is_file():
+                    errors.append(
+                        f"{_STEP_CONVERT}: reported success but wrote no file at {video}"
+                    )
+                else:
+                    recording.video = str(video)
+                    # 4. Share it. Only reachable with a video in hand.
+                    if publisher.uploader is not None:
+                        try:
+                            url = publisher.uploader.upload(video)
+                        except Exception as exc:  # noqa: BLE001 - no failure may fail the run
+                            errors.append(f"{_STEP_UPLOAD}: {exc}")
                         else:
-                            recording.url = url
+                            # An empty URL is no URL: `url: ""` on a recording
+                            # with no error claims a link a reader cannot
+                            # follow.
+                            if not url:
+                                errors.append(f"{_STEP_UPLOAD}: {_NO_URL}")
+                            else:
+                                recording.url = url
 
         # 5. Record what happened, including which step it happened in.
         if errors:
@@ -726,14 +763,33 @@ def _sanitize(value: str) -> str:
     return "".join(c if c.isalnum() or c in "-_" else "-" for c in value)
 
 
+#: What Rust's ``store::sanitize_component`` substitutes for a component that
+#: sanitises to nothing. ``_sanitize`` has no such fallback, so the two disagree
+#: for an empty label — see :func:`_recording_file_stem`.
+_EMPTY_COMPONENT = "default"
+
+
 def _recording_file_stem(index: int, label: str) -> str:
     """Filename stem shared by a recording's cast and video.
 
     Numbered like :meth:`CapturedStep.file_stem` and for the same reason: labels
     are caller-supplied and may repeat, and two recordings called
     ``full-session`` must not overwrite each other's cast.
+
+    The empty-label fallback is applied here rather than in :func:`_sanitize`.
+    Rust builds this stem through ``store::sanitize_component``, which yields
+    ``"default"`` for a component that sanitises to nothing where ``_sanitize``
+    yields ``""``; a recording's ``cast`` and ``video`` are strings in the
+    manifest, so left alone the two implementations would write different paths
+    for ``record_session("", ...)``. The conformance pair records an empty-label
+    recording for that reason.
+
+    :meth:`CapturedStep.file_stem` still differs from Rust's the same way for
+    the same input. Converging ``_sanitize`` itself would move paths that
+    already ship, so it stays a change of its own; this narrows the divergence
+    to the surface that predates it rather than extending it to a new one.
     """
-    return f"recording-{index:02d}-{_sanitize(label[:MAX_LABEL_IN_FILENAME])}"
+    return f"recording-{index:02d}-{_sanitize(label[:MAX_LABEL_IN_FILENAME]) or _EMPTY_COMPONENT}"
 
 
 #: A source built from a screen the caller already has. Useful in tests and for

--- a/python/tests/test_cast_video.py
+++ b/python/tests/test_cast_video.py
@@ -11,6 +11,7 @@ from unittest import mock
 from termproof.attributed import AttributedCell, AttributedScreen, attributed_screen_from_text
 from termproof.cast_video import (
     DEFAULT_CHECKPOINT_HOLD,
+    DEFAULT_FPS,
     DEFAULT_IDLE_TIME_LIMIT,
     MIN_CHECKPOINT_HOLD,
     RsvgFfmpegBackend,
@@ -322,6 +323,27 @@ class RsvgFfmpegBackendTest(unittest.TestCase):
 
         backend = RsvgFfmpegBackend.from_config(EvidenceConfig(video=VideoConfig(idle_time_limit=3.0)))
         self.assertEqual(3.0, backend.idle_time_limit)
+
+    def test_convert_returns_where_the_video_landed(self) -> None:
+        # The seam `EvidenceCollector.record_session` drives: `render` returns
+        # nothing, so a caller that wants a video path has to be handed one.
+        out = self.tmp / "elsewhere.mp4"
+        self.assertEqual(out, self._backend().convert(self.cast, out))
+        self.assertEqual(self.runner.calls[-1][0], "/fake/ffmpeg")
+        self.assertIn(str(out), self.runner.calls[-1][1])
+
+    def test_convert_defaults_the_video_beside_the_cast(self) -> None:
+        self.assertEqual(self.tmp / "s.mp4", self._backend().convert(self.cast))
+
+    def test_convert_encodes_at_the_rate_rust_defaults_to(self) -> None:
+        # An unconfigured backend is the counterpart of `CastVideoConverter`'s
+        # own default, so the two implementations record at one frame rate.
+        self._backend().convert(self.cast)
+        self.assertIn(str(DEFAULT_FPS), self.runner.calls[-1][1])
+
+    def test_convert_honours_a_configured_frame_rate(self) -> None:
+        self._backend(video=VideoConfig(fps=12)).convert(self.cast)
+        self.assertIn("12", self.runner.calls[-1][1])
 
 
 #: Replaying an appended cast through the real emulator is the strongest check

--- a/python/tests/test_collector.py
+++ b/python/tests/test_collector.py
@@ -351,6 +351,294 @@ class RecordingTest(unittest.TestCase):
         self.assertNotIn("recordings", document)
 
 
+#: A cast with one event, the shape ``save_cast`` is expected to produce.
+_A_CAST = '{"version":2,"width":10,"height":3}\n[0.5,"o","live"]\n'
+
+
+def _save_a_cast(dest: Path) -> None:
+    """Writes :data:`_A_CAST` and returns, the way a real ``save_cast`` would."""
+    dest.write_text(_A_CAST, encoding="utf-8")
+
+
+class _StubConverter:
+    """Writes a fixed byte instead of shelling out to rsvg-convert and ffmpeg."""
+
+    def __init__(self) -> None:
+        self.converted: list[Path] = []
+
+    def convert(self, cast_path: Path, video_path: Path | None = None) -> Path:
+        output = cast_path.with_suffix(".mp4") if video_path is None else video_path
+        self.converted.append(cast_path)
+        output.write_text("mp4", encoding="utf-8")
+        return output
+
+
+class _BrokenConverter:
+    def convert(self, cast_path: Path, video_path: Path | None = None) -> Path:
+        raise RuntimeError("encoder exploded")
+
+
+class _RefusingUploader:
+    """Declines without saying why, which is all the protocol allows."""
+
+    def upload(self, path: Path) -> str | None:
+        return None
+
+
+class _ExplodingUploader:
+    def upload(self, path: Path) -> str | None:
+        raise RuntimeError("store down")
+
+
+class RecordSessionTest(unittest.TestCase):
+    """The five-step session recording, and what each step's failure does.
+
+    Mirrors ``record_session``'s tests in ``collector.rs``. Nothing here may
+    raise: a recording is evidence about a run, not part of its verdict, so a
+    test that fails by exception rather than by assertion is itself the bug.
+    """
+
+    def _collector(self) -> EvidenceCollector:
+        collector = EvidenceCollector()
+        collector.capture("only", static_source("screen text"))
+        return collector
+
+    def test_record_session_runs_the_five_steps_in_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            directory = Path(tmpdir) / "evidence"
+            uploader = _Uploader()
+            publisher = EvidencePublisher(
+                directory=directory,
+                identity=_identity(),
+                renderer=_RecordingRenderer(),
+                uploader=uploader,
+                video_converter=_StubConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            recording = collector.recordings[0]
+            self.assertEqual("full-session", recording.label)
+            self.assertIsNone(recording.error)
+
+            # 1. The cast is where the collector said it would be.
+            cast = Path(recording.cast)
+            self.assertEqual("recording-00-full-session.cast", cast.name)
+            contents = cast.read_text(encoding="utf-8")
+
+            # 2. With the captured screen appended to it, which is the whole
+            #    reason step 2 exists: the session's own last frame is not the
+            #    evidence.
+            self.assertTrue(contents.startswith(_A_CAST), contents)
+            self.assertIn("screen text", contents)
+
+            # 3 and 4.
+            video = Path(recording.video or "")
+            self.assertEqual("recording-00-full-session.mp4", video.name)
+            self.assertEqual("mp4", video.read_text(encoding="utf-8"))
+            self.assertEqual(f"https://example/{video.name}", recording.url)
+            self.assertEqual([video], uploader.uploaded)
+
+            # 5. And all of it reaches the manifest, which is what a report
+            #    reads.
+            manifest = collector.publish(publisher)
+            document = json.loads(manifest.path.read_text())
+
+        self.assertEqual(1, len(document["recordings"]))
+        self.assertEqual(str(video), document["recordings"][0]["video"])
+
+    def test_a_cast_that_cannot_be_saved_stops_the_sequence(self) -> None:
+        # Nothing downstream has anything to work on, so nothing downstream
+        # runs -- and the recording says which step it was.
+        def explode(dest: Path) -> None:
+            raise RuntimeError("disk on fire")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uploader = _Uploader()
+            converter = _StubConverter()
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                uploader=uploader,
+                video_converter=converter,
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, explode)
+
+            recording = collector.recordings[0]
+            self.assertEqual("save cast: disk on fire", recording.error)
+            self.assertIsNone(recording.video)
+            self.assertIsNone(recording.url)
+            self.assertEqual([], converter.converted)
+            self.assertEqual([], uploader.uploaded)
+            self.assertFalse(Path(recording.cast).exists())
+
+    def test_a_save_that_writes_nothing_is_the_save_step_failing(self) -> None:
+        # A callable that returns normally and writes no file is step 1 going
+        # wrong, not step 2 finding a missing file: blaming the append would
+        # send a reader to the wrong code.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            converter = _StubConverter()
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir), identity=_identity(), video_converter=converter
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, lambda dest: None)
+
+            error = collector.recordings[0].error or ""
+            self.assertTrue(error.startswith("save cast: "), error)
+            self.assertIn("wrote no file", error)
+            self.assertEqual([], converter.converted)
+
+    def test_an_append_failure_does_not_stop_the_conversion(self) -> None:
+        # Step 2 is the one non-fatal step: the cast is on disk either way, and
+        # a recording that ends on the session is worth more than none.
+        #
+        # An empty cast is the append failure reachable through
+        # `record_session`, the hold not being caller-supplied here. The stub
+        # converter does not read the cast, so this can assert the video
+        # survived; the Rust mirror uses a real `CastVideoConverter`, which
+        # cannot read an empty cast either, and asserts instead that step 3 was
+        # attempted and both failures were recorded.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                video_converter=_StubConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("empty", publisher, lambda dest: dest.write_text(""))
+
+            recording = collector.recordings[0]
+            error = recording.error or ""
+            self.assertTrue(error.startswith("append checkpoint frames: "), error)
+            self.assertIsNotNone(recording.video)
+
+    def test_a_publisher_with_no_video_converter_says_so(self) -> None:
+        # Not silence: `record_session` was called to produce a video, so a
+        # publisher that cannot is a failure of the convert step.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(directory=Path(tmpdir), identity=_identity())
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            recording = collector.recordings[0]
+            self.assertEqual("convert: no video converter configured", recording.error)
+            # Steps 1 and 2 still happened, so the cast is still evidence.
+            self.assertIn("screen text", Path(recording.cast).read_text(encoding="utf-8"))
+            self.assertIsNone(recording.video)
+
+    def test_a_failed_conversion_is_never_uploaded(self) -> None:
+        # The error path a hand-written version gets wrong: uploading the path
+        # a conversion did not produce, and reporting a store failure for a
+        # video that was never encoded.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uploader = _Uploader()
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                uploader=uploader,
+                video_converter=_BrokenConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            recording = collector.recordings[0]
+            self.assertEqual("convert: encoder exploded", recording.error)
+            self.assertIsNone(recording.video)
+            self.assertIsNone(recording.url)
+            self.assertEqual([], uploader.uploaded)
+
+    def test_a_failed_upload_keeps_the_video(self) -> None:
+        # Step 4 is last, so its failure costs the URL and nothing else. The
+        # video is still on disk and still worth naming.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                uploader=_ExplodingUploader(),
+                video_converter=_StubConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            recording = collector.recordings[0]
+            self.assertEqual("upload: store down", recording.error)
+            self.assertIsNotNone(recording.video)
+            self.assertIsNone(recording.url)
+
+    def test_an_uploader_that_declines_without_a_reason_still_names_the_step(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                uploader=_RefusingUploader(),
+                video_converter=_StubConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            self.assertEqual(
+                "upload: uploader returned no URL", collector.recordings[0].error
+            )
+
+    def test_a_publisher_with_no_uploader_is_not_a_failure(self) -> None:
+        # Absent is not broken: a publisher without an uploader was not asked to
+        # upload, exactly as in `publish`.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                video_converter=_StubConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            recording = collector.recordings[0]
+            self.assertIsNone(recording.error)
+            self.assertIsNotNone(recording.video)
+            self.assertIsNone(recording.url)
+
+    def test_two_recordings_with_one_label_do_not_share_a_cast(self) -> None:
+        # Labels are caller-supplied and may repeat; the second recording must
+        # not overwrite the first one's evidence.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                video_converter=_StubConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            first, second = collector.recordings
+            self.assertNotEqual(first.cast, second.cast)
+            self.assertNotEqual(first.video, second.video)
+            self.assertEqual("recording-01-full-session.cast", Path(second.cast).name)
+            self.assertEqual([None, None], [first.error, second.error])
+
+    def test_a_recorded_session_sits_beside_a_hand_attached_one(self) -> None:
+        # `record_session` and `attach_recording` write to the same list, in
+        # call order, so a caller that encodes its own video is not shut out.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                video_converter=_StubConverter(),
+            )
+            collector = self._collector()
+            collector.attach_recording(Recording(label="hand-made", cast="/tmp/other.cast"))
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            manifest = collector.publish(publisher)
+            document = json.loads(manifest.path.read_text())
+
+        self.assertEqual(
+            ["hand-made", "full-session"], [r["label"] for r in document["recordings"]]
+        )
+
+
 class AttachToTest(unittest.TestCase):
     """Joining a manifest to a result, which is what stops A being paired with B."""
 

--- a/python/tests/test_collector.py
+++ b/python/tests/test_collector.py
@@ -514,6 +514,28 @@ class RecordSessionTest(unittest.TestCase):
             self.assertTrue(error.startswith("append checkpoint frames: "), error)
             self.assertIsNotNone(recording.video)
 
+    def test_two_failures_are_both_recorded(self) -> None:
+        # `error` is one field, so a second failure must not evict the first:
+        # a report that names only the conversion sends a reader looking for a
+        # broken encoder when the evidence never reached the cast either.
+        #
+        # The Rust mirror asserts this inside
+        # `an_append_failure_does_not_stop_the_conversion`, where a real
+        # `CastVideoConverter` cannot read the empty cast either and so fails
+        # of its own accord.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                video_converter=_BrokenConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("empty", publisher, lambda dest: dest.write_text(""))
+
+            error = collector.recordings[0].error or ""
+            self.assertTrue(error.startswith("append checkpoint frames: "), error)
+            self.assertTrue(error.endswith("; convert: encoder exploded"), error)
+
     def test_a_publisher_with_no_video_converter_says_so(self) -> None:
         # Not silence: `record_session` was called to produce a video, so a
         # publisher that cannot is a failure of the convert step.
@@ -578,9 +600,11 @@ class RecordSessionTest(unittest.TestCase):
             collector = self._collector()
             collector.record_session("full-session", publisher, _save_a_cast)
 
-            self.assertEqual(
-                "upload: uploader returned no URL", collector.recordings[0].error
-            )
+            recording = collector.recordings[0]
+            self.assertEqual("upload: uploader returned no URL", recording.error)
+            # Step 4 is last: a declined upload costs the URL, not the video.
+            self.assertIsNotNone(recording.video)
+            self.assertIsNone(recording.url)
 
     def test_a_publisher_with_no_uploader_is_not_a_failure(self) -> None:
         # Absent is not broken: a publisher without an uploader was not asked to

--- a/python/tests/test_collector.py
+++ b/python/tests/test_collector.py
@@ -378,6 +378,19 @@ class _BrokenConverter:
         raise RuntimeError("encoder exploded")
 
 
+class _SilentConverter:
+    """Reports success and writes nothing.
+
+    The plausible shape of a lying converter, not a contrived one: an ``ffmpeg``
+    that exits 0 without producing its output leaves ``convert`` returning a
+    path that does not exist, and ``VideoConverterLike`` is a public protocol
+    whose whole purpose is third-party converters.
+    """
+
+    def convert(self, cast_path: Path, video_path: Path | None = None) -> Path:
+        return cast_path.with_suffix(".mp4") if video_path is None else video_path
+
+
 class _RefusingUploader:
     """Declines without saying why, which is all the protocol allows."""
 
@@ -388,6 +401,11 @@ class _RefusingUploader:
 class _ExplodingUploader:
     def upload(self, path: Path) -> str | None:
         raise RuntimeError("store down")
+
+
+class _BlankUploader:
+    def upload(self, path: Path) -> str | None:
+        return ""
 
 
 class RecordSessionTest(unittest.TestCase):
@@ -571,6 +589,49 @@ class RecordSessionTest(unittest.TestCase):
             self.assertIsNone(recording.url)
             self.assertEqual([], uploader.uploaded)
 
+    def test_a_converter_that_writes_nothing_is_the_convert_step_failing(self) -> None:
+        # The counterpart of test_a_save_that_writes_nothing_..., and the worse
+        # of the two if it is missed: taken on trust, a converter that returns a
+        # path it did not write produces a Recording with no error, a video that
+        # is not there and a URL for it -- a run reporting success for evidence
+        # that does not exist.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uploader = _Uploader()
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                uploader=uploader,
+                video_converter=_SilentConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            recording = collector.recordings[0]
+            error = recording.error or ""
+            self.assertTrue(error.startswith("convert: "), error)
+            self.assertIn("wrote no file", error)
+            self.assertIsNone(recording.video)
+            self.assertIsNone(recording.url)
+            self.assertEqual([], uploader.uploaded)
+
+    def test_an_empty_url_is_no_url(self) -> None:
+        # `url: ""` on a recording with no error claims a link a reader cannot
+        # follow, which is the same false success as a video that is not there.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            publisher = EvidencePublisher(
+                directory=Path(tmpdir),
+                identity=_identity(),
+                uploader=_BlankUploader(),
+                video_converter=_StubConverter(),
+            )
+            collector = self._collector()
+            collector.record_session("full-session", publisher, _save_a_cast)
+
+            recording = collector.recordings[0]
+            self.assertEqual("upload: uploader returned no URL", recording.error)
+            self.assertIsNone(recording.url)
+            self.assertIsNotNone(recording.video)
+
     def test_a_failed_upload_keeps_the_video(self) -> None:
         # Step 4 is last, so its failure costs the URL and nothing else. The
         # video is still on disk and still worth naming.
@@ -641,6 +702,21 @@ class RecordSessionTest(unittest.TestCase):
             self.assertNotEqual(first.video, second.video)
             self.assertEqual("recording-01-full-session.cast", Path(second.cast).name)
             self.assertEqual([None, None], [first.error, second.error])
+
+    def test_an_empty_label_names_a_recording_the_way_rust_names_it(self) -> None:
+        # The one input where the two implementations' filename schemes could
+        # part: Rust's `sanitize_component` substitutes "default" for a
+        # component that sanitises to nothing and `_sanitize` does not, so this
+        # stem applies the same fallback. Pinned literally, and in the
+        # conformance corpus, because a recording's `cast` and `video` are
+        # strings in the manifest.
+        self.assertEqual(
+            "recording-00-default", collector_module._recording_file_stem(0, "")
+        )
+        # A label that sanitises to something is not touched by the fallback.
+        self.assertEqual(
+            "recording-01---", collector_module._recording_file_stem(1, "!!")
+        )
 
     def test_a_recorded_session_sits_beside_a_hand_attached_one(self) -> None:
         # `record_session` and `attach_recording` write to the same list, in

--- a/rust/crates/termproof/Cargo.toml
+++ b/rust/crates/termproof/Cargo.toml
@@ -35,6 +35,35 @@ exclude = [
 [package.metadata.docs.rs]
 all-features = true
 
+# One waived semver lint, and the reason it is waived rather than fixed.
+#
+# `EvidencePublisher` gained a fifth public field, `video_converter`, and every
+# field of it is `pub` with no `#[non_exhaustive]`, so an external crate writing
+# `EvidencePublisher { dir, identity, renderer, uploader }` stopped compiling
+# (#196). Under the pre-1.0 rule in `docs/publishing.md` that is a minor bump.
+# The captain's decision on #196 is that termproof stays on 0.4.x and this
+# break is waived, so the lint is turned off here rather than the version being
+# moved or the job being disabled — `CHANGELOG.md` still describes the break in
+# full under `Rust — Changed (breaking)`, because a waiver is a decision about
+# the version and not a claim that nothing broke.
+#
+# **This is the tool's own scoped mechanism and it is scoped to a lint, not to a
+# struct.** cargo-semver-checks has no per-item allow, so while this line is
+# here a new `pub` field on *any* exhaustively-constructible public struct in
+# the crate passes CI unremarked. Two things bound that:
+#
+#   - `every_public_field_of_the_publisher_is_accounted_for` in
+#     `evidence::collector` pins `EvidencePublisher`'s field list, so the struct
+#     this waiver was granted for cannot grow another field silently;
+#   - the waiver is scoped in time to 0.4.x, and
+#     `the_semver_waiver_is_scoped_to_the_release_it_was_granted_for` fails the
+#     build when the version leaves that line, which is when the decision that
+#     justified it expires.
+#
+# Delete both this entry and those two tests together, or neither.
+[package.metadata.cargo-semver-checks.lints]
+constructible_struct_adds_field = "allow"
+
 [lints]
 workspace = true
 

--- a/rust/crates/termproof/README.md
+++ b/rust/crates/termproof/README.md
@@ -154,7 +154,11 @@ a comment on each one that sits above the oldest workable version.
   the step that produced it — `save cast`, `append checkpoint frames`,
   `convert` or `upload`. A step runs only when the step before it produced what
   it works on, so a failed save skips everything after it and **a failed
-  conversion is never uploaded**; a failed append is the one non-fatal case.
+  conversion is never uploaded**; a failed append is the one non-fatal case. A
+  step is not believed either: a closure that writes no cast, a converter that
+  returns a path it did not write, and an uploader that returns an empty string
+  are each recorded as that step failing, rather than reaching the manifest as
+  a recording that claims a video nobody can open.
 - `render_svg` / `render_by_extension` — plain screen text to an SVG, in
   default colours.
 - `ScreenshotRenderer` — an attributed grid to a PNG, with the colours the

--- a/rust/crates/termproof/README.md
+++ b/rust/crates/termproof/README.md
@@ -145,6 +145,16 @@ a comment on each one that sits above the oldest workable version.
   `capture_text(label, screen, kind=CaptureKind.CHECKPOINT)`, so the Rust call
   spells out `CaptureKind::Checkpoint` where the Python one may omit it. The
   meaning, the ordering and the resulting manifest are identical.
+- `EvidenceCollector::record_session` — the five steps around a whole-session
+  video: save the live session's cast through the closure you pass, append the
+  captured checkpoints to it as held trailing frames, convert it through the
+  publisher's `with_video_converter`, upload it, and attach a `Recording` that
+  `publish` writes into the manifest. It returns nothing, because no step may
+  fail the run: each failure lands on the `Recording`'s `error` prefixed with
+  the step that produced it — `save cast`, `append checkpoint frames`,
+  `convert` or `upload`. A step runs only when the step before it produced what
+  it works on, so a failed save skips everything after it and **a failed
+  conversion is never uploaded**; a failed append is the one non-fatal case.
 - `render_svg` / `render_by_extension` — plain screen text to an SVG, in
   default colours.
 - `ScreenshotRenderer` — an attributed grid to a PNG, with the colours the

--- a/rust/crates/termproof/src/evidence/collector.rs
+++ b/rust/crates/termproof/src/evidence/collector.rs
@@ -1381,6 +1381,55 @@ mod tests {
     }
 
     #[test]
+    fn every_public_field_of_the_publisher_is_accounted_for() {
+        // Half of what the waived `constructible_struct_adds_field` lint bought.
+        //
+        // `EvidencePublisher` is exhaustively constructible — every field `pub`,
+        // no `#[non_exhaustive]` — and adding `video_converter` broke external
+        // literals. `Cargo.toml` waives the lint that says so, on the captain's
+        // decision that 0.4.x stands; waiving it crate-wide is the only
+        // granularity cargo-semver-checks offers, so this recovers the cover for
+        // the struct the waiver was granted for.
+        //
+        // The assertions are incidental. **The exhaustive literal is the test**:
+        // a sixth field stops this compiling, so the struct cannot grow one
+        // without someone deciding to, which is exactly what the lint was for.
+        let publisher = EvidencePublisher {
+            dir: PathBuf::from("/tmp/evidence"),
+            identity: identity(),
+            renderer: ScreenshotRenderer::new(),
+            uploader: None,
+            video_converter: None,
+        };
+        assert_eq!(publisher.dir, PathBuf::from("/tmp/evidence"));
+        assert!(publisher.uploader.is_none());
+        assert!(publisher.video_converter.is_none());
+    }
+
+    #[test]
+    fn the_semver_waiver_is_scoped_to_the_release_it_was_granted_for() {
+        // The other half: the waiver is a decision about *this* release line,
+        // not a permanent exemption. It was granted on the reasoning that
+        // termproof stays on 0.4.x; the moment the version leaves 0.4.x that
+        // reasoning has expired and the waiver has to be re-decided rather than
+        // carried along, so this fails the build instead of letting it ride.
+        //
+        // Matched on the lint name alone: `cargo package` normalises the
+        // manifest, so the spacing around the value is not ours to rely on.
+        let manifest = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
+        let waived = manifest.contains("constructible_struct_adds_field");
+        let version = env!("CARGO_PKG_VERSION");
+        assert!(
+            !waived || version.starts_with("0.4."),
+            "the constructible_struct_adds_field waiver in Cargo.toml was granted \
+             for 0.4.x and this crate is {version}. Re-decide it: either the break \
+             is now carried by the version bump and the waiver, its comment and \
+             `every_public_field_of_the_publisher_is_accounted_for` all go, or it \
+             is re-granted for the new line and this test moves with it."
+        );
+    }
+
+    #[test]
     fn record_session_runs_the_five_steps_in_order() {
         let dir = tempfile::tempdir().expect("tempdir");
         let uploaded = Arc::new(Mutex::new(Vec::new()));

--- a/rust/crates/termproof/src/evidence/collector.rs
+++ b/rust/crates/termproof/src/evidence/collector.rs
@@ -480,13 +480,40 @@ impl EvidenceCollector {
     /// publisher with no *converter* is a failure, because converting is what
     /// this method was called to do.
     ///
+    /// # A step is not believed, it is checked
+    ///
+    /// Every step here is a caller-supplied seam, and the outcome worse than
+    /// any recorded failure is a `Recording` that reports none: no `error`, a
+    /// `video` that is not on disk, and a `url` for it. So each step that
+    /// claims to have produced something is asked for the thing:
+    ///
+    /// - step 1 reporting `Ok(())` with no file at the path is
+    ///   `save cast: reported success but wrote no file at <path>`;
+    /// - step 3 returning a path it did not write is
+    ///   `convert: reported success but wrote no file at <path>`;
+    /// - step 4 returning an empty string is treated as having returned
+    ///   nothing, because a `url` of `""` is a link no reader can follow.
+    ///
+    /// In each case the step that lied is the one named, rather than leaving
+    /// the next step to trip over the absence and take the blame. Step 2
+    /// produces nothing to check — it edits the cast in place — and step 5
+    /// appends to a `Vec`.
+    ///
     /// # `save_cast`
     ///
     /// Returns `Ok(())` having written a cast to the path it was handed, or
-    /// `Err` describing why it could not. A closure that reports success and
-    /// writes nothing is treated as step 1 failing, rather than left for step 2
-    /// to discover as a missing file: the step that lied is the one worth
-    /// naming.
+    /// `Err` describing why it could not.
+    ///
+    /// # What *can* still escape
+    ///
+    /// "No failure fails the run" is about failures the seams report. It is not
+    /// a catch-all: a **panic** in `save_cast`, in the converter or in the
+    /// uploader unwinds through this method like any other, and because the
+    /// `Recording` is attached at the end, an unwind loses it rather than
+    /// degrading it. That is deliberate — a panic is not a failed step, it is a
+    /// broken program — but it is the boundary of the promise, and the Python
+    /// implementation draws it in the same place by catching `Exception` and
+    /// not `BaseException`.
     ///
     /// ```no_run
     /// # use termproof::evidence::collector::{EvidenceCollector, EvidencePublisher, RunIdentity};
@@ -545,10 +572,24 @@ impl EvidenceCollector {
             errors.push(format!("{STEP_APPEND_FRAMES}: {message}"));
         }
 
-        // 3. Encode it.
+        // 3. Encode it, and check it. A converter that returns a path it did
+        //    not write is step 3 lying in exactly the way a `save_cast` that
+        //    writes nothing is step 1 lying; taken on trust it produces the one
+        //    outcome worse than a recorded failure, a `Recording` with no error,
+        //    a video that is not there and a URL for it.
         let video_path = path_string(&publisher.dir.join(format!("{stem}.mp4")));
         let converted = match &publisher.video_converter {
-            Some(converter) => converter.convert(&cast_string, Some(&video_path)),
+            Some(converter) => {
+                converter
+                    .convert(&cast_string, Some(&video_path))
+                    .and_then(|video| {
+                        if Path::new(&video).is_file() {
+                            Ok(video)
+                        } else {
+                            Err(format!("reported success but wrote no file at {video}"))
+                        }
+                    })
+            }
             None => Err(NO_VIDEO_CONVERTER.to_string()),
         };
         match converted {
@@ -556,7 +597,10 @@ impl EvidenceCollector {
                 recording.video = Some(video.clone());
                 // 4. Share it. Only reachable with a video in hand.
                 if let Some(uploader) = publisher.uploader.as_mut() {
-                    match uploader.upload(&video) {
+                    // An empty URL is no URL, the same scepticism `last_error`
+                    // already gets below: `url: ""` on a recording with no
+                    // error claims a link a reader cannot follow.
+                    match uploader.upload(&video).filter(|url| !url.is_empty()) {
                         Some(url) => recording.url = Some(url),
                         None => {
                             let detail = uploader
@@ -1306,6 +1350,17 @@ mod tests {
         CastVideoConverter::with_runner(Box::new(|_, _, _| Err("encoder exploded".to_string())))
     }
 
+    /// A converter whose tools all report success and write nothing.
+    ///
+    /// The plausible shape of a lying converter, not a contrived one: an
+    /// `ffmpeg` that exits 0 without producing its output leaves `convert`
+    /// returning `Ok(path)` for a path that does not exist, and
+    /// `CastVideoConverter::with_runner` is public precisely so a caller can
+    /// substitute its own tools.
+    fn silent_converter() -> CastVideoConverter {
+        CastVideoConverter::with_runner(Box::new(|_, _, _| Ok(())))
+    }
+
     /// An uploader that counts what it was asked to upload.
     struct CountingUploader(Arc<Mutex<Vec<String>>>);
 
@@ -1490,6 +1545,64 @@ mod tests {
     }
 
     #[test]
+    fn a_converter_that_writes_nothing_is_the_convert_step_failing() {
+        // The counterpart of `a_save_that_writes_nothing_is_the_save_step_failing`,
+        // and the worse of the two if it is missed: taken on trust, a converter
+        // that returns a path it did not write produces a `Recording` with no
+        // error, a video that is not there and a URL for it — a run reporting
+        // success for evidence that does not exist.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uploaded = Arc::new(Mutex::new(Vec::new()));
+        let mut publisher = publisher(dir.path())
+            .with_video_converter(silent_converter())
+            .with_uploader(Box::new(CountingUploader(uploaded.clone())));
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let recording = &collector.recordings()[0];
+        let error = recording.error.clone().expect("error");
+        assert!(error.starts_with("convert: "), "{error}");
+        assert!(error.contains("wrote no file"), "{error}");
+        assert_eq!(recording.video, None, "a video that is not on disk");
+        assert_eq!(recording.url, None);
+        assert!(
+            uploaded.lock().expect("poisoned").is_empty(),
+            "a video that was never written must not be uploaded"
+        );
+    }
+
+    #[test]
+    fn an_empty_url_is_no_url() {
+        // `url: ""` on a recording with no error claims a link a reader cannot
+        // follow, which is the same false success as a video that is not there.
+        struct Blank;
+        impl ArtifactUploader for Blank {
+            fn upload(&mut self, _: &str) -> Option<String> {
+                Some(String::new())
+            }
+            fn last_error(&self) -> Option<&str> {
+                None
+            }
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path())
+            .with_video_converter(stub_converter())
+            .with_uploader(Box::new(Blank));
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let recording = &collector.recordings()[0];
+        assert_eq!(
+            recording.error.as_deref(),
+            Some("upload: uploader returned no URL")
+        );
+        assert_eq!(recording.url, None);
+        assert!(recording.video.is_some());
+    }
+
+    #[test]
     fn a_failed_upload_keeps_the_video() {
         // Step 4 is last, so its failure costs the URL and nothing else. The
         // video is still on disk and still worth naming.
@@ -1575,6 +1688,19 @@ mod tests {
             .cast
             .ends_with("recording-01-full-session.cast"));
         assert!(recordings.iter().all(|r| r.error.is_none()));
+    }
+
+    #[test]
+    fn an_empty_label_names_a_recording_the_way_python_names_it() {
+        // The one input where the two implementations' filename schemes could
+        // part: `sanitize_component` substitutes "default" for a component that
+        // sanitises to nothing and Python's `_sanitize` does not, so Python
+        // applies the same fallback when building this stem. Pinned literally,
+        // and in the conformance corpus, because a recording's `cast` and
+        // `video` are strings in the manifest.
+        assert_eq!(recording_file_stem(0, ""), "recording-00-default");
+        // A label that sanitises to something is not touched by the fallback.
+        assert_eq!(recording_file_stem(1, "!!"), "recording-01---");
     }
 
     #[test]

--- a/rust/crates/termproof/src/evidence/collector.rs
+++ b/rust/crates/termproof/src/evidence/collector.rs
@@ -70,12 +70,25 @@
 //! A session's raw output is the whole log so far rather than the delta, so a
 //! copy per checkpoint is quadratic in the length of the run and every copy
 //! but the last is a prefix of a later one.
+//!
+//! # A whole-session recording is five steps, and four of them can fail
+//!
+//! [`record_session`](EvidenceCollector::record_session) is the wiring between
+//! the pieces above: it saves the live session's cast through a caller-supplied
+//! closure, appends the captured checkpoints to it with
+//! [`append_checkpoint_frames`], converts it to a video, uploads the video, and
+//! records the outcome on a [`Recording`]. Every consumer that needed a video
+//! of the whole run wrote that sequence itself, and what they got wrong was
+//! never the happy path — it was which step is allowed to fail, and what the
+//! run is told when one does. See
+//! [`record_session`](EvidenceCollector::record_session) for the rule.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::evidence::cast_video::{append_checkpoint_frames, CastVideoConverter};
 use crate::evidence::dedup::Deduper;
 use crate::evidence::screenshot::ScreenshotRenderer;
 use crate::evidence::uploader::ArtifactUploader;
@@ -94,6 +107,25 @@ pub const MANIFEST_FILE: &str = "evidence.json";
 
 /// Longest label fragment allowed in a generated filename.
 const MAX_LABEL_IN_FILENAME: usize = 40;
+
+/// Names of the four fallible steps of
+/// [`record_session`](EvidenceCollector::record_session), as they appear at the
+/// front of a [`Recording::error`].
+///
+/// Spelled once each, and asserted literally in the tests, because "which step
+/// failed" is the whole point of the field: a report that says only that
+/// something went wrong sends a reader back to the machine that produced it.
+/// The Python implementation writes the same four strings.
+const STEP_SAVE_CAST: &str = "save cast";
+const STEP_APPEND_FRAMES: &str = "append checkpoint frames";
+const STEP_CONVERT: &str = "convert";
+const STEP_UPLOAD: &str = "upload";
+
+/// Step 3's failure when the publisher was never given a converter.
+const NO_VIDEO_CONVERTER: &str = "no video converter configured";
+
+/// Step 4's failure when the uploader declined without saying why.
+const NO_URL: &str = "uploader returned no URL";
 
 /// Whether a capture should carry the raw output log with it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -394,6 +426,158 @@ impl EvidenceCollector {
         self.recordings.push(recording);
     }
 
+    /// Save the session's cast, derive a video from it, upload it, and record
+    /// the outcome.
+    ///
+    /// The five steps, in order:
+    ///
+    /// 1. write the live session's cast, by calling `save_cast` with the path
+    ///    to write to — the collector picks the path so the cast lands beside
+    ///    the stills it belongs with;
+    /// 2. append the captured checkpoints to that cast as held trailing frames,
+    ///    through [`append_checkpoint_frames`];
+    /// 3. convert the cast to a video, through the publisher's
+    ///    [`video_converter`](EvidencePublisher::video_converter);
+    /// 4. upload the video, through the publisher's
+    ///    [`uploader`](EvidencePublisher::uploader);
+    /// 5. attach a [`Recording`] describing what came of all that, which
+    ///    [`publish`](Self::publish) then writes into the manifest.
+    ///
+    /// `&mut self` because it appends that recording; [`publish`](Self::publish)
+    /// stays `&self`.
+    ///
+    /// # No failure fails the run
+    ///
+    /// There is no `Result` here on purpose. A recording is evidence *about* a
+    /// run, not part of its verdict, so a missing video degrades the report and
+    /// nothing else. Every failure instead lands on the `Recording`, prefixed
+    /// with the name of the step that produced it — `save cast`,
+    /// `append checkpoint frames`, `convert` or `upload` — and reaches the
+    /// report from there. Two failures in one call are joined with `"; "`, so
+    /// neither is lost to the other.
+    ///
+    /// Step 5 is the only one that cannot fail: it appends to a `Vec`.
+    ///
+    /// # Which later steps run after a failure
+    ///
+    /// **A step runs only when the step before it produced the thing it works
+    /// on.** That is the whole rule, and it decides every case:
+    ///
+    /// | step that failed | what still runs | why |
+    /// |---|---|---|
+    /// | 1, save cast | nothing | there is no cast to append to, convert or upload |
+    /// | 2, append frames | 3 and 4 | the cast is still on disk and still convertible; it just ends on the session instead of on the evidence |
+    /// | 3, convert | nothing after it | there is no video to upload |
+    /// | 4, upload | — | it is last; `video` is still recorded, only `url` is missing |
+    ///
+    /// The case worth naming is the one a hand-written version gets wrong:
+    /// **an upload is never attempted after a failed conversion.** Uploading
+    /// the path a conversion did not produce is how a run ends up reporting a
+    /// store error for a video that was never encoded.
+    ///
+    /// A publisher with no uploader is not a failure — it is a publisher that
+    /// was not asked to upload, exactly as in [`publish`](Self::publish). A
+    /// publisher with no *converter* is a failure, because converting is what
+    /// this method was called to do.
+    ///
+    /// # `save_cast`
+    ///
+    /// Returns `Ok(())` having written a cast to the path it was handed, or
+    /// `Err` describing why it could not. A closure that reports success and
+    /// writes nothing is treated as step 1 failing, rather than left for step 2
+    /// to discover as a missing file: the step that lied is the one worth
+    /// naming.
+    ///
+    /// ```no_run
+    /// # use termproof::evidence::collector::{EvidenceCollector, EvidencePublisher, RunIdentity};
+    /// # use termproof::evidence::cast_video::CastVideoConverter;
+    /// # let mut evidence = EvidenceCollector::new();
+    /// # let identity = RunIdentity::new("login", "default", "run-1");
+    /// # let live_cast = std::path::PathBuf::from("/tmp/session.cast");
+    /// let mut publisher = EvidencePublisher::new("/tmp/run-1/evidence", identity)
+    ///     .with_video_converter(CastVideoConverter::new());
+    ///
+    /// evidence.record_session("full-session", &mut publisher, |dest| {
+    ///     std::fs::copy(&live_cast, dest).map(|_| ()).map_err(|e| e.to_string())
+    /// });
+    /// let manifest = evidence.publish(&mut publisher).expect("published");
+    /// ```
+    pub fn record_session<F>(
+        &mut self,
+        label: &str,
+        publisher: &mut EvidencePublisher,
+        save_cast: F,
+    ) where
+        F: FnOnce(&Path) -> Result<(), String>,
+    {
+        let stem = recording_file_stem(self.recordings.len(), label);
+        let cast_path = publisher.dir.join(format!("{stem}.cast"));
+        let mut recording = Recording::new(label, path_string(&cast_path));
+        let mut errors: Vec<String> = Vec::new();
+
+        // 1. Write the cast. The directory is created here rather than left to
+        //    the closure: the collector chose the path, so the collector owes
+        //    it somewhere to be written.
+        let saved = std::fs::create_dir_all(&publisher.dir)
+            .map_err(|e| e.to_string())
+            .and_then(|()| save_cast(&cast_path))
+            .and_then(|()| {
+                if cast_path.is_file() {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "reported success but wrote no file at {}",
+                        path_string(&cast_path)
+                    ))
+                }
+            });
+        if let Err(message) = saved {
+            recording.error = Some(format!("{STEP_SAVE_CAST}: {message}"));
+            self.recordings.push(recording);
+            return;
+        }
+
+        // 2. Put the evidence sequence on the end of it. Non-fatal: the cast is
+        //    on disk either way, and a recording that stops on the session is
+        //    worth more than no recording at all.
+        let cast_string = path_string(&cast_path);
+        if let Err(message) = append_checkpoint_frames(&cast_string, &self.steps, None) {
+            errors.push(format!("{STEP_APPEND_FRAMES}: {message}"));
+        }
+
+        // 3. Encode it.
+        let video_path = path_string(&publisher.dir.join(format!("{stem}.mp4")));
+        let converted = match &publisher.video_converter {
+            Some(converter) => converter.convert(&cast_string, Some(&video_path)),
+            None => Err(NO_VIDEO_CONVERTER.to_string()),
+        };
+        match converted {
+            Ok(video) => {
+                recording.video = Some(video.clone());
+                // 4. Share it. Only reachable with a video in hand.
+                if let Some(uploader) = publisher.uploader.as_mut() {
+                    match uploader.upload(&video) {
+                        Some(url) => recording.url = Some(url),
+                        None => {
+                            let detail = uploader
+                                .last_error()
+                                .filter(|e| !e.is_empty())
+                                .unwrap_or(NO_URL);
+                            errors.push(format!("{STEP_UPLOAD}: {detail}"));
+                        }
+                    }
+                }
+            }
+            Err(message) => errors.push(format!("{STEP_CONVERT}: {message}")),
+        }
+
+        // 5. Record what happened, including which step it happened in.
+        if !errors.is_empty() {
+            recording.error = Some(errors.join("; "));
+        }
+        self.recordings.push(recording);
+    }
+
     /// The attached recordings, in the order they were attached.
     pub fn recordings(&self) -> &[Recording] {
         &self.recordings
@@ -513,6 +697,16 @@ impl EvidenceCollector {
     }
 }
 
+/// Filename stem shared by a recording's cast and video.
+///
+/// Numbered like [`CapturedStep::file_stem`] and for the same reason: labels are
+/// caller-supplied and may repeat, and two recordings called `full-session`
+/// must not overwrite each other's cast.
+fn recording_file_stem(index: usize, label: &str) -> String {
+    let label: String = label.chars().take(MAX_LABEL_IN_FILENAME).collect();
+    format!("recording-{:02}-{}", index, sanitize_component(&label))
+}
+
 /// Which run a manifest belongs to.
 ///
 /// Evidence sits beside [`RunResult`] rather than inside it, so nothing about
@@ -582,6 +776,17 @@ pub struct EvidencePublisher {
     /// Optional upload seam. Uploads are best-effort: a failure leaves the
     /// step's `url` empty rather than failing the publish.
     pub uploader: Option<Box<dyn ArtifactUploader>>,
+    /// Optional cast-to-video seam, used by
+    /// [`EvidenceCollector::record_session`] and by nothing else —
+    /// [`publish`](EvidenceCollector::publish) renders stills and does not
+    /// encode.
+    ///
+    /// Optional rather than defaulted because a converter is two more binaries
+    /// on the host (`rsvg-convert` and `ffmpeg`), and a publisher that is only
+    /// ever going to write stills should not imply them. A `record_session`
+    /// against a publisher without one records that as the `convert` step
+    /// failing.
+    pub video_converter: Option<CastVideoConverter>,
 }
 
 impl std::fmt::Debug for EvidencePublisher {
@@ -590,6 +795,7 @@ impl std::fmt::Debug for EvidencePublisher {
             .field("dir", &self.dir)
             .field("identity", &self.identity)
             .field("uploader", &self.uploader.is_some())
+            .field("video_converter", &self.video_converter.is_some())
             .finish()
     }
 }
@@ -603,6 +809,7 @@ impl EvidencePublisher {
             identity,
             renderer: ScreenshotRenderer::new(),
             uploader: None,
+            video_converter: None,
         }
     }
 
@@ -615,6 +822,15 @@ impl EvidencePublisher {
     /// Upload every rendered screenshot through `uploader`.
     pub fn with_uploader(mut self, uploader: Box<dyn ArtifactUploader>) -> Self {
         self.uploader = Some(uploader);
+        self
+    }
+
+    /// Encode session recordings through `converter`.
+    ///
+    /// Needed by [`EvidenceCollector::record_session`]; nothing else consults
+    /// it.
+    pub fn with_video_converter(mut self, converter: CastVideoConverter) -> Self {
+        self.video_converter = Some(converter);
         self
     }
 
@@ -1053,6 +1269,332 @@ mod tests {
             format!("{recording:?}"),
             r#"Recording { label: "full-session", cast: "/tmp/s.cast", video: Some("/tmp/s.mp4"), url: Some("https://x/v"), error: None }"#
         );
+    }
+
+    // -- record_session ------------------------------------------------------
+
+    /// A cast with one event, the shape `save_cast` is expected to produce.
+    const A_CAST: &str = "{\"version\":2,\"width\":10,\"height\":3}\n[0.5,\"o\",\"live\"]\n";
+
+    /// Writes `A_CAST` and reports success, the way a real `save_cast` would.
+    fn save_a_cast(dest: &Path) -> Result<(), String> {
+        std::fs::write(dest, A_CAST).map_err(|e| e.to_string())
+    }
+
+    /// A converter whose tools write a fixed byte instead of running.
+    ///
+    /// `convert` still replays the cast and renders every frame, so this
+    /// exercises the real code up to the two `Command` invocations — which is
+    /// as far as a test can go without `rsvg-convert` and `ffmpeg` installed.
+    fn stub_converter() -> CastVideoConverter {
+        CastVideoConverter::with_runner(Box::new(|exe, args, _| {
+            let (path, bytes): (&String, &[u8]) = if exe.ends_with("ffmpeg") {
+                (args.last().ok_or("stub: no output")?, b"mp4")
+            } else {
+                let at = args
+                    .iter()
+                    .position(|a| a == "--output")
+                    .ok_or("stub: no --output")?;
+                (args.get(at + 1).ok_or("stub: no output")?, b"png")
+            };
+            std::fs::write(path, bytes).map_err(|e| e.to_string())
+        }))
+    }
+
+    /// A converter that cannot encode anything.
+    fn broken_converter() -> CastVideoConverter {
+        CastVideoConverter::with_runner(Box::new(|_, _, _| Err("encoder exploded".to_string())))
+    }
+
+    /// An uploader that counts what it was asked to upload.
+    struct CountingUploader(Arc<Mutex<Vec<String>>>);
+
+    impl ArtifactUploader for CountingUploader {
+        fn upload(&mut self, path: &str) -> Option<String> {
+            self.0.lock().expect("poisoned").push(path.to_string());
+            Some("https://example/video".to_string())
+        }
+        fn last_error(&self) -> Option<&str> {
+            None
+        }
+    }
+
+    fn one_capture() -> EvidenceCollector {
+        let mut collector = EvidenceCollector::new();
+        collector.capture("only", &mut session("screen text"));
+        collector
+    }
+
+    #[test]
+    fn record_session_runs_the_five_steps_in_order() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uploaded = Arc::new(Mutex::new(Vec::new()));
+        let mut publisher = publisher(dir.path())
+            .with_video_converter(stub_converter())
+            .with_uploader(Box::new(CountingUploader(uploaded.clone())));
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let recording = &collector.recordings()[0];
+        assert_eq!(recording.label, "full-session");
+        assert_eq!(recording.error, None);
+
+        // 1. The cast is where the collector said it would be.
+        let cast = Path::new(&recording.cast);
+        assert!(cast.exists(), "{:?}", recording.cast);
+        assert_eq!(
+            cast.file_name().map(|n| n.to_string_lossy().to_string()),
+            Some("recording-00-full-session.cast".to_string())
+        );
+
+        // 2. With the captured screen appended to it, which is the whole reason
+        //    step 2 exists — the session's own last frame is not the evidence.
+        let contents = std::fs::read_to_string(cast).expect("cast readable");
+        assert!(contents.starts_with(A_CAST), "the session's cast is intact");
+        assert!(contents.contains("screen text"), "{contents}");
+
+        // 3 and 4.
+        let video = recording.video.as_deref().expect("video");
+        assert!(video.ends_with("recording-00-full-session.mp4"), "{video}");
+        assert_eq!(std::fs::read_to_string(video).expect("video"), "mp4");
+        assert_eq!(recording.url.as_deref(), Some("https://example/video"));
+        assert_eq!(*uploaded.lock().expect("poisoned"), vec![video.to_string()]);
+
+        // 5. And all of it reaches the manifest, which is what a report reads.
+        let manifest = collector.publish(&mut publisher).expect("published");
+        assert_eq!(manifest.recordings, collector.recordings());
+    }
+
+    #[test]
+    fn a_cast_that_cannot_be_saved_stops_the_sequence() {
+        // Nothing downstream has anything to work on, so nothing downstream
+        // runs — and the recording says which step it was.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uploaded = Arc::new(Mutex::new(Vec::new()));
+        let mut publisher = publisher(dir.path())
+            .with_video_converter(stub_converter())
+            .with_uploader(Box::new(CountingUploader(uploaded.clone())));
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, |_| {
+            Err("disk on fire".to_string())
+        });
+
+        let recording = &collector.recordings()[0];
+        assert_eq!(
+            recording.error.as_deref(),
+            Some("save cast: disk on fire"),
+            "the failure has to name the step"
+        );
+        assert_eq!(recording.video, None);
+        assert_eq!(recording.url, None);
+        assert!(
+            uploaded.lock().expect("poisoned").is_empty(),
+            "nothing to upload, so nothing was uploaded"
+        );
+        assert!(!Path::new(&recording.cast).exists());
+    }
+
+    #[test]
+    fn a_save_that_writes_nothing_is_the_save_step_failing() {
+        // A closure that reports success and writes no file is step 1 going
+        // wrong, not step 2 finding a missing file: blaming the append would
+        // send a reader to the wrong code.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path()).with_video_converter(stub_converter());
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, |_| Ok(()));
+
+        let error = collector.recordings()[0].error.clone().expect("error");
+        assert!(error.starts_with("save cast: "), "{error}");
+        assert!(error.contains("wrote no file"), "{error}");
+        assert_eq!(collector.recordings()[0].video, None);
+    }
+
+    #[test]
+    fn an_append_failure_does_not_stop_the_conversion() {
+        // Step 2 is the one non-fatal step: the cast is on disk either way, and
+        // a recording that ends on the session is worth more than none.
+        //
+        // The only append failure reachable through `record_session` is a cast
+        // that cannot be read or is empty — the hold is not caller-supplied
+        // here — and `CastVideoConverter` cannot read one of those either. So
+        // what this pins is that step 3 was *attempted* after step 2 failed and
+        // both failures survived; were the sequence to stop at step 2, only the
+        // first of these two would be recorded.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path()).with_video_converter(stub_converter());
+
+        let mut collector = one_capture();
+        collector.record_session("empty", &mut publisher, |dest| {
+            std::fs::write(dest, "").map_err(|e| e.to_string())
+        });
+
+        let error = collector.recordings()[0].error.clone().expect("error");
+        assert_eq!(
+            error,
+            "append checkpoint frames: empty cast file; convert: empty cast file"
+        );
+    }
+
+    #[test]
+    fn a_publisher_with_no_video_converter_says_so() {
+        // Not silence: `record_session` was called to produce a video, so a
+        // publisher that cannot is a failure of the convert step.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path());
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let recording = &collector.recordings()[0];
+        assert_eq!(
+            recording.error.as_deref(),
+            Some("convert: no video converter configured")
+        );
+        // Steps 1 and 2 still happened, so the cast is still evidence.
+        assert!(Path::new(&recording.cast).exists());
+        assert!(std::fs::read_to_string(&recording.cast)
+            .expect("cast")
+            .contains("screen text"));
+        assert_eq!(recording.video, None);
+    }
+
+    #[test]
+    fn a_failed_conversion_is_never_uploaded() {
+        // The error path a hand-written version gets wrong: uploading the path
+        // a conversion did not produce, and reporting a store failure for a
+        // video that was never encoded.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uploaded = Arc::new(Mutex::new(Vec::new()));
+        let mut publisher = publisher(dir.path())
+            .with_video_converter(broken_converter())
+            .with_uploader(Box::new(CountingUploader(uploaded.clone())));
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let recording = &collector.recordings()[0];
+        assert_eq!(
+            recording.error.as_deref(),
+            Some("convert: encoder exploded")
+        );
+        assert_eq!(recording.video, None);
+        assert_eq!(recording.url, None);
+        assert!(
+            uploaded.lock().expect("poisoned").is_empty(),
+            "an upload was attempted for a video that does not exist"
+        );
+    }
+
+    #[test]
+    fn a_failed_upload_keeps_the_video() {
+        // Step 4 is last, so its failure costs the URL and nothing else. The
+        // video is still on disk and still worth naming.
+        struct Refuses;
+        impl ArtifactUploader for Refuses {
+            fn upload(&mut self, _: &str) -> Option<String> {
+                None
+            }
+            fn last_error(&self) -> Option<&str> {
+                Some("store down")
+            }
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path())
+            .with_video_converter(stub_converter())
+            .with_uploader(Box::new(Refuses));
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let recording = &collector.recordings()[0];
+        assert_eq!(recording.error.as_deref(), Some("upload: store down"));
+        assert!(recording.video.is_some());
+        assert_eq!(recording.url, None);
+    }
+
+    #[test]
+    fn an_uploader_that_declines_without_a_reason_still_names_the_step() {
+        struct Silent;
+        impl ArtifactUploader for Silent {
+            fn upload(&mut self, _: &str) -> Option<String> {
+                None
+            }
+            fn last_error(&self) -> Option<&str> {
+                None
+            }
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path())
+            .with_video_converter(stub_converter())
+            .with_uploader(Box::new(Silent));
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        assert_eq!(
+            collector.recordings()[0].error.as_deref(),
+            Some("upload: uploader returned no URL")
+        );
+    }
+
+    #[test]
+    fn a_publisher_with_no_uploader_is_not_a_failure() {
+        // Absent is not broken: a publisher without an uploader was not asked
+        // to upload, exactly as in `publish`.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path()).with_video_converter(stub_converter());
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let recording = &collector.recordings()[0];
+        assert_eq!(recording.error, None);
+        assert!(recording.video.is_some());
+        assert_eq!(recording.url, None);
+    }
+
+    #[test]
+    fn two_recordings_with_one_label_do_not_share_a_cast() {
+        // Labels are caller-supplied and may repeat; the second recording must
+        // not overwrite the first one's evidence.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path()).with_video_converter(stub_converter());
+
+        let mut collector = one_capture();
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let recordings = collector.recordings();
+        assert_ne!(recordings[0].cast, recordings[1].cast);
+        assert_ne!(recordings[0].video, recordings[1].video);
+        assert!(recordings[1]
+            .cast
+            .ends_with("recording-01-full-session.cast"));
+        assert!(recordings.iter().all(|r| r.error.is_none()));
+    }
+
+    #[test]
+    fn a_recorded_session_sits_beside_a_hand_attached_one() {
+        // `record_session` and `attach_recording` write to the same list, in
+        // call order, so a caller that encodes its own video is not shut out.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut publisher = publisher(dir.path()).with_video_converter(stub_converter());
+
+        let mut collector = one_capture();
+        collector.attach_recording(Recording::new("hand-made", "/tmp/other.cast"));
+        collector.record_session("full-session", &mut publisher, save_a_cast);
+
+        let manifest = collector.publish(&mut publisher).expect("published");
+        let labels: Vec<&str> = manifest
+            .recordings
+            .iter()
+            .map(|r| r.label.as_str())
+            .collect();
+        assert_eq!(labels, ["hand-made", "full-session"]);
     }
 
     #[test]

--- a/rust/crates/termproof/tests/differential_evidence_manifest.rs
+++ b/rust/crates/termproof/tests/differential_evidence_manifest.rs
@@ -27,6 +27,15 @@
 //! recording, and once `append_checkpoint_frames` puts the evidence sequence on
 //! the end of one, the cast is the artifact a reviewer actually watches.
 //!
+//! The scenario also drives `record_session` down each of its outcomes, because
+//! the `error` it writes onto a `Recording` is a string in the manifest and has
+//! to be the *same* string on both sides — "which step failed" is only useful to
+//! a reader if it does not depend on which implementation produced the run. One
+//! failure is deliberately left out: an append that fails. Its message comes
+//! from `append_checkpoint_frames` itself, which words its complaints
+//! differently in the two languages, so it is covered by unit tests on each side
+//! rather than recorded here as a divergence.
+//!
 //! # Determinism
 //!
 //! Two things about the scenario are properties of the machine rather than of
@@ -45,7 +54,7 @@
 
 use std::path::Path;
 
-use termproof::evidence::cast_video::append_checkpoint_frames;
+use termproof::evidence::cast_video::{append_checkpoint_frames, CastVideoConverter};
 use termproof::evidence::collector::{
     CaptureKind, EvidenceCollector, EvidencePublisher, Recording, RunIdentity,
 };
@@ -112,6 +121,51 @@ impl ArtifactUploader for StubUploader {
     fn last_error(&self) -> Option<&str> {
         None
     }
+}
+
+/// Declines without saying why. Reports no `last_error` so that this half falls
+/// back on the shared message, which is all the oracle's protocol can express.
+struct RefusingUploader;
+
+impl ArtifactUploader for RefusingUploader {
+    fn upload(&mut self, _path: &str) -> Option<String> {
+        None
+    }
+
+    fn last_error(&self) -> Option<&str> {
+        None
+    }
+}
+
+/// A converter whose tools write a fixed byte instead of running.
+///
+/// `convert` still replays the cast and renders every frame; the oracle's
+/// counterpart is a hand-written stub that writes the same byte and reads
+/// nothing. Neither the frame count nor the encoder reaches the manifest — the
+/// video *path* and the file at it are what the two sides have to agree on.
+fn stub_converter() -> CastVideoConverter {
+    CastVideoConverter::with_runner(Box::new(|exe, args, _timeout| {
+        let (path, bytes): (&String, &[u8]) = if exe.ends_with("ffmpeg") {
+            (args.last().ok_or("stub converter: no output")?, b"mp4")
+        } else {
+            let at = args
+                .iter()
+                .position(|a| a == "--output")
+                .ok_or("stub converter: no --output argument")?;
+            (args.get(at + 1).ok_or("stub converter: no output")?, b"png")
+        };
+        std::fs::write(path, bytes).map_err(|e| e.to_string())
+    }))
+}
+
+/// Fails with a message neither language contributes to.
+fn broken_converter() -> CastVideoConverter {
+    CastVideoConverter::with_runner(Box::new(|_, _, _| Err("encoder exploded".to_string())))
+}
+
+/// Writes [`BASE_CAST`], the way a real `save_cast` would.
+fn save_base_cast(dest: &Path) -> Result<(), String> {
+    std::fs::write(dest, BASE_CAST).map_err(|e| e.to_string())
 }
 
 /// A session serving `screen` and `raw`, the Rust equivalent of the oracle's
@@ -192,6 +246,39 @@ fn the_published_manifest_matches_the_python_document() {
     collector.attach_recording(
         Recording::new("failed-encode", "/tmp/broken.cast").with_error("video conversion failed"),
     );
+
+    // `record_session`, once per outcome. Every publisher writes into the same
+    // directory and differs only in the seam under test, so the recordings are
+    // numbered consecutively and their artifacts all land in `files`.
+    let mut working = EvidencePublisher::new(&directory, identity())
+        .with_renderer(stub_renderer())
+        .with_uploader(Box::new(StubUploader))
+        .with_video_converter(stub_converter());
+    // All five steps succeed: cast, appended evidence, video, URL.
+    collector.record_session("recorded", &mut working, save_base_cast);
+    // Step 1 fails, so nothing downstream runs.
+    collector.record_session("unsaveable", &mut working, |_| {
+        Err("disk on fire".to_string())
+    });
+    // Step 1 fails quietly, which is still step 1.
+    collector.record_session("silent-save", &mut working, |_| Ok(()));
+    // Step 3 has nothing to convert with.
+    let mut no_converter = EvidencePublisher::new(&directory, identity())
+        .with_renderer(stub_renderer())
+        .with_uploader(Box::new(StubUploader));
+    collector.record_session("no-converter", &mut no_converter, save_base_cast);
+    // Step 3 fails, so step 4 is not attempted: no URL, and no upload error.
+    let mut bad_encode = EvidencePublisher::new(&directory, identity())
+        .with_renderer(stub_renderer())
+        .with_uploader(Box::new(StubUploader))
+        .with_video_converter(broken_converter());
+    collector.record_session("bad-encode", &mut bad_encode, save_base_cast);
+    // Step 4 fails, which costs the URL and not the video.
+    let mut no_url = EvidencePublisher::new(&directory, identity())
+        .with_renderer(stub_renderer())
+        .with_uploader(Box::new(RefusingUploader))
+        .with_video_converter(stub_converter());
+    collector.record_session("no-url", &mut no_url, save_base_cast);
 
     let mut publisher = EvidencePublisher::new(&directory, identity())
         .with_renderer(stub_renderer())

--- a/rust/crates/termproof/tests/differential_evidence_manifest.rs
+++ b/rust/crates/termproof/tests/differential_evidence_manifest.rs
@@ -30,11 +30,16 @@
 //! The scenario also drives `record_session` down each of its outcomes, because
 //! the `error` it writes onto a `Recording` is a string in the manifest and has
 //! to be the *same* string on both sides — "which step failed" is only useful to
-//! a reader if it does not depend on which implementation produced the run. One
-//! failure is deliberately left out: an append that fails. Its message comes
-//! from `append_checkpoint_frames` itself, which words its complaints
-//! differently in the two languages, so it is covered by unit tests on each side
-//! rather than recorded here as a divergence.
+//! a reader if it does not depend on which implementation produced the run.
+//!
+//! Two failures are deliberately left out, both because the two implementations
+//! word them differently and pinning either would make this harness certify a
+//! divergence: an **append that fails**, whose message comes from
+//! `append_checkpoint_frames` itself, and an **upload that declines with a
+//! reason**, whose message comes from `ArtifactUploader::last_error` — which the
+//! oracle's `UploaderLike` has no counterpart for. `no-url` and `blank-url`
+//! therefore pin the shared fallback, not the shipped behaviour; see
+//! `conformance/README.md`.
 //!
 //! # Determinism
 //!
@@ -123,6 +128,23 @@ impl ArtifactUploader for StubUploader {
     }
 }
 
+/// Returns an empty string, which is no URL.
+///
+/// A distinct scenario from [`RefusingUploader`] even though both produce the
+/// same message: the two implementations reject the empty string in their own
+/// code, so this is what stops one of them keeping it.
+struct BlankUploader;
+
+impl ArtifactUploader for BlankUploader {
+    fn upload(&mut self, _path: &str) -> Option<String> {
+        Some(String::new())
+    }
+
+    fn last_error(&self) -> Option<&str> {
+        None
+    }
+}
+
 /// Declines without saying why. Reports no `last_error` so that this half falls
 /// back on the shared message, which is all the oracle's protocol can express.
 struct RefusingUploader;
@@ -161,6 +183,15 @@ fn stub_converter() -> CastVideoConverter {
 /// Fails with a message neither language contributes to.
 fn broken_converter() -> CastVideoConverter {
     CastVideoConverter::with_runner(Box::new(|_, _, _| Err("encoder exploded".to_string())))
+}
+
+/// Reports success and writes nothing.
+///
+/// Every invocation exits cleanly and produces no file, which is what a real
+/// `ffmpeg` misconfigured for its output looks like. Both implementations have
+/// to refuse it, and to refuse it with the same words.
+fn silent_converter() -> CastVideoConverter {
+    CastVideoConverter::with_runner(Box::new(|_, _, _| Ok(())))
 }
 
 /// Writes [`BASE_CAST`], the way a real `save_cast` would.
@@ -273,12 +304,31 @@ fn the_published_manifest_matches_the_python_document() {
         .with_uploader(Box::new(StubUploader))
         .with_video_converter(broken_converter());
     collector.record_session("bad-encode", &mut bad_encode, save_base_cast);
+    // Step 3 reports success and writes nothing, which is step 3 lying — the
+    // same guard as `silent-save`, one step further down.
+    let mut silent_encode = EvidencePublisher::new(&directory, identity())
+        .with_renderer(stub_renderer())
+        .with_uploader(Box::new(StubUploader))
+        .with_video_converter(silent_converter());
+    collector.record_session("silent-encode", &mut silent_encode, save_base_cast);
     // Step 4 fails, which costs the URL and not the video.
     let mut no_url = EvidencePublisher::new(&directory, identity())
         .with_renderer(stub_renderer())
         .with_uploader(Box::new(RefusingUploader))
         .with_video_converter(stub_converter());
     collector.record_session("no-url", &mut no_url, save_base_cast);
+    // Step 4 returning an empty string, which is no URL.
+    let mut blank_url = EvidencePublisher::new(&directory, identity())
+        .with_renderer(stub_renderer())
+        .with_uploader(Box::new(BlankUploader))
+        .with_video_converter(stub_converter());
+    collector.record_session("blank-url", &mut blank_url, save_base_cast);
+    // An empty label, the one input on which the two filename schemes could
+    // part: this half builds the stem through `sanitize_component`, which
+    // substitutes "default" for a component that sanitises to nothing, and the
+    // oracle's `_sanitize` does not. That half applies the same fallback, and
+    // this is what holds it there.
+    collector.record_session("", &mut working, save_base_cast);
 
     let mut publisher = EvidencePublisher::new(&directory, identity())
         .with_renderer(stub_renderer())

--- a/rust/docs/publishing.md
+++ b/rust/docs/publishing.md
@@ -240,6 +240,18 @@ The workflow enforces the mechanical items; these are the ones it cannot.
       on crates.io. The Security workflow runs this on every pull request, so
       by release time it should already be green; re-run it at the tag to be
       sure.
+- [ ] **Read `[package.metadata.cargo-semver-checks.lints]` in
+      `crates/termproof/Cargo.toml` before trusting the line above.** Any lint
+      listed there is waived, so the check passing does not mean nothing broke —
+      it means nothing broke *except* what a waiver already covers. Each entry
+      carries the decision that granted it and the release line it was granted
+      for, and `CHANGELOG.md` describes the break itself under a
+      `— Changed (breaking)` heading regardless. A waiver is a decision about
+      the version, not a claim of compatibility. Today there is one:
+      `constructible_struct_adds_field`, for the `EvidencePublisher` field
+      addition in #196, scoped to 0.4.x — bumping past 0.4.x fails
+      `the_semver_waiver_is_scoped_to_the_release_it_was_granted_for` until it
+      is re-decided.
 - [ ] The maturity warning in the crate's README still describes the port
       accurately. It is what the crates.io front page carries; a stale one is
       a claim of parity that has not been earned.
@@ -302,7 +314,8 @@ file is copied into each crate directory; keep the copies in sync with the root
   that, and duplicating it would mean two places to keep correct.
 - `.github/workflows/rust-security.yml` — dependency/advisory policy (`cargo deny
   check` against `deny.toml`), public-API compatibility (`cargo semver-checks`
-  against the latest published `termproof`), and package-tarball verification
+  against the latest published `termproof`, minus any lint waived in
+  `crates/termproof/Cargo.toml`), and package-tarball verification
   (`cargo package -p termproof` plus content assertions). It runs on every
   pull request and push, and the deny check also runs weekly on a schedule so
   a newly published advisory is caught without a code change.


### PR DESCRIPTION
## What this is

`EvidenceCollector.record_session`, in both implementations, plus the
`EvidencePublisher` video-converter seam it needs. This is the wiring 0.4.0 left
out: `Recording`, `attach_recording`, the cast-to-video converters and
`ArtifactUploader` all existed, and nothing joined them, so a downstream
consumer still carried `publish_media(config, save_cast)` and got the error
paths wrong twice before it settled.

The five steps, in order:

1. write the live session's cast, through a caller-supplied closure/callable
2. append the captured checkpoints to it, through the existing
   `append_checkpoint_frames`
3. convert the cast to a video, through the publisher's new video-converter seam
4. upload the video, through the publisher's existing uploader
5. attach a `Recording` describing what came of all that, which `publish` writes
   into the manifest

## The error-path matrix

**No failure fails the run.** Rust returns nothing rather than a `Result`;
Python raises nothing. A recording is evidence *about* a run, not part of its
verdict.

**Every failure names its step.** The error is prefixed with one of four strings
— `save cast`, `append checkpoint frames`, `convert`, `upload` — spelled once
per implementation as a constant, asserted literally in the tests, and compared
across the two by the conformance corpus. Two failures in one call are joined
with `"; "`, so `Recording.error` staying one field costs nothing.

**Which later steps run is a stated rule, not control flow:** *a step runs only
when the step before it produced the thing it works on.*

| step that failed | what still runs | why |
|---|---|---|
| 1, save cast | nothing | no cast to append to, convert or upload |
| 2, append frames | 3 and 4 | the cast is on disk and still convertible; it just ends on the session instead of the evidence |
| 3, convert | nothing after it | there is no video to upload |
| 4, upload | — | it is last; `video` is still recorded, only `url` is missing |

The case worth naming: **an upload is never attempted after a failed
conversion.** Uploading the path a conversion did not produce is how a run ends
up reporting a store error for a video that was never encoded.

Two more decisions, both tested:

- A `save_cast` that reports success and writes nothing is **step 1** failing,
  not step 2 finding a missing file. The step that lied is the one worth naming.
- A publisher with no *uploader* is not a failure — it was not asked to upload,
  exactly as in `publish`. A publisher with no *converter* is, because
  converting is what `record_session` was called to do.

Step 5 is the only step that cannot fail: it appends to a list.

## The seam

`EvidencePublisher` gains `video_converter`, beside `renderer` and `uploader`,
in the builder style already there (`with_video_converter` in Rust, a keyword
field in Python). It is `Option`/`| None` rather than defaulted: a converter is
two more binaries on the host, and a publisher that only writes stills should
not imply them.

Rust holds a concrete `CastVideoConverter`, mirroring the concrete
`ScreenshotRenderer` beside it. Python declares a `VideoConverterLike` protocol
and `RsvgFfmpegBackend` gains `convert` / `output_path_for` to satisfy it —
`render` is the `VideoBackend` protocol method and is untouched; `convert`
supplies the two things it makes a caller invent, an output path and a frame
rate.

## Tests

**Per failure path, in both languages.** Thirteen new Rust tests and fourteen new
Python ones: happy path, save refusing, save lying, append failing, no
converter, conversion failing (and the upload that must not follow), upload
raising, upload declining silently, no uploader, two failures joined, repeated
labels not sharing a cast, and `record_session` sitting beside
`attach_recording`.

**Mutation check.** 13 Rust mutants and 16 Python ones, one per behaviour the
new tests claim to guard, applied and reverted mechanically. First pass: all 13
Rust killed, 14/16 Python killed. The two survivors were real gaps — keeping
only the first of two failures, and clearing the video when an uploader declines
without a reason — and are fixed in the second commit, after which all 29 die.
Three of the Rust mutations were also run against the differential harness
alone, which killed all three. Nothing stayed green.

**Conformance.** `probe_evidence_manifest.py` and
`differential_evidence_manifest.rs` now drive `record_session` once per outcome
— `recorded`, `unsaveable`, `silent-save`, `no-converter`, `bad-encode`,
`no-url` — over publishers that differ only in the seam under test, and the
corpus is regenerated. The error strings are compared, not merely claimed to
match; so are the casts and videos the recordings write into the publish
directory. The corpus reproduces byte-for-byte from a clean run, and the Rust
half passed against it first time.

One failure is deliberately **not** in the corpus: an append that fails. Its
message comes from `append_checkpoint_frames`, which words its complaints
differently in the two languages (`empty cast file` against `<path> is empty: a
cast has a header line`), so recording it would freeze a pre-existing divergence
rather than check a shared surface. Each side covers it in its own unit tests,
and `conformance/README.md` says so.

## Deliberate differences between the two

- **`save_cast` reports failure by `Err(String)` in Rust and by raising in
  Python** — the house pattern. The message that reaches `Recording.error` is
  the same either way.
- **An uploader's own reason.** Rust reads `ArtifactUploader::last_error()` when
  it has one; Python's `UploaderLike` has no such accessor, so a Python uploader
  says why by raising. Both fall back on the same `uploader returned no URL`
  when there is no reason to be had, which is what the corpus records. Widening
  the Python protocol would break every existing uploader and is not this
  change.
- **One test differs in strength.** Python's
  `an_append_failure_does_not_stop_the_conversion` asserts the video survived,
  because its stub converter does not read the cast. Rust's real
  `CastVideoConverter` cannot read the empty cast the test uses either, so its
  version asserts step 3 was *attempted* and both failures were recorded —
  which is the same rule, and Python covers the join separately in
  `two_failures_are_both_recorded`.

## Validation

- Rust: 549 tests across 19 binaries, 0 failures; `clippy --all-targets` clean;
  `cargo fmt --check` clean.
- Python: 841 tests, 0 failures; `run_stdlib_tests.py` (149) green, so
  `cast_video` still holds its standard-library-only claim; `ruff check` and
  `mypy` clean.
- `conformance/probe_evidence_manifest.py` reproduces the committed corpus
  byte-for-byte.
- No version bump. The changelog entries are under `[Unreleased]`.

## Noticed and deliberately left alone

Out of scope, noted rather than fixed:

- **`append_checkpoint_frames` words the same two failures differently in the
  two languages** (`empty cast file` against `<path> is empty: a cast has a
  header line`). It predates this change and is why that one failure stays out
  of the conformance corpus. Worth converging, in its own diff.
- **The two `VideoBackend` shapes.** Rust has `evidence::video::VideoBackend`
  (`render(&Path, &Path, u32) -> Result<(), VideoError>`) *and* the concrete
  `CastVideoConverter`; Python has `protocols.VideoBackend` and now
  `collector.VideoConverterLike`. Four names for two ideas. Unifying them is a
  publisher refactor.
- **`store::sanitize_component` returns `"default"` for an empty label where
  Python's `_sanitize` returns `""`.** Pre-existing, reachable by both
  `CapturedStep::file_stem` and the new recording stem, and not exercised by any
  caller in tree.
- **`RsvgFfmpegBackend.convert` defaults to `DEFAULT_FPS` (24) while
  `VideoConfig.fps` defaults to 60.** `convert` takes the configured rate when
  the backend was built `from_config`, and 24 — Rust's `CastVideoConverter`
  default — otherwise. Reconciling the two written-down defaults is a config
  change with its own compatibility question.
