### PR TITLE
result: one scoring rule, and the empty-assertion case as contract (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,20 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ### Python — Added
 
+- **`termproof.models.score_from` and `termproof.models.assertion_map`:**
+  `score_from` scores a name → passed mapping the way `RunResult.score` is
+  defined — the fraction that held — and `assertion_map` builds that mapping
+  from `(name, passed)` pairs, last pair for a name winning. Consumers were
+  each writing those four lines, which was fine for the arithmetic and not fine
+  for the one decision inside it: **a run that asserted nothing scores `1.0`,
+  not `0.0`**, and a consumer that chose the other way published numbers that
+  looked comparable to these and were not. That choice is now stated in the
+  `RunResult` docstring and in `spec/003-builtin-assertions/spec.md` FR-022,
+  as part of the result contract rather than as a note on one function.
+  `score_from_assertions` is unchanged in behaviour and now delegates to the
+  same rule; the difference between the two shapes is that a list weighs
+  duplicate names once each and a mapping folds them into one entry.
+
 - **`termproof.cast_video.append_checkpoint_frames`:** appends the captured
   checkpoint screens to a cast as held trailing frames, so a recording ends by
   replaying the evidence sequence instead of stopping on whatever the last
@@ -197,6 +211,12 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ### Rust — Added
 
+- **`result::score_from` and `result::assertion_map`:** the same two functions
+  with the same semantics, `score_from` taking `&BTreeMap<String, bool>` and
+  `assertion_map` collecting `(impl Into<String>, bool)` pairs. The empty-map
+  case is `1.0` here too, and is documented on `RunResult::score` — the field
+  the number ends up in — rather than only on the function that computes it.
+
 - **`evidence::cast_video::append_checkpoint_frames`:** the same capability with
   the same semantics, taking `hold_seconds: Option<f64>` where Python takes a
   defaulted keyword and returning `Err` where Python raises `ValueError`. The
@@ -209,7 +229,14 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ### Rust — Changed
 
-- Nothing. `SvgMetrics` in `terminal::attributed` already took every default
+- **scoring:** `assertions::score` and `RunResult::score_from_assertions` were
+  two hand-written copies of the same arithmetic, and `result::score_from`
+  would have made a third. All three now call one private rule in `result`.
+  Nothing observable moved — the assertion differential harness reproduces the
+  committed corpus, `score` cases included — and the point is that the
+  empty-set answer can no longer drift between them.
+
+- On SVG geometry, nothing. `SvgMetrics` in `terminal::attributed` already took every default
   from the `DEFAULT_*` constants beside it, `ScreenshotRenderer` and
   `CastVideoConverter` already referenced those same constants rather than
   restating them, and the Rust stack was already the Linux-first one — the

--- a/python/termproof/models.py
+++ b/python/termproof/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -152,6 +153,22 @@ class PublishedArtifact:
 
 @dataclass(frozen=True)
 class RunResult:
+    """One recipe × one renderer, as a canonical result payload.
+
+    ``score`` is the fraction of assertions that held, in ``0.0..=1.0``.
+    **A run that asserted nothing scores 1.0, not 0.0.** That is part of this
+    contract rather than a choice each producer makes, because a score is read
+    comparatively: a consumer that scored the empty set ``0.0`` would publish
+    numbers that look like these and rank against them wrongly. The reading is
+    "no assertion failed", which is what an empty set reports; "nothing was
+    verified" is carried by ``assertions`` being empty, and a caller that cares
+    about it should read that rather than the score.
+
+    :func:`score_from` computes it from a name → passed mapping and
+    :func:`score_from_assertions` from an :class:`AssertionResult` list; both
+    are the same rule, and neither should be re-derived by a caller.
+    """
+
     recipe_name: str
     passed: bool
     exit_code: int | None
@@ -243,11 +260,44 @@ def load_recipe(path: Path) -> Recipe:
     return replace(recipe, source_path=str(path))
 
 
+def score_from(assertions: Mapping[str, bool]) -> float:
+    """:attr:`RunResult.score` for a name → passed mapping.
+
+    **An empty mapping scores 1.0.** See :class:`RunResult` for why that is the
+    contract and not each caller's decision.
+
+    The mapping's ordering cannot affect the result — only how many values are
+    true and how many there are — so a caller that collected its assertions in
+    a different order gets the same number. Two entries under one name are one
+    entry, which is the difference from :func:`score_from_assertions`: a list
+    keeps duplicates and weighs each of them.
+    """
+    return _score_of(assertions.values())
+
+
+def assertion_map(pairs: Iterable[tuple[str, bool]]) -> dict[str, bool]:
+    """The mapping :func:`score_from` scores, from ``(name, passed)`` pairs.
+
+    The last pair for a name wins, as assigning into the mapping would.
+    """
+    return {str(name): bool(passed) for name, passed in pairs}
+
+
 def score_from_assertions(assertions: list[AssertionResult]) -> float:
-    if not assertions:
+    """:attr:`RunResult.score` from assertion results (all pass → 1.0, else fraction)."""
+    return _score_of(assertion.passed for assertion in assertions)
+
+
+def _score_of(values: Iterable[bool]) -> float:
+    """The one scoring rule, over whatever the caller counted as an assertion."""
+    total = 0
+    passed = 0
+    for value in values:
+        total += 1
+        passed += 1 if value else 0
+    if total == 0 or passed == total:
         return 1.0
-    passed = sum(1 for assertion in assertions if assertion.passed)
-    return 1.0 if passed == len(assertions) else passed / len(assertions)
+    return passed / total
 
 
 def _normalize_renderers(value: Any) -> dict[str, list[str]]:

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import unittest
 
-from termproof.models import AssertionResult, RunResult, StepResult
+from termproof.models import (
+    AssertionResult,
+    RunResult,
+    StepResult,
+    assertion_map,
+    score_from,
+    score_from_assertions,
+)
 
 
 def _result() -> RunResult:
@@ -60,6 +67,49 @@ class RunResultSerializationTest(unittest.TestCase):
         self.assertEqual([], restored.steps)
         self.assertEqual([], restored.assertions)
         self.assertEqual({}, restored.artifacts)
+
+
+class ScoreFromTest(unittest.TestCase):
+    def test_an_empty_assertion_map_scores_one_not_zero(self) -> None:
+        # The contract decision this function exists to make once: see the
+        # RunResult docstring.
+        self.assertEqual(1.0, score_from({}))
+
+    def test_a_map_scores_the_fraction_that_held(self) -> None:
+        self.assertEqual(1.0, score_from(assertion_map([("a", True), ("b", True)])))
+        self.assertEqual(0.0, score_from(assertion_map([("a", False), ("b", False)])))
+        self.assertEqual(0.5, score_from(assertion_map([("a", True), ("b", False)])))
+        self.assertEqual(
+            2.0 / 3.0,
+            score_from(assertion_map([("a", True), ("b", True), ("c", False)])),
+        )
+
+    def test_the_order_the_pairs_arrived_in_cannot_move_the_score(self) -> None:
+        forwards = assertion_map([("a", True), ("b", False), ("c", False)])
+        backwards = assertion_map([("c", False), ("b", False), ("a", True)])
+        self.assertEqual(score_from(forwards), score_from(backwards))
+
+    def test_a_repeated_name_is_one_assertion_and_the_last_value_wins(self) -> None:
+        mapping = assertion_map([("a", True), ("a", False)])
+        self.assertEqual(1, len(mapping))
+        self.assertEqual(0.0, score_from(mapping))
+
+    def test_the_list_and_the_map_score_the_same_assertions_alike(self) -> None:
+        # One rule, two shapes: the list keeps duplicates, so this is only
+        # stated for distinct names.
+        cases: list[list[tuple[str, bool]]] = [
+            [],
+            [("a", True)],
+            [("a", False), ("b", False)],
+            [("a", True), ("b", False), ("c", True)],
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                results = [AssertionResult(name, passed, "") for name, passed in case]
+                self.assertEqual(
+                    score_from_assertions(results),
+                    score_from(assertion_map(case)),
+                )
 
 
 if __name__ == "__main__":

--- a/rust/crates/termproof/src/assertions.rs
+++ b/rust/crates/termproof/src/assertions.rs
@@ -493,12 +493,12 @@ fn describe_json_error(input: &str, error: &serde_json::Error) -> String {
 
 /// The score a set of assertion results earns (FR-022): the fraction that
 /// passed, and `1.0` when there are none to fail.
+///
+/// The rule itself lives in [`crate::result`], with the empty-set case
+/// documented on [`crate::result::RunResult::score`]; this is the same rule
+/// over the legacy [`crate::models::AssertionResult`], not a second one.
 pub fn score(results: &[AssertionResult]) -> f64 {
-    if results.is_empty() {
-        return 1.0;
-    }
-    let passed = results.iter().filter(|r| r.passed).count();
-    passed as f64 / results.len() as f64
+    crate::result::score_of(results.iter().map(|r| r.passed))
 }
 
 /// The built-in registry, for a caller that needs to know whether a name is

--- a/rust/crates/termproof/src/models.rs
+++ b/rust/crates/termproof/src/models.rs
@@ -173,7 +173,8 @@ pub struct RunResult {
     pub execution: String,
     /// Renderer.
     pub renderer: String,
-    /// Score 0..1.
+    /// Score 0..1, under the contract on [`crate::result::RunResult::score`]
+    /// — an empty assertion set scores `1.0`.
     pub score: f64,
     /// Step results.
     pub steps: Vec<StepResult>,

--- a/rust/crates/termproof/src/result.rs
+++ b/rust/crates/termproof/src/result.rs
@@ -164,7 +164,19 @@ pub struct RunResult {
     pub execution: String,
     /// Renderer name (`default`, …).
     pub renderer: String,
-    /// Score `0.0..1.0`.
+    /// Fraction of assertions that held, in `0.0..=1.0`.
+    ///
+    /// **A run that asserted nothing scores `1.0`, not `0.0`.** That is part of
+    /// this contract rather than a choice each producer makes, because a score
+    /// is read comparatively: a consumer that scored the empty set `0.0` would
+    /// publish numbers that look like these and rank against them wrongly. The
+    /// reading is "no assertion failed", which is what an empty set reports;
+    /// "nothing was verified" is carried by `assertions` being empty, and a
+    /// caller that cares about it should read that rather than the score.
+    ///
+    /// [`score_from`] computes it from a name → passed map and
+    /// [`RunResult::score_from_assertions`] from an [`AssertionResult`] list;
+    /// both are the same rule, and neither should be re-derived by a caller.
     pub score: f64,
     /// Per-step results in order.
     pub steps: Vec<StepResult>,
@@ -174,18 +186,54 @@ pub struct RunResult {
     pub artifacts: BTreeMap<String, String>,
 }
 
+/// [`RunResult::score`] for a name → passed map: the fraction that held.
+///
+/// **An empty map scores `1.0`.** See [`RunResult::score`] for why that is the
+/// contract and not each caller's decision.
+///
+/// The map's ordering cannot affect the result — only how many values are true
+/// and how many there are — so a caller that collected its assertions in a
+/// different order gets the same number. Two entries under one name are one
+/// entry, which is the difference from
+/// [`RunResult::score_from_assertions`]: a list keeps duplicates and weighs
+/// each of them.
+pub fn score_from(assertions: &BTreeMap<String, bool>) -> f64 {
+    score_of(assertions.values().copied())
+}
+
+/// The map [`score_from`] scores, from `(name, passed)` pairs.
+///
+/// The last pair for a name wins, as inserting into the map would.
+pub fn assertion_map<I, S>(pairs: I) -> BTreeMap<String, bool>
+where
+    I: IntoIterator<Item = (S, bool)>,
+    S: Into<String>,
+{
+    pairs
+        .into_iter()
+        .map(|(name, passed)| (name.into(), passed))
+        .collect()
+}
+
+/// The one scoring rule, over whatever the caller counted as an assertion.
+pub(crate) fn score_of(values: impl IntoIterator<Item = bool>) -> f64 {
+    let mut total = 0usize;
+    let mut passed = 0usize;
+    for value in values {
+        total += 1;
+        passed += usize::from(value);
+    }
+    if total == 0 || passed == total {
+        1.0
+    } else {
+        passed as f64 / total as f64
+    }
+}
+
 impl RunResult {
-    /// Compute score from assertion results (all pass → 1.0, else fraction).
+    /// [`RunResult::score`] from assertion results (all pass → 1.0, else fraction).
     pub fn score_from_assertions(assertions: &[AssertionResult]) -> f64 {
-        if assertions.is_empty() {
-            return 1.0;
-        }
-        let passed = assertions.iter().filter(|a| a.passed).count();
-        if passed == assertions.len() {
-            1.0
-        } else {
-            passed as f64 / assertions.len() as f64
-        }
+        score_of(assertions.iter().map(|a| a.passed))
     }
 
     /// Serialize to canonical JSON value (BTreeMap ensures stable key ordering).
@@ -259,6 +307,69 @@ mod tests {
             steps: vec![],
             assertions: vec![],
             artifacts: BTreeMap::new(),
+        }
+    }
+
+    fn assertion(name: &str, passed: bool) -> AssertionResult {
+        AssertionResult {
+            name: name.to_string(),
+            passed,
+            detail: String::new(),
+        }
+    }
+
+    #[test]
+    fn an_empty_assertion_map_scores_one_not_zero() {
+        // The contract decision this function exists to make once: see the
+        // `RunResult::score` docs.
+        assert_eq!(score_from(&BTreeMap::new()), 1.0);
+    }
+
+    #[test]
+    fn a_map_scores_the_fraction_that_held() {
+        assert_eq!(score_from(&assertion_map([("a", true), ("b", true)])), 1.0);
+        assert_eq!(
+            score_from(&assertion_map([("a", false), ("b", false)])),
+            0.0
+        );
+        assert_eq!(score_from(&assertion_map([("a", true), ("b", false)])), 0.5);
+        assert_eq!(
+            score_from(&assertion_map([("a", true), ("b", true), ("c", false)])),
+            2.0 / 3.0
+        );
+    }
+
+    #[test]
+    fn the_order_the_pairs_arrived_in_cannot_move_the_score() {
+        let forwards = assertion_map([("a", true), ("b", false), ("c", false)]);
+        let backwards = assertion_map([("c", false), ("b", false), ("a", true)]);
+        assert_eq!(score_from(&forwards), score_from(&backwards));
+    }
+
+    #[test]
+    fn a_repeated_name_is_one_assertion_and_the_last_value_wins() {
+        let map = assertion_map([("a", true), ("a", false)]);
+        assert_eq!(map.len(), 1);
+        assert_eq!(score_from(&map), 0.0);
+    }
+
+    #[test]
+    fn the_list_and_the_map_score_the_same_assertions_alike() {
+        // One rule, two shapes: the list keeps duplicates, so this is only
+        // stated for distinct names.
+        let cases: [&[(&str, bool)]; 4] = [
+            &[],
+            &[("a", true)],
+            &[("a", false), ("b", false)],
+            &[("a", true), ("b", false), ("c", true)],
+        ];
+        for case in cases {
+            let list: Vec<_> = case.iter().map(|(n, p)| assertion(n, *p)).collect();
+            assert_eq!(
+                RunResult::score_from_assertions(&list),
+                score_from(&assertion_map(case.iter().copied())),
+                "{case:?}"
+            );
         }
     }
 

--- a/spec/003-builtin-assertions/spec.md
+++ b/spec/003-builtin-assertions/spec.md
@@ -427,9 +427,21 @@ the detail strings literally.
 - **FR-022** `[BYTE-EXACT]` A run's `score` is `1.0` when the evaluated assertion list is
   empty; otherwise `1.0` when all assertions passed, and `passed_count / total_count`
   otherwise. `total_count` includes the synthetic exit-code assertion.
-  **Authority**: `SOURCE` (`models.py:172`, `score_from_assertions`). Note the first branch:
+  **Authority**: `SOURCE` (`models.py`, `score_from_assertions`). Note the first branch:
   a recipe with `expect_exit_code: null` and no assertions scores `1.0` while asserting
   nothing.
+
+  **The empty case is contract, not each producer's choice.** A score is read
+  comparatively, so a producer that scored the empty set `0.0` would publish numbers that
+  look like these and rank against them wrongly. `1.0` reads as "no assertion failed",
+  which is what an empty set reports; "nothing was verified" is carried by the assertion
+  list being empty, and a consumer that cares about it reads that rather than the score.
+  The rule is computed once per implementation and shared by every shape that needs it —
+  `models.score_from` / `models.score_from_assertions` in Python,
+  `result::score_from` / `RunResult::score_from_assertions` / `assertions::score` in Rust.
+  `score_from` takes a name → passed map, whose ordering cannot affect the result and in
+  which two entries under one name are one entry; the list form keeps duplicates and
+  weighs each of them.
 
 - **FR-023** `[BYTE-EXACT]` A run's overall `passed` is true only when **every** step passed
   **and** every assertion passed. A failing step fails the run even if all assertions pass.


### PR DESCRIPTION
Closes #198.

## What changed

`RunResult.score` is already the crate's notion of "what fraction of assertions held", but
nothing computed it from a name → passed map, so every consumer wrote its own four lines.
The arithmetic was never the problem — **the empty case is a contract decision** that each
caller was making independently. A run that asserted nothing scoring `1.0` is defensible; a
consumer that chose `0.0` would publish numbers that look comparable to these and are not.

Added, with identical semantics in both languages:

| | Rust | Python |
|---|---|---|
| score a map | `result::score_from(&BTreeMap<String, bool>) -> f64` | `models.score_from(Mapping[str, bool]) -> float` |
| build the map | `result::assertion_map(pairs)` | `models.assertion_map(pairs)` |

Both agree on: empty → `1.0`; ordering cannot move the result; a repeated name is one entry
whose **last** value wins. The difference from the existing list-shaped
`score_from_assertions` is spelled out in the docs — a list weighs duplicate names once
each, a map folds them into one.

## The empty case is documented in the result contract

Not only on the new function:

- **Rust** — the `RunResult::score` field doc, i.e. on the field the number ends up in.
- **Python** — the `RunResult` class docstring (the file has no module docstring; this is
  the nearest equivalent to the Rust field doc).
- **Spec** — `spec/003-builtin-assertions/spec.md` FR-022, which is where the two
  implementations' shared contract for `score` already lived. It now says why `1.0` and
  names every function that implements the rule.

## One path, not a second one

The crate *did* compute scores inline — in three places once this change was counted:

- `RunResult::score_from_assertions` (Rust)
- `assertions::score` (Rust) — a separate hand-written copy of the same arithmetic
- `models.score_from_assertions` (Python)

All of them now call one private rule (`result::score_of` / `models._score_of`). Behaviour
is unchanged: the assertion differential harness reproduces the committed corpus, `score`
cases included. `assertions::score` keeps its signature over the legacy
`models::AssertionResult`; only its body moved.

## Tests

New tests in both languages cover empty, all-true, all-false, mixed, ordering independence,
duplicate names, and list/map agreement. Each was broken to confirm it goes red:

| mutation | red in Rust | red in Python |
|---|---|---|
| empty → `0.0` | `an_empty_assertion_map_scores_one_not_zero` | `test_an_empty_assertion_map_scores_one_not_zero` |
| fraction → always `1.0` | `a_map_scores_the_fraction_that_held` | `test_a_map_scores_the_fraction_that_held` |
| `assertion_map` keeps the first value | `a_repeated_name_is_one_assertion_and_the_last_value_wins` | `test_a_repeated_name_is_one_assertion_and_the_last_value_wins` |
| list path stops delegating (empty list → `0.0`) | `the_list_and_the_map_score_the_same_assertions_alike` | `test_the_list_and_the_map_score_the_same_assertions_alike` |
| score counts only the first two values | `a_map_scores_the_fraction_that_held` | `test_the_order_...`, `test_a_map_scores_...` |

**One test stayed green where its Python mirror went red**, and it is worth naming: the Rust
`the_order_the_pairs_arrived_in_cannot_move_the_score` cannot be made to fail by any mutation
of the scoring rule, because `BTreeMap` iterates in key order whatever order the pairs
arrived in — the guarantee holds by construction, and the test states it rather than guards
it. Python's `dict` preserves insertion order, so the same test there is a real guard and does
go red under the truncation mutant.

Also run: full `cargo test --all-features` (all green, differential harnesses included),
`cargo clippy --all-targets --all-features`, `cargo fmt --check`, the full 830-test Python
suite, `ruff check`, `mypy termproof/models.py`.

## `cargo semver-checks`

Clean — `196 checks: 196 pass, 58 skip`, "no semver update required". The change is purely
additive; no version number was touched.

## Deliberately not done

- **No new conformance corpus.** The three differential harnesses compare steps, assertions
  and the evidence manifest. Scoring is already covered by the assertions pair — six
  `003-FR-022` `score/*` cases whose expectations `differential_assertions.rs` checks through
  `assertions::score`, which this change routes into the shared rule — so parity for the rule
  is asserted where it already was. The map-shaped surface has no I/O and no corpus of its
  own; its parity is asserted by the mirrored unit tests above. The evidence-manifest pair is
  untouched because nothing about evidence changed.
- **Not exported from `termproof/__init__.py`.** `score_from_assertions` is not either;
  consumers import from `termproof.models`, which mirrors `termproof::result` being reachable
  as a module rather than re-exported at the crate root. Adding both to the package root
  would be a reasonable follow-up, in both implementations at once.

## Noticed, not fixed

- `models::RunResult` (Rust) is the legacy twin of `result::RunResult` and duplicates every
  field. Its `score` doc now points at the canonical contract rather than restating it, which
  is the smallest thing that stops the two docs drifting; collapsing the twins is its own
  change.
- The `[Unreleased]` → `Rust — Changed` section opened with a bullet reading "Nothing." That
  became false with this PR, so it now reads "On SVG geometry, nothing." — content unchanged
  otherwise. Flagging it because it edits a sibling PR's entry.
- `ruff format --check` fails on `python/termproof/models.py` and `python/tests/test_models.py`
  on **pre-existing** lines (it wants to join wrapped expressions that predate this change).
  Not touched; `ruff check` passes.
