### PR TITLE
cli: the clap layer that turns a command line into a RunConfig, behind an opt-in feature

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -33,7 +33,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    # 75, not 45, because the feature powerset doubled with `clap` (#197) and
+    # that step is most of the job. Measured locally on a warm cache at roughly
+    # 50 seconds per combination, so thirty-two is ~28 minutes before the other
+    # steps and before a cold CI build. The headroom is for the doubling, not a
+    # sign the job got slower per unit of work.
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
@@ -49,21 +54,25 @@ jobs:
       # `--all-features` cannot catch a feature that only builds alongside
       # another, which is the failure mode an undeclared `dep:` produces. So
       # check the whole powerset rather than a sample (#27, extended for
-      # `schema` in #28 and for `junit` in #34). `json-schema` implies `schema`,
-      # so some combinations resolve to the same set as others — they are run
-      # anyway, because what is being checked is that every combination a
-      # consumer can *write* compiles, not every set cargo can resolve.
-      # `default` and `--all-features` are the same set today and the steps
-      # above already cover them.
+      # `schema` in #28, `junit` in #34 and `clap` in #197). `json-schema`
+      # implies `schema`, so some combinations resolve to the same set as
+      # others — they are run anyway, because what is being checked is that
+      # every combination a consumer can *write* compiles, not every set cargo
+      # can resolve. `clap` is the first feature that is not in `default`, so
+      # `default` and `--all-features` are no longer the same set: the steps
+      # above cover `--all-features`, and the combination naming the other four
+      # below is `default`.
       #
       # The list is enumerated from FEATURES rather than written out, so adding
       # a feature grows the matrix by construction and cannot be half-extended:
-      # four features is sixteen combinations, and the count is printed so a
-      # silently shrinking matrix is visible in the log.
+      # five features is thirty-two combinations, and the count is printed so a
+      # silently shrinking matrix is visible in the log. Growth is doubling, so
+      # a sixth feature is the point at which this wants splitting across the
+      # job matrix rather than another entry in the array.
       - name: clippy and test each feature combination
         run: |
           set -eux
-          FEATURES=(evidence junit json-schema schema)
+          FEATURES=(evidence junit json-schema schema clap)
           total=$((1 << ${#FEATURES[@]}))
           echo "feature powerset: $total combinations"
           for mask in $(seq 0 $((total - 1))); do

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -33,12 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    # 75, not 45, because the feature powerset doubled with `clap` (#197) and
-    # that step is most of the job. Measured locally on a warm cache at roughly
-    # 50 seconds per combination, so thirty-two is ~28 minutes before the other
-    # steps and before a cold CI build. The headroom is for the doubling, not a
-    # sign the job got slower per unit of work.
-    timeout-minutes: 75
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
@@ -66,9 +61,18 @@ jobs:
       # The list is enumerated from FEATURES rather than written out, so adding
       # a feature grows the matrix by construction and cannot be half-extended:
       # five features is thirty-two combinations, and the count is printed so a
-      # silently shrinking matrix is visible in the log. Growth is doubling, so
-      # a sixth feature is the point at which this wants splitting across the
-      # job matrix rather than another entry in the array.
+      # silently shrinking matrix is visible in the log.
+      #
+      # Growth is doubling, so it is worth writing down where the ceiling is.
+      # Measured on run 32429616067, the last `main` run before `clap`: this
+      # step was 7.8 min on ubuntu and 9.3 on macos for sixteen combinations —
+      # ~30-35s each — in a job totalling 10.1 and 12.1. Thirty-two puts the
+      # step at ~16-19 min and the job at ~18-21, which is why the job's
+      # `timeout-minutes` is unchanged at 45. A sixth feature would be ~37 min
+      # of powerset in a ~40 min job, past that headroom and near the 60-minute
+      # cap `python/tests/test_ci_timeouts.py` enforces on every job. That is
+      # the point at which this wants sharding across the job matrix rather
+      # than another entry in the array.
       - name: clippy and test each feature combination
         run: |
           set -eux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,55 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   sub-module path would be a second papercut on top of the first.
   ([#199](https://github.com/md-mt/termproof/issues/199))
 
+- **`run_config::cli`, behind the new opt-in `clap` feature:** the command line
+  that fills in a `RunConfig`. `run_config` has modelled a whole run since it
+  landed — `RunConfig`, `Discovery`, `Selection`, `Execution`, `BinarySource`,
+  `Output`, `Publisher`, `Requirements`, and `pick(flag, configured, builtin)`
+  for how the three sources of an answer rank — but nothing populated it from
+  argv, so each consumer wrote that layer again. Measured on one of them, a TUI
+  validator: 23 `clap` argument builders and about 200 lines whose only job was
+  to get from flags to this crate's own type, with `pick()` re-derived by hand
+  once per flag (#197).
+
+  Six functions, re-exported at the `run_config` root:
+  `clap_command()` for the standard flags on a bare command;
+  `augment_args(Command)` for adding them to a consumer's own, so extra `.arg()`
+  calls compose and the consumer keeps its name, version and subcommands;
+  `from_matches(&ArgMatches)` for exactly what the flags said;
+  `configured(&ArgMatches)` for the file `--run-config` names;
+  `merge(flags, configured, builtin)` for `pick()` applied to every field at
+  once; and `resolve(&ArgMatches, builtin)` for all of it in one call.
+
+  Two rules are load-bearing and are asserted rather than described. No flag
+  carries a `default_value` — a defaulted flag is indistinguishable from a
+  passed one, and if the two look alike a config file can never override one,
+  which is what `run_config`'s precedence section warned about; the built-in
+  therefore arrives as the `builtin: &RunConfig` argument. And a flag passed
+  empty is a flag passed: `--renderer ''` beats a configured renderer, because
+  reading it as unset would add a fourth state to `pick()`'s three and put every
+  consumer back to remembering which flags have it.
+
+  **Reconciled against `termproof.cli`.** Where the two name the same thing they
+  use the same flag: `--priority`, `--recipe-name` (repeatable in both) and
+  `--renderer`. The rest is new, and no name is reused for a second meaning:
+
+  | This layer | Python's `termproof.cli` | Why |
+  |---|---|---|
+  | `--run-config PATH` | `--config PATH` is the *plugin registry* (`VerifierConfig`) | Two different config files. Reusing `--config` would be the one collision worth avoiding, and a consumer that has both still needs to name each. |
+  | `--artifact-dir DIR` | `--out DIR` | Not the same thing. `--out` is one directory that the report path is also derived from; `RunConfig` separates `artifact_dir`, `report_path` and `result_json_path`, so no flag here has `--out`'s meaning. |
+  | `--all`, `--changed-files` | — | `Selection` has four arms; Python's CLI exposes two of them. All four get a flag, in one `ArgGroup`, so "all *and* a priority" is a usage error rather than something this layer has to rank. |
+  | `--root`, `--repo-marker`, `--exclude`, `--transport`, `--model`, `--effort`, `--binary-installed`, `--binary-build`, `--env`, `--timeout-scale`, `--publisher`, `--publisher-setting`, `--require-uploaded-media`, `--require-media-publisher` | — | Fields `RunConfig` has and Python has no counterpart for. |
+
+  The feature is off by default, so a consumer that does not name it does not
+  compile `clap`. CI's feature powerset is enumerated from the feature list, so
+  it grew from sixteen combinations to thirty-two by construction, and both the
+  default build without `clap` and every build that names it are exercised.
+
+  Python is deliberately unchanged. `run_config` is Rust-only — there is no
+  `termproof.run_config`, and the conformance pair has nothing to compare —
+  so this closes an asymmetry rather than opening one. `termproof.cli` is an
+  `argparse` *program*; this is a library layer, and no binary is added.
+
 ### Rust — Changed
 
 - **scoring:** `assertions::score` and `RunResult::score_from_assertions` were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,20 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   reading it as unset would add a fourth state to `pick()`'s three and put every
   consumer back to remembering which flags have it.
 
+  **One field does not obey that precedence, and it is deliberate.**
+  `Requirements.uploaded_media` is a `bool`, so it has no unset state for
+  `pick()` to rank and the three layers are ORed instead: any of them asking for
+  it is asking for it. It can therefore be raised but never lowered —
+  `require: {uploaded_media: false}` in a config file is inert against a
+  built-in `true`, and there is no `--no-require-uploaded-media`. For a
+  requirement that is the safe direction to fail in, since a config file quietly
+  switching off a "the evidence must be shareable" gate is the outcome worth
+  preventing, but it is an exception to the rule rather than an instance of it:
+  a caller that needs the gate off has to leave it off in the built-in. The
+  repeatable flags behave differently again — for those, empty is unset, and the
+  first non-empty of flag / config / built-in wins as a whole rather than
+  merging, so a passed `--env` replaces a configured `env` outright.
+
   **Reconciled against `termproof.cli`.** Where the two name the same thing they
   use the same flag: `--priority`, `--recipe-name` (repeatable in both) and
   `--renderer`. The rest is new, and no name is reused for a second meaning:
@@ -365,6 +379,7 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   | `--run-config PATH` | `--config PATH` is the *plugin registry* (`VerifierConfig`) | Two different config files. Reusing `--config` would be the one collision worth avoiding, and a consumer that has both still needs to name each. |
   | `--artifact-dir DIR` | `--out DIR` | Not the same thing. `--out` is one directory that the report path is also derived from; `RunConfig` separates `artifact_dir`, `report_path` and `result_json_path`, so no flag here has `--out`'s meaning. |
   | `--all`, `--changed-files` | — | `Selection` has four arms; Python's CLI exposes two of them. All four get a flag, in one `ArgGroup`, so "all *and* a priority" is a usage error rather than something this layer has to rank. |
+  | `--priority` **with** `--recipe-name` is a usage error | the two compose | The one divergence that is not about a name. `termproof.registry.select_recipes` applies priority and then names as successive filters, so `--priority P0 --recipe-name smoke` is a legal narrowing there — "smoke, if it is P0". `Selection` holds one arm, so the same pair is an `ArgumentConflict` here. Same names, same individual meanings, different composition, which is exactly the case a ported command line trips over; a caller wanting the intersection filters a `Selection::Priority` run itself. |
   | `--root`, `--repo-marker`, `--exclude`, `--transport`, `--model`, `--effort`, `--binary-installed`, `--binary-build`, `--env`, `--timeout-scale`, `--publisher`, `--publisher-setting`, `--require-uploaded-media`, `--require-media-publisher` | — | Fields `RunConfig` has and Python has no counterpart for. |
 
   The feature is off by default, so a consumer that does not name it does not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,10 +197,12 @@ cargo test  --manifest-path rust/Cargo.toml --workspace
 ```
 
 Run all three before pushing. CI also runs the suite across the whole feature
-powerset (four features — `evidence`, `junit`, `json-schema`, `schema`, so
-sixteen combinations) and at the declared dependency floors, so a change that
-only breaks a non-default combination is caught there even if your local
-default build is green. `.github/workflows/rust-security.yml` adds
+powerset (five features — `evidence`, `junit`, `json-schema`, `schema` and the
+default-off `clap`, so thirty-two combinations) and at the declared dependency
+floors, so a change that only breaks a non-default combination is caught there
+even if your local default build is green. Note that `clap` being default-off
+means `cargo test --workspace` above does not compile `run_config::cli` at all;
+add `--features clap` if you are touching it. `.github/workflows/rust-security.yml` adds
 `cargo deny`, `cargo semver-checks` against the latest published `termproof`,
 and a `cargo package` contents check.
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -254,7 +254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
@@ -267,18 +266,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -563,12 +550,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1598,6 +1598,7 @@ version = "0.4.0"
 dependencies = [
  "avt",
  "chrono",
+ "clap",
  "fancy-regex",
  "globset",
  "image",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -233,5 +233,25 @@ thiserror = "2.0"
 avt = "0.16"
 chrono = "0.4"
 globset = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+# Builder API only, so no `derive`. Neither crate that uses clap has a
+# `#[derive(Parser)]` in it — `termproof-cli` says so in its own module doc
+# ("without proc macros so the build does not require proc-macro2 build scripts
+# under sandbox") and `run_config::cli` is `Arg::new`/`ArgGroup`/`value_parser!`
+# throughout — so the feature was compiling `clap_derive` and `heck` for nobody.
+# Measured on `cargo tree -p termproof --no-default-features --features clap`:
+# 80 crates with it, 78 without, and the one it removes is a proc macro.
+# `syn`, `quote` and `proc-macro2` stay regardless — `serde` and `thiserror`
+# need them — so dropping `derive` is worth exactly those two crates, not the
+# whole proc-macro chain (#197).
+#
+# The rest of clap's defaults are deliberately kept. `default-features = false,
+# features = ["std"]` removes nine crates rather than two, and the extra seven
+# are not free: `render_help()` then returns the empty string, so every
+# `.help()` in `run_config::cli` is silently discarded, and errors degrade from
+# "the argument '--all' cannot be used with '--priority <PRIORITY>'" to "an
+# argument cannot be used with one or more of the other specified arguments".
+# This layer's whole product is a `Command` a consumer calls `get_matches()` on;
+# shipping one whose `--help` is blank to save seven crates is the wrong trade,
+# and the consumer cannot undo it from their side.
+clap = { version = "4.5" }
 termproof-plugin-protocol = { path = "crates/termproof-plugin-protocol", version = "0.4.0" }

--- a/rust/crates/termproof/Cargo.toml
+++ b/rust/crates/termproof/Cargo.toml
@@ -103,10 +103,10 @@ struct_pub_field_missing = "allow"
 workspace = true
 
 # Feature names carry a one-line description and the issue that justifies them
-# (docs/engineering-baseline.md §7). All four are default-on, so no consumer
-# sees a change by not asking for one. `evidence` and `json-schema` are from
-# #27: every consumer used to compile all 18 dependencies whether or not it
-# used them. `schema` is from #28, `junit` from #34.
+# (docs/engineering-baseline.md §7). The first four are default-on, so no
+# consumer sees a change by not asking for one. `evidence` and `json-schema`
+# are from #27: every consumer used to compile all 18 dependencies whether or
+# not it used them. `schema` is from #28, `junit` from #34, `clap` from #197.
 #
 # There is deliberately no `terminal`/`core` split. `terminal` is the base layer
 # the crate root is built on — `recipe`, `steps`, `runner`, `execution` and
@@ -159,6 +159,20 @@ json-schema = ["dep:jsonschema", "schema"]
 # the derive registers and will not compile without it.
 schema = ["dep:schemars"]
 
+# The `run_config::cli` layer: a `clap::Command` carrying the standard flags for
+# `RunConfig`, and the parse back into one with the `pick()` precedence applied
+# (#197).
+#
+# Off by default, unlike the other four, and the difference is deliberate. The
+# other four subtract from a shape that has always been published, so default-on
+# is what keeps them from being a break. This one adds a shape that has never
+# been published, so default-off is what keeps *it* from being a change: a
+# consumer that drives `RunConfig` from its own parser, or from a file alone,
+# does not compile `clap` for a layer it will not call. A consumer that wants it
+# names it, which is also the only way an opt-in dependency can be honest about
+# who is paying for it.
+clap = ["dep:clap"]
+
 # The union of what termproof-core, termproof-terminal and termproof-evidence
 # each declared, minus `ab_glyph`, which no code ever referenced (#27).
 # `tempfile` was a dev-dependency of termproof-terminal and a regular dependency
@@ -166,6 +180,7 @@ schema = ["dep:schemars"]
 [dependencies]
 avt = { workspace = true, optional = true }
 chrono.workspace = true
+clap = { workspace = true, optional = true }
 fancy-regex.workspace = true
 globset.workspace = true
 image = { workspace = true, optional = true }

--- a/rust/crates/termproof/README.md
+++ b/rust/crates/termproof/README.md
@@ -40,7 +40,7 @@ it has always been published. `clap` is the exception and is opt-in.
 | `junit` | on | the `junit` module, and `generate_junit` in `evidence` | `quick-junit` |
 | `json-schema` | on | `validation`, `pyschema`, and the `json_schema` built-in assertion. Implies `schema` | `jsonschema` |
 | `schema` | on | the `schema` module, and `JsonSchema` on `Recipe`, `VerifierConfig` and the types they contain | `schemars` |
-| `clap` | off | `run_config::cli` — a `clap::Command` of the standard `RunConfig` flags, and the parse back into one | `clap` |
+| `clap` | off | `run_config::cli` — a `clap::Command` of the standard `RunConfig` flags, and the parse back into one | `clap`, builder-only (no `clap_derive`) |
 
 The default-on four and the default-off one are default-on and default-off for
 the same reason. Each of the four *subtracts* from a shape that was already

--- a/rust/crates/termproof/README.md
+++ b/rust/crates/termproof/README.md
@@ -31,17 +31,25 @@ the only one that has ever existed on crates.io.
 
 ## Features
 
-All four are on by default, so `termproof = "0.3"` is the whole crate — the
-shape that has always been published.
+The first four are on by default, so `termproof = "0.3"` is the whole crate as
+it has always been published. `clap` is the exception and is opt-in.
 
-| Feature | Enables | Costs |
-|---|---|---|
-| `evidence` | the `evidence` module | `image`, `avt` |
-| `junit` | the `junit` module, and `generate_junit` in `evidence` | `quick-junit` |
-| `json-schema` | `validation`, `pyschema`, and the `json_schema` built-in assertion. Implies `schema` | `jsonschema` |
-| `schema` | the `schema` module, and `JsonSchema` on `Recipe`, `VerifierConfig` and the types they contain | `schemars` |
+| Feature | Default | Enables | Costs |
+|---|---|---|---|
+| `evidence` | on | the `evidence` module | `image`, `avt` |
+| `junit` | on | the `junit` module, and `generate_junit` in `evidence` | `quick-junit` |
+| `json-schema` | on | `validation`, `pyschema`, and the `json_schema` built-in assertion. Implies `schema` | `jsonschema` |
+| `schema` | on | the `schema` module, and `JsonSchema` on `Recipe`, `VerifierConfig` and the types they contain | `schemars` |
+| `clap` | off | `run_config::cli` — a `clap::Command` of the standard `RunConfig` flags, and the parse back into one | `clap` |
 
-Turning all four off takes the crate from 180 transitive dependencies to 66:
+The default-on four and the default-off one are default-on and default-off for
+the same reason. Each of the four *subtracts* from a shape that was already
+published, so on by default is what keeps turning one off from being a break.
+`clap` *adds* a shape that never was, so off by default is what keeps it from
+being a change: a consumer that fills in a `RunConfig` from a file, or from its
+own parser, does not compile `clap` for a layer it will not call.
+
+Turning the four off takes the crate from 180 transitive dependencies to 66:
 
 ```toml
 termproof = { version = "0.3", default-features = false }
@@ -187,7 +195,8 @@ lists the same fourteen.
 - `parity` — compares two runs and reports where they disagree.
 - `before_after` — reports which outcomes flipped between two runs.
 - `selection` — maps a changeset onto the recipes it affects, via `ci_paths`.
-- `run_config` — a whole run described by one file.
+- `run_config` — a whole run described by one file, and under the `clap`
+  feature `run_config::cli`, the command line that fills one in.
 - `vocabulary` — a configurable failure detector.
 - `build_info` — provenance for the binary under test, so a result can be
   traced back to an exact artifact.

--- a/rust/crates/termproof/src/lib.rs
+++ b/rust/crates/termproof/src/lib.rs
@@ -36,8 +36,10 @@
 //!
 //! # Features
 //!
-//! All four are on by default, so a consumer that does not name features gets
-//! the whole crate — the shape that has always been published.
+//! The first four are on by default, so a consumer that does not name features
+//! gets the crate as it has always been published. `clap` is the exception: it
+//! is off by default, so `--all-features` and `default` are no longer the same
+//! set.
 //!
 //! - **`evidence`** — the [`evidence`] module. Off, the crate does not compile
 //!   `image` or `avt`.
@@ -57,6 +59,14 @@
 //!   it, because the derives put `JsonSchema` on the published types themselves
 //!   rather than in a signature; turning it off is how a consumer on a
 //!   different `schemars` major stops carrying two.
+//! - **`clap`** (off) — [`run_config`]'s `cli` submodule: a `clap::Command`
+//!   carrying the standard flags for a [`run_config::RunConfig`], and the parse
+//!   back into one with [`run_config::pick`] applied once rather than per flag.
+//!   Off, the crate does not compile `clap`. It is the only default-off feature
+//!   here, and for the mirror image of the other four's reason: they subtract
+//!   from a shape that was already published, so default-on is what keeps
+//!   turning one off from being a break; this adds a shape that never was, so
+//!   default-off is what keeps it from being a change (#197).
 //!
 //! [`terminal`] has no feature of its own: the crate root is built on it, and
 //! every build drives a terminal, so there is nothing to save.

--- a/rust/crates/termproof/src/run_config.rs
+++ b/rust/crates/termproof/src/run_config.rs
@@ -17,6 +17,10 @@
 //! schema below would be dead. The CLI layer is responsible for telling them
 //! apart.
 //!
+//! That layer ships here, behind the `clap` feature: [`cli`] emits the standard
+//! flags for every field below and parses them back, with [`pick`] applied once
+//! rather than per flag. See [`clap_command`] and [`resolve`].
+//!
 //! # Format
 //!
 //! YAML, with JSON parsing for free — YAML 1.2 is a superset of JSON, so one
@@ -37,6 +41,12 @@ use std::path::Path;
 
 use serde::Deserialize;
 use serde::Serialize;
+
+#[cfg(feature = "clap")]
+pub mod cli;
+
+#[cfg(feature = "clap")]
+pub use cli::{augment_args, clap_command, configured, from_matches, merge, resolve};
 
 /// The precedence rule, in one place.
 ///

--- a/rust/crates/termproof/src/run_config.rs
+++ b/rust/crates/termproof/src/run_config.rs
@@ -17,9 +17,14 @@
 //! schema below would be dead. The CLI layer is responsible for telling them
 //! apart.
 //!
-//! That layer ships here, behind the `clap` feature: [`cli`] emits the standard
-//! flags for every field below and parses them back, with [`pick`] applied once
-//! rather than per flag. See [`clap_command`] and [`resolve`].
+//! That layer ships here, behind the off-by-default `clap` feature: the `cli`
+//! submodule emits the standard flags for every field below and parses them
+//! back, with [`pick`] applied once rather than per flag — see
+//! `cli::clap_command` and `cli::resolve`.
+//!
+//! Those three are named in plain code spans rather than as intra-doc links on
+//! purpose: they exist only when the feature is on, and a link from this
+//! ungated paragraph is an unresolved-link warning in every default `cargo doc`.
 //!
 //! # Format
 //!

--- a/rust/crates/termproof/src/run_config/cli.rs
+++ b/rust/crates/termproof/src/run_config/cli.rs
@@ -75,6 +75,48 @@
 //! key by key: per-key merging is a fourth precedence rule, and this layer
 //! exists to stop those being invented one consumer at a time.
 //!
+//! # `uploaded_media` is the one field that does not obey the precedence
+//!
+//! [`Requirements::uploaded_media`](super::Requirements::uploaded_media) is a
+//! `bool`, so it has no unset state for [`pick`] to rank and [`merge`] ORs the
+//! three layers instead. Any of the three asking for it is asking for it.
+//!
+//! The consequence is that it can be raised but never lowered: `require:
+//! {uploaded_media: false}` in a `--run-config` file is inert against a
+//! built-in `true`, and there is no `--no-require-uploaded-media`. For a
+//! *requirement* that is the safe direction to fail in — a config file quietly
+//! switching off a "the evidence must be shareable" gate is the outcome worth
+//! preventing — but it is a real exception to the rule above rather than an
+//! instance of it, so a caller that needs the gate off has to leave it off in
+//! the built-in.
+//!
+//! # Names this layer claims
+//!
+//! [`augment_args`] adds 22 long options, and several are generic enough that a
+//! consumer may already own one: `--root`, `--model`, `--exclude`, `--env`,
+//! `--publisher`, `--transport`, `--effort`. A duplicate long name is a
+//! `clap` **panic**, not an error, and `clap`'s `debug_assert` machinery only
+//! runs in debug builds, so a consumer that only builds release gets the
+//! collision resolved by `clap`'s internal ordering with no diagnostic at all.
+//! The full list, in the order they are added:
+//!
+//! `--run-config`, `--root`, `--repo-marker`, `--all`, `--priority`,
+//! `--recipe-name`, `--changed-files`, `--exclude`, `--transport`,
+//! `--renderer`, `--model`, `--effort`, `--binary-installed`,
+//! `--binary-build`, `--env`, `--timeout-scale`, `--artifact-dir`,
+//! `--report-path`, `--result-json-path`, `--publisher`,
+//! `--publisher-setting`, `--require-uploaded-media`,
+//! `--require-media-publisher`.
+//!
+//! The argument ids are the same strings without the leading `--`, and the two
+//! [`ArgGroup`] names are `select` and `binary`.
+//!
+//! For the same reason, [`from_matches`] and [`resolve`] must be handed an
+//! `ArgMatches` from a command this module augmented. `clap` panics on a lookup
+//! of an id the command never declared, so despite the `Result` these two
+//! cannot turn a foreign `ArgMatches` into an `Err` — the realistic way in is
+//! augmenting a *subcommand* and then passing the top-level matches.
+//!
 //! # Divergence from `termproof.cli`
 //!
 //! Python's `termproof.cli` is an `argparse` program for the `termproof`
@@ -84,6 +126,17 @@
 //! module picks a different name rather than reusing one of Python's for a
 //! different meaning. The full reconciliation is in the CHANGELOG entry for
 //! #197.
+//!
+//! One divergence is not about a *name* and is the easiest to trip over.
+//! `--priority` and `--recipe-name` **compose in Python and conflict here.**
+//! `termproof.registry.select_recipes` applies priority and then names as
+//! successive filters, so `--priority P0 --recipe-name smoke` is a legal
+//! narrowing — "smoke, if it is P0". Here they are two arms of [`Selection`],
+//! which holds one, so they sit in one [`ArgGroup`] and passing both is a usage
+//! error. Same two flag names, same two meanings, different composition; a
+//! command line ported from Python that pairs them stops working. Expressing
+//! the intersection needs the caller to filter the result of a
+//! `Selection::Priority` run themselves.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -663,6 +716,20 @@ mod tests {
     }
 
     #[test]
+    fn priority_and_recipe_name_do_not_compose_here_though_they_do_in_python() {
+        // Pinned because it is the one divergence from `termproof.cli` that is
+        // not visible in a flag *name*. `select_recipes` there applies priority
+        // and then names as successive filters, so this pair is a legal
+        // narrowing; `Selection` holds one arm, so here it is a usage error.
+        // If `Selection` ever grows a way to say both, this test failing is the
+        // prompt to update the divergence table rather than a regression.
+        let e = clap_command()
+            .try_get_matches_from(["termproof", "--priority", "P0", "--recipe-name", "smoke"])
+            .unwrap_err();
+        assert_eq!(e.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
     fn a_binary_cannot_be_both_installed_and_built() {
         let e = clap_command()
             .try_get_matches_from(["termproof", "--binary-installed", "--binary-build", "D123"])
@@ -798,6 +865,39 @@ mod tests {
                 .uploaded_media
         );
         assert!(!merge(&parse(&[]), &off, &off).output.require.uploaded_media);
+    }
+
+    #[test]
+    fn a_required_upload_can_be_raised_but_never_lowered() {
+        // The documented exception to the precedence, pinned so it stays a
+        // decision rather than becoming a surprise. A `bool` has no unset
+        // state, so a configured `false` is indistinguishable from an absent
+        // key and cannot outrank a built-in `true` — and there is no flag for
+        // it either, which is the half that makes this one-way.
+        let builtin = RunConfig {
+            output: Output {
+                require: Requirements {
+                    uploaded_media: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let says_false =
+            RunConfig::parse("output:\n  require:\n    uploaded_media: false\n").unwrap();
+        assert!(
+            merge(&parse(&[]), &says_false, &builtin)
+                .output
+                .require
+                .uploaded_media
+        );
+        assert!(
+            !clap_command()
+                .get_arguments()
+                .any(|a| a.get_long() == Some("no-require-uploaded-media")),
+            "a flag to lower it would make this test's premise false"
+        );
     }
 
     #[test]

--- a/rust/crates/termproof/src/run_config/cli.rs
+++ b/rust/crates/termproof/src/run_config/cli.rs
@@ -1,0 +1,949 @@
+//! The command line that fills in a [`RunConfig`].
+//!
+//! [`super`] models a whole run and says how the three sources of an answer
+//! rank — flag, then config file, then built-in default, via [`pick`]. It does
+//! not say where the flags come from, so every consumer wrote that layer again:
+//! the same twenty-odd `clap` builders, and [`pick`] re-derived by hand once per
+//! flag. This module is that layer, once.
+//!
+//! # The whole outer loop
+//!
+//! ```no_run
+//! use termproof::run_config::{self, Execution, RunConfig};
+//!
+//! let builtin = RunConfig {
+//!     execution: Execution { transport: Some("pty".into()), ..Default::default() },
+//!     ..Default::default()
+//! };
+//! let matches = run_config::clap_command().get_matches();
+//! let config = run_config::resolve(&matches, &builtin)?;
+//! # Ok::<(), String>(())
+//! ```
+//!
+//! [`resolve`] reads `--run-config`, parses it, and applies the precedence to
+//! every field. A consumer with no flags of its own needs nothing else.
+//!
+//! # Composing
+//!
+//! A consumer with flags of its own owns the [`Command`] and asks for the
+//! standard ones to be added to it:
+//!
+//! ```
+//! use clap::{Arg, ArgAction, Command};
+//! use termproof::run_config;
+//!
+//! let command = run_config::augment_args(Command::new("validate"))
+//!     .arg(Arg::new("watch").long("watch").action(ArgAction::SetTrue));
+//! let matches = command.get_matches_from(["validate", "--renderer", "alternate", "--watch"]);
+//!
+//! assert!(matches.get_flag("watch"));
+//! let flags = run_config::from_matches(&matches).unwrap();
+//! assert_eq!(flags.execution.renderer.as_deref(), Some("alternate"));
+//! ```
+//!
+//! [`clap_command`] is [`augment_args`] over a bare `termproof` command, so the
+//! two agree by construction rather than by being kept in step.
+//!
+//! # No flag here has a `default_value`
+//!
+//! That is the load-bearing rule, and [`super`]'s precedence section is where
+//! it comes from: a flag that merely *has* a default is indistinguishable from
+//! one the caller *passed*, and if the two look alike a config file can never
+//! override a defaulted flag — which would make most of the schema dead. So the
+//! built-in default lives in the `builtin: &RunConfig` argument to [`resolve`]
+//! and [`merge`], never in the `clap` argument, and "the caller passed this"
+//! means exactly that `ArgMatches` has a value for it.
+//!
+//! The corollary is that **an empty value is still a value**. `--renderer ''`
+//! beats a configured renderer and resolves to `Some("")`, because the caller
+//! passed it. Reading it as "unset" would be this layer inventing a fourth rule
+//! on top of the three [`pick`] states, and would put the caller back to
+//! guessing which flags treat empty specially.
+//!
+//! # Repeatable flags, and what "unset" means for them
+//!
+//! `--root`, `--exclude`, `--recipe-name`, `--env`, `--publisher` and
+//! `--publisher-setting` are repeatable, and land in fields that are a `Vec` or
+//! a map rather than an `Option`. For those, empty is unset and the first
+//! non-empty of flag / config / built-in wins as a whole — the same shape
+//! [`pick`] has, applied to the whole list.
+//!
+//! Two consequences worth stating rather than discovering. There is no way to
+//! say "explicitly no excludes" on the command line, which matches the config
+//! file, where `exclude: []` is also indistinguishable from an absent key. And
+//! a passed `--env` replaces a configured `env` wholesale rather than merging
+//! key by key: per-key merging is a fourth precedence rule, and this layer
+//! exists to stop those being invented one consumer at a time.
+//!
+//! # Divergence from `termproof.cli`
+//!
+//! Python's `termproof.cli` is an `argparse` program for the `termproof`
+//! binary; this is a library layer for a config type Python has no counterpart
+//! for. Where the two name the same thing they use the same flag —
+//! `--priority`, `--recipe-name`, `--renderer` — and where they do not, this
+//! module picks a different name rather than reusing one of Python's for a
+//! different meaning. The full reconciliation is in the CHANGELOG entry for
+//! #197.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use clap::{value_parser, Arg, ArgAction, ArgGroup, ArgMatches, Command};
+
+use super::{
+    pick, BinarySource, Discovery, Execution, Output, Publisher, Requirements, RunConfig, Selection,
+};
+
+/// The standard `RunConfig` flags on a bare `termproof` command.
+///
+/// Equal to [`augment_args`] over `Command::new("termproof")`; a consumer that
+/// already owns a [`Command`] should call that instead.
+pub fn clap_command() -> Command {
+    augment_args(Command::new("termproof"))
+}
+
+/// Add the standard `RunConfig` flags to an existing command.
+///
+/// The consumer keeps its own `Command` — name, version, about, subcommands and
+/// any flags of its own — and gets the ones this crate knows how to parse back
+/// into a [`RunConfig`].
+pub fn augment_args(command: Command) -> Command {
+    command
+        .arg(
+            Arg::new("run-config")
+                .long("run-config")
+                .value_name("PATH")
+                .help("Read a run config from this YAML or JSON file"),
+        )
+        // -- discovery ---------------------------------------------------
+        .arg(
+            Arg::new("root")
+                .long("root")
+                .value_name("DIR")
+                .action(ArgAction::Append)
+                .help("Directory a changed file must fall under to count as touching the framework (repeatable)"),
+        )
+        .arg(
+            Arg::new("repo-marker")
+                .long("repo-marker")
+                .value_name("FRAGMENT")
+                .help("Path fragment that marks the start of a repo-relative path"),
+        )
+        .arg(
+            Arg::new("all")
+                .long("all")
+                .action(ArgAction::SetTrue)
+                .help("Run every discovered recipe"),
+        )
+        .arg(
+            Arg::new("priority")
+                .long("priority")
+                .value_name("PRIORITY")
+                .help("Run every recipe at this priority, e.g. P0"),
+        )
+        .arg(
+            Arg::new("recipe-name")
+                .long("recipe-name")
+                .value_name("NAME")
+                .action(ArgAction::Append)
+                .help("Run exactly this recipe (repeatable)"),
+        )
+        .arg(
+            Arg::new("changed-files")
+                .long("changed-files")
+                .value_name("PATH")
+                .help("Run recipes whose ci_paths match the changed files listed in this file"),
+        )
+        // The enum is mutually exclusive by construction, so the command line
+        // is too — otherwise "all and a priority" becomes something this layer
+        // has to rank, and the config file has no such ranking to mirror.
+        .group(
+            ArgGroup::new("select")
+                .args(["all", "priority", "recipe-name", "changed-files"])
+                .multiple(false),
+        )
+        .arg(
+            Arg::new("exclude")
+                .long("exclude")
+                .value_name("GLOB")
+                .action(ArgAction::Append)
+                .help("Skip recipes whose name matches this glob (repeatable)"),
+        )
+        // -- execution ---------------------------------------------------
+        .arg(
+            Arg::new("transport")
+                .long("transport")
+                .value_name("NAME")
+                .help("Terminal transport, for example pty or tmux"),
+        )
+        .arg(
+            Arg::new("renderer")
+                .long("renderer")
+                .value_name("NAME")
+                .help("Renderer or renderer set to validate"),
+        )
+        .arg(
+            Arg::new("model")
+                .long("model")
+                .value_name("ID")
+                .help("Model identifier to run the product under test with"),
+        )
+        .arg(
+            Arg::new("effort")
+                .long("effort")
+                .value_name("LEVEL")
+                .help("Reasoning-effort setting to pair with --model"),
+        )
+        .arg(
+            Arg::new("binary-installed")
+                .long("binary-installed")
+                .action(ArgAction::SetTrue)
+                .help("Test the already-installed binary"),
+        )
+        .arg(
+            Arg::new("binary-build")
+                .long("binary-build")
+                .value_name("CHANGE")
+                .help("Build from the current checkout, labelling results with this change id"),
+        )
+        .group(
+            ArgGroup::new("binary")
+                .args(["binary-installed", "binary-build"])
+                .multiple(false),
+        )
+        .arg(
+            Arg::new("env")
+                .long("env")
+                .value_name("KEY=VALUE")
+                .action(ArgAction::Append)
+                .help("Environment applied to every recipe (repeatable)"),
+        )
+        .arg(
+            Arg::new("timeout-scale")
+                .long("timeout-scale")
+                .value_name("FACTOR")
+                .value_parser(value_parser!(f64))
+                .help("Multiply every recipe's declared timeout by this factor"),
+        )
+        // -- output ------------------------------------------------------
+        .arg(
+            Arg::new("artifact-dir")
+                .long("artifact-dir")
+                .value_name("DIR")
+                .help("Directory for screenshots, casts and videos"),
+        )
+        .arg(
+            Arg::new("report-path")
+                .long("report-path")
+                .value_name("PATH")
+                .help("Where the human-readable report is written"),
+        )
+        .arg(
+            Arg::new("result-json-path")
+                .long("result-json-path")
+                .value_name("PATH")
+                .help("Where the machine-readable result JSON is written"),
+        )
+        .arg(
+            Arg::new("publisher")
+                .long("publisher")
+                .value_name("NAME")
+                .action(ArgAction::Append)
+                .help("Publisher to run, in the order given (repeatable)"),
+        )
+        .arg(
+            Arg::new("publisher-setting")
+                .long("publisher-setting")
+                .value_name("PUBLISHER:KEY=VALUE")
+                .action(ArgAction::Append)
+                .help("Setting for a publisher named by --publisher (repeatable)"),
+        )
+        .arg(
+            Arg::new("require-uploaded-media")
+                .long("require-uploaded-media")
+                .action(ArgAction::SetTrue)
+                .help("Fail if evidence was not uploaded anywhere shareable"),
+        )
+        .arg(
+            Arg::new("require-media-publisher")
+                .long("require-media-publisher")
+                .value_name("NAME")
+                .help("Fail if this specific publisher did not carry the evidence"),
+        )
+}
+
+/// Exactly what the flags said, and nothing else.
+///
+/// Every field the caller did not pass is left unset, so the result is the
+/// `flag` column of [`pick`] rather than a usable config. [`resolve`] is what
+/// turns it into one.
+pub fn from_matches(matches: &ArgMatches) -> Result<RunConfig, String> {
+    Ok(RunConfig {
+        discovery: Discovery {
+            roots: strings(matches, "root"),
+            repo_marker: string(matches, "repo-marker"),
+            select: selection(matches),
+            exclude: strings(matches, "exclude"),
+        },
+        execution: Execution {
+            transport: string(matches, "transport"),
+            renderer: string(matches, "renderer"),
+            model: string(matches, "model"),
+            effort: string(matches, "effort"),
+            binary: binary(matches),
+            env: env(matches)?,
+            timeout_scale: matches.get_one::<f64>("timeout-scale").copied(),
+        },
+        output: Output {
+            artifact_dir: string(matches, "artifact-dir"),
+            report_path: string(matches, "report-path"),
+            result_json_path: string(matches, "result-json-path"),
+            publishers: publishers(matches)?,
+            require: Requirements {
+                uploaded_media: matches.get_flag("require-uploaded-media"),
+                media_publisher: string(matches, "require-media-publisher"),
+            },
+        },
+    })
+}
+
+/// The config file named by `--run-config`, or an empty config if there is none.
+pub fn configured(matches: &ArgMatches) -> Result<RunConfig, String> {
+    match matches.get_one::<String>("run-config") {
+        Some(path) => RunConfig::from_path(Path::new(path)),
+        None => Ok(RunConfig::default()),
+    }
+}
+
+/// The command line and its `--run-config` file, resolved against `builtin`.
+///
+/// This is the whole outer loop: [`configured`] for the file, [`from_matches`]
+/// for the flags, [`merge`] for the precedence.
+pub fn resolve(matches: &ArgMatches, builtin: &RunConfig) -> Result<RunConfig, String> {
+    Ok(merge(
+        &from_matches(matches)?,
+        &configured(matches)?,
+        builtin,
+    ))
+}
+
+/// [`pick`] over every field of a [`RunConfig`], in one place.
+///
+/// Separate from [`resolve`] because it is pure: a consumer that reads its
+/// config from somewhere other than `--run-config` still wants the precedence
+/// applied once rather than per flag.
+pub fn merge(flags: &RunConfig, configured: &RunConfig, builtin: &RunConfig) -> RunConfig {
+    let (f, c, b) = (flags, configured, builtin);
+    RunConfig {
+        discovery: Discovery {
+            roots: pick_list(&f.discovery.roots, &c.discovery.roots, &b.discovery.roots),
+            repo_marker: pick_opt(
+                &f.discovery.repo_marker,
+                &c.discovery.repo_marker,
+                &b.discovery.repo_marker,
+            ),
+            select: pick_opt(
+                &f.discovery.select,
+                &c.discovery.select,
+                &b.discovery.select,
+            ),
+            exclude: pick_list(
+                &f.discovery.exclude,
+                &c.discovery.exclude,
+                &b.discovery.exclude,
+            ),
+        },
+        execution: Execution {
+            transport: pick_opt(
+                &f.execution.transport,
+                &c.execution.transport,
+                &b.execution.transport,
+            ),
+            renderer: pick_opt(
+                &f.execution.renderer,
+                &c.execution.renderer,
+                &b.execution.renderer,
+            ),
+            model: pick_opt(&f.execution.model, &c.execution.model, &b.execution.model),
+            effort: pick_opt(
+                &f.execution.effort,
+                &c.execution.effort,
+                &b.execution.effort,
+            ),
+            binary: pick_opt(
+                &f.execution.binary,
+                &c.execution.binary,
+                &b.execution.binary,
+            ),
+            env: pick_map(&f.execution.env, &c.execution.env, &b.execution.env),
+            timeout_scale: pick_opt(
+                &f.execution.timeout_scale,
+                &c.execution.timeout_scale,
+                &b.execution.timeout_scale,
+            ),
+        },
+        output: Output {
+            artifact_dir: pick_opt(
+                &f.output.artifact_dir,
+                &c.output.artifact_dir,
+                &b.output.artifact_dir,
+            ),
+            report_path: pick_opt(
+                &f.output.report_path,
+                &c.output.report_path,
+                &b.output.report_path,
+            ),
+            result_json_path: pick_opt(
+                &f.output.result_json_path,
+                &c.output.result_json_path,
+                &b.output.result_json_path,
+            ),
+            publishers: pick_list(
+                &f.output.publishers,
+                &c.output.publishers,
+                &b.output.publishers,
+            ),
+            require: Requirements {
+                // A `bool` has no unset state to rank, so this is `pick` where
+                // `pick` can tell the difference and a disjunction where it
+                // cannot: any of the three asking for it is asking for it.
+                uploaded_media: f.output.require.uploaded_media
+                    || c.output.require.uploaded_media
+                    || b.output.require.uploaded_media,
+                media_publisher: pick_opt(
+                    &f.output.require.media_publisher,
+                    &c.output.require.media_publisher,
+                    &b.output.require.media_publisher,
+                ),
+            },
+        },
+    }
+}
+
+/// [`pick`] for a field whose built-in is itself optional.
+///
+/// [`pick`] takes the built-in as a value, because that is what a built-in
+/// usually is. Here it arrives as a field of a [`RunConfig`], so it can be
+/// absent too — and when it is, there is no third answer and the first two are
+/// the whole ranking.
+fn pick_opt<T: Clone>(flags: &Option<T>, configured: &Option<T>, builtin: &Option<T>) -> Option<T> {
+    match builtin {
+        Some(builtin) => Some(pick(flags.clone(), configured.clone(), builtin.clone())),
+        None => flags.clone().or_else(|| configured.clone()),
+    }
+}
+
+/// [`pick`] for a field whose "unset" is emptiness rather than `None`.
+fn pick_list<T: Clone>(flags: &[T], configured: &[T], builtin: &[T]) -> Vec<T> {
+    for candidate in [flags, configured, builtin] {
+        if !candidate.is_empty() {
+            return candidate.to_vec();
+        }
+    }
+    Vec::new()
+}
+
+/// [`pick_list`], for the one field that is a map rather than a list.
+fn pick_map(
+    flags: &BTreeMap<String, String>,
+    configured: &BTreeMap<String, String>,
+    builtin: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    for candidate in [flags, configured, builtin] {
+        if !candidate.is_empty() {
+            return candidate.clone();
+        }
+    }
+    BTreeMap::new()
+}
+
+fn string(matches: &ArgMatches, id: &str) -> Option<String> {
+    matches.get_one::<String>(id).cloned()
+}
+
+fn strings(matches: &ArgMatches, id: &str) -> Vec<String> {
+    matches
+        .get_many::<String>(id)
+        .map(|values| values.cloned().collect())
+        .unwrap_or_default()
+}
+
+fn selection(matches: &ArgMatches) -> Option<Selection> {
+    if matches.get_flag("all") {
+        return Some(Selection::All);
+    }
+    if let Some(priority) = string(matches, "priority") {
+        return Some(Selection::Priority(priority));
+    }
+    let names = strings(matches, "recipe-name");
+    if !names.is_empty() {
+        return Some(Selection::Names(names));
+    }
+    string(matches, "changed-files").map(Selection::ChangedFiles)
+}
+
+fn binary(matches: &ArgMatches) -> Option<BinarySource> {
+    if matches.get_flag("binary-installed") {
+        return Some(BinarySource::Installed);
+    }
+    string(matches, "binary-build").map(BinarySource::Build)
+}
+
+fn env(matches: &ArgMatches) -> Result<BTreeMap<String, String>, String> {
+    let mut env = BTreeMap::new();
+    for entry in strings(matches, "env") {
+        let (key, value) = entry
+            .split_once('=')
+            .ok_or_else(|| format!("--env {entry}: expected KEY=VALUE"))?;
+        if key.is_empty() {
+            return Err(format!("--env {entry}: the key is empty"));
+        }
+        env.insert(key.to_string(), value.to_string());
+    }
+    Ok(env)
+}
+
+fn publishers(matches: &ArgMatches) -> Result<Vec<Publisher>, String> {
+    let mut publishers: Vec<Publisher> = strings(matches, "publisher")
+        .into_iter()
+        .map(|name| Publisher {
+            name,
+            settings: BTreeMap::new(),
+        })
+        .collect();
+    for entry in strings(matches, "publisher-setting") {
+        let (name, setting) = entry
+            .split_once(':')
+            .ok_or_else(|| format!("--publisher-setting {entry}: expected PUBLISHER:KEY=VALUE"))?;
+        let (key, value) = setting
+            .split_once('=')
+            .ok_or_else(|| format!("--publisher-setting {entry}: expected PUBLISHER:KEY=VALUE"))?;
+        // Not auto-created: a setting for a publisher nobody asked to run is
+        // either a typo in the name or a forgotten `--publisher`, and both are
+        // better as a startup failure than as a publisher that silently
+        // appears, or settings that silently go nowhere.
+        let publisher = publishers
+            .iter_mut()
+            .find(|p| p.name == name)
+            .ok_or_else(|| format!("--publisher-setting {entry}: no --publisher named {name:?}"))?;
+        publisher
+            .settings
+            .insert(key.to_string(), value.to_string());
+    }
+    Ok(publishers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse a command line the way a consumer with no extra flags would.
+    fn parse(argv: &[&str]) -> RunConfig {
+        try_parse(argv).unwrap()
+    }
+
+    fn try_parse(argv: &[&str]) -> Result<RunConfig, String> {
+        from_matches(&matches_of(argv))
+    }
+
+    fn matches_of(argv: &[&str]) -> ArgMatches {
+        let mut full = vec!["termproof"];
+        full.extend_from_slice(argv);
+        clap_command().get_matches_from(full)
+    }
+
+    #[test]
+    fn the_command_line_says_the_same_things_the_config_file_does() {
+        // The counterpart of `the_ci_workflows_flags_are_all_expressible` in
+        // the parent module: every field of the schema, said as flags.
+        let c = parse(&[
+            "--root",
+            "some/framework/root/",
+            "--repo-marker",
+            "/repo/",
+            "--recipe-name",
+            "smoke",
+            "--recipe-name",
+            "plugins",
+            "--exclude",
+            "flaky-*",
+            "--transport",
+            "pty",
+            "--renderer",
+            "some-renderer",
+            "--model",
+            "some-model",
+            "--effort",
+            "high",
+            "--binary-installed",
+            "--env",
+            "KEY=value",
+            "--timeout-scale",
+            "1.5",
+            "--artifact-dir",
+            "/tmp/evidence",
+            "--report-path",
+            "/tmp/report.md",
+            "--result-json-path",
+            "/tmp/results.json",
+            "--publisher",
+            "object-store",
+            "--publisher-setting",
+            "object-store:bucket=some-bucket",
+            "--require-uploaded-media",
+            "--require-media-publisher",
+            "image-host",
+        ]);
+        assert_eq!(c.discovery.roots, ["some/framework/root/"]);
+        assert_eq!(c.discovery.repo_marker.as_deref(), Some("/repo/"));
+        assert_eq!(
+            c.discovery.select,
+            Some(Selection::Names(vec![
+                "smoke".to_string(),
+                "plugins".to_string()
+            ]))
+        );
+        assert_eq!(c.discovery.exclude, ["flaky-*"]);
+        assert_eq!(c.execution.transport.as_deref(), Some("pty"));
+        assert_eq!(c.execution.renderer.as_deref(), Some("some-renderer"));
+        assert_eq!(c.execution.model.as_deref(), Some("some-model"));
+        assert_eq!(c.execution.effort.as_deref(), Some("high"));
+        assert_eq!(c.execution.binary, Some(BinarySource::Installed));
+        assert_eq!(c.execution.env["KEY"], "value");
+        assert_eq!(c.execution.timeout_scale, Some(1.5));
+        assert_eq!(c.output.artifact_dir.as_deref(), Some("/tmp/evidence"));
+        assert_eq!(c.output.report_path.as_deref(), Some("/tmp/report.md"));
+        assert_eq!(
+            c.output.result_json_path.as_deref(),
+            Some("/tmp/results.json")
+        );
+        assert_eq!(
+            c.publisher("object-store").unwrap().settings["bucket"],
+            "some-bucket"
+        );
+        assert!(c.output.require.uploaded_media);
+        assert_eq!(
+            c.output.require.media_publisher.as_deref(),
+            Some("image-host")
+        );
+    }
+
+    #[test]
+    fn an_empty_command_line_asks_for_nothing() {
+        // The precondition for the whole precedence: what the caller did not
+        // pass has to arrive as unset, or the config file is dead.
+        assert_eq!(parse(&[]), RunConfig::default());
+    }
+
+    #[test]
+    fn every_way_of_selecting_recipes_has_a_flag() {
+        assert_eq!(parse(&["--all"]).discovery.select, Some(Selection::All));
+        assert_eq!(
+            parse(&["--priority", "P0"]).discovery.select,
+            Some(Selection::Priority("P0".into()))
+        );
+        assert_eq!(
+            parse(&["--recipe-name", "a"]).discovery.select,
+            Some(Selection::Names(vec!["a".to_string()]))
+        );
+        assert_eq!(
+            parse(&["--changed-files", "/tmp/c.txt"]).discovery.select,
+            Some(Selection::ChangedFiles("/tmp/c.txt".into()))
+        );
+    }
+
+    #[test]
+    fn a_second_way_of_selecting_is_a_usage_error() {
+        // The enum cannot hold two, so neither can the command line, and clap
+        // says so before this module has to rank them.
+        let e = clap_command()
+            .try_get_matches_from(["termproof", "--all", "--priority", "P0"])
+            .unwrap_err();
+        assert_eq!(e.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn a_binary_cannot_be_both_installed_and_built() {
+        let e = clap_command()
+            .try_get_matches_from(["termproof", "--binary-installed", "--binary-build", "D123"])
+            .unwrap_err();
+        assert_eq!(e.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn building_from_a_checkout_carries_the_change_id() {
+        assert_eq!(
+            parse(&["--binary-build", "D123"]).execution.binary,
+            Some(BinarySource::Build("D123".into()))
+        );
+    }
+
+    #[test]
+    fn a_flag_beats_the_config_which_beats_the_builtin() {
+        let builtin = RunConfig {
+            execution: Execution {
+                transport: Some("builtin".into()),
+                renderer: Some("builtin".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let configured = RunConfig {
+            execution: Execution {
+                renderer: Some("configured".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let c = merge(&parse(&["--renderer", "flag"]), &configured, &builtin);
+        assert_eq!(c.execution.renderer.as_deref(), Some("flag"));
+
+        let c = merge(&parse(&[]), &configured, &builtin);
+        assert_eq!(c.execution.renderer.as_deref(), Some("configured"));
+
+        // And the field no flag and no config named still gets the built-in,
+        // which is the half a caller re-deriving `pick()` per flag drops.
+        assert_eq!(c.execution.transport.as_deref(), Some("builtin"));
+    }
+
+    #[test]
+    fn a_flag_passed_empty_is_still_a_flag_passed() {
+        // The bug this layer exists to stop being rewritten: `--renderer ''`
+        // is a value the caller chose, so it beats the config. Treating it as
+        // unset would be a fourth state on top of `pick`'s three, and every
+        // consumer would have to remember which flags have it.
+        let configured = RunConfig {
+            execution: Execution {
+                renderer: Some("configured".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let c = merge(
+            &parse(&["--renderer", ""]),
+            &configured,
+            &RunConfig::default(),
+        );
+        assert_eq!(c.execution.renderer.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn a_repeatable_flag_replaces_the_configured_list_rather_than_adding_to_it() {
+        let configured = RunConfig {
+            discovery: Discovery {
+                exclude: vec!["configured-*".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let c = merge(
+            &parse(&["--exclude", "flag-*"]),
+            &configured,
+            &RunConfig::default(),
+        );
+        assert_eq!(c.discovery.exclude, ["flag-*"]);
+
+        // Unset for a list is empty, so the configured list survives.
+        let c = merge(&parse(&[]), &configured, &RunConfig::default());
+        assert_eq!(c.discovery.exclude, ["configured-*"]);
+    }
+
+    #[test]
+    fn a_passed_env_replaces_the_configured_env_wholesale() {
+        let configured = RunConfig {
+            execution: Execution {
+                env: BTreeMap::from([("FROM_CONFIG".to_string(), "1".to_string())]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let c = merge(
+            &parse(&["--env", "FROM_FLAG=1"]),
+            &configured,
+            &RunConfig::default(),
+        );
+        assert_eq!(c.execution.env.keys().collect::<Vec<_>>(), ["FROM_FLAG"]);
+    }
+
+    #[test]
+    fn any_of_the_three_can_require_uploaded_media() {
+        let required = RunConfig {
+            output: Output {
+                require: Requirements {
+                    uploaded_media: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let off = RunConfig::default();
+        assert!(
+            merge(&parse(&["--require-uploaded-media"]), &off, &off)
+                .output
+                .require
+                .uploaded_media
+        );
+        assert!(
+            merge(&parse(&[]), &required, &off)
+                .output
+                .require
+                .uploaded_media
+        );
+        assert!(
+            merge(&parse(&[]), &off, &required)
+                .output
+                .require
+                .uploaded_media
+        );
+        assert!(!merge(&parse(&[]), &off, &off).output.require.uploaded_media);
+    }
+
+    #[test]
+    fn an_env_entry_without_a_value_says_what_it_wanted() {
+        let e = try_parse(&["--env", "NOEQUALS"]).unwrap_err();
+        assert!(e.contains("KEY=VALUE"), "{e}");
+        let e = try_parse(&["--env", "=value"]).unwrap_err();
+        assert!(e.contains("empty"), "{e}");
+        // An empty *value* is legitimate: setting a variable to nothing.
+        assert_eq!(parse(&["--env", "KEY="]).execution.env["KEY"], "");
+    }
+
+    #[test]
+    fn publishers_keep_the_order_they_were_given() {
+        let c = parse(&["--publisher", "first", "--publisher", "second"]);
+        let names: Vec<&str> = c
+            .output
+            .publishers
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(names, ["first", "second"]);
+    }
+
+    #[test]
+    fn a_setting_for_a_publisher_nobody_asked_for_is_an_error() {
+        let e = try_parse(&[
+            "--publisher",
+            "object-store",
+            "--publisher-setting",
+            "objectstore:bucket=b",
+        ])
+        .unwrap_err();
+        assert!(e.contains("objectstore"), "{e}");
+        let e = try_parse(&["--publisher-setting", "no-colon-or-equals"]).unwrap_err();
+        assert!(e.contains("PUBLISHER:KEY=VALUE"), "{e}");
+    }
+
+    #[test]
+    fn a_setting_value_may_contain_the_separators() {
+        // Split at the *first* colon and the *first* equals, so a URL or a
+        // key=value payload survives being a setting value.
+        let c = parse(&[
+            "--publisher",
+            "object-store",
+            "--publisher-setting",
+            "object-store:endpoint=https://host:9000/?a=b",
+        ]);
+        assert_eq!(
+            c.publisher("object-store").unwrap().settings["endpoint"],
+            "https://host:9000/?a=b"
+        );
+    }
+
+    #[test]
+    fn a_timeout_scale_that_is_not_a_number_is_a_usage_error() {
+        let e = clap_command()
+            .try_get_matches_from(["termproof", "--timeout-scale", "slow"])
+            .unwrap_err();
+        assert_eq!(e.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn no_flag_carries_a_default_value() {
+        // The rule the whole precedence rests on, asserted structurally rather
+        // than trusted: a `default_value` here would make that flag
+        // indistinguishable from one the caller passed, and the config file
+        // could never override it.
+        for arg in clap_command().get_arguments() {
+            assert!(
+                arg.get_default_values().is_empty(),
+                "--{} has a default value; the built-in belongs in `builtin`, not in clap",
+                arg.get_id()
+            );
+        }
+    }
+
+    #[test]
+    fn a_consumer_can_add_its_own_flags() {
+        let command = augment_args(Command::new("validator"))
+            .arg(Arg::new("watch").long("watch").action(ArgAction::SetTrue));
+        // It is the consumer's command that comes back, not one of ours with
+        // the consumer's flags bolted on — the name, and with it the about,
+        // version and subcommands, is still theirs.
+        assert_eq!(command.get_name(), "validator");
+        let matches = command.get_matches_from(["validator", "--watch", "--priority", "P0"]);
+        assert!(matches.get_flag("watch"));
+        assert_eq!(
+            from_matches(&matches).unwrap().discovery.select,
+            Some(Selection::Priority("P0".into()))
+        );
+    }
+
+    #[test]
+    fn the_run_config_flag_reads_the_file_it_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.yaml");
+        std::fs::write(&path, "execution:\n  renderer: from-file\n").unwrap();
+        let path = path.to_str().unwrap();
+
+        let c = resolve(&matches_of(&["--run-config", path]), &RunConfig::default()).unwrap();
+        assert_eq!(c.execution.renderer.as_deref(), Some("from-file"));
+
+        // And the flag still wins over the file it was read from.
+        let c = resolve(
+            &matches_of(&["--run-config", path, "--renderer", "from-flag"]),
+            &RunConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(c.execution.renderer.as_deref(), Some("from-flag"));
+    }
+
+    #[test]
+    fn a_missing_run_config_says_which_file() {
+        let e = resolve(
+            &matches_of(&["--run-config", "/nonexistent/run.yaml"]),
+            &RunConfig::default(),
+        )
+        .unwrap_err();
+        assert!(e.contains("/nonexistent/run.yaml"), "{e}");
+    }
+
+    #[test]
+    fn with_no_run_config_the_configured_layer_is_simply_empty() {
+        assert_eq!(configured(&matches_of(&[])).unwrap(), RunConfig::default());
+    }
+
+    #[test]
+    fn the_bare_command_and_an_augmented_one_carry_the_same_flags() {
+        // `clap_command` is `augment_args` over a bare command, so this cannot
+        // drift — which is the point of it not being a second builder.
+        let bare: Vec<_> = clap_command()
+            .get_arguments()
+            .map(|a| a.get_id().to_string())
+            .collect();
+        let augmented: Vec<_> = augment_args(Command::new("other"))
+            .get_arguments()
+            .map(|a| a.get_id().to_string())
+            .collect();
+        assert_eq!(bare, augmented);
+    }
+
+    #[test]
+    fn the_command_is_internally_consistent() {
+        // clap's own audit of ids, groups and conflicts. It panics rather than
+        // returning, and only in debug builds, which is where tests run.
+        clap_command().debug_assert();
+    }
+}

--- a/rust/docs/architecture.md
+++ b/rust/docs/architecture.md
@@ -134,7 +134,8 @@ the CLI has.
 - `parity` — compares two runs and reports where they disagree.
 - `before_after` — reports which outcomes flipped.
 - `selection` — maps a changeset onto recipes via `ci_paths`.
-- `run_config` — a whole run described by one file.
+- `run_config` — a whole run described by one file, and under the `clap`
+  feature `run_config::cli`, the command line that fills one in.
 - `vocabulary` — a configurable failure detector.
 - `build_info` — provenance for the binary under test.
 - `terminal::attributed` — a per-cell screen (colours, styles, display

--- a/rust/docs/engineering-baseline.md
+++ b/rust/docs/engineering-baseline.md
@@ -186,11 +186,23 @@ and this document is updated.
   "junit")] pub use` lines in `evidence` are path aliases that keep the 0.3.1
   paths resolving — they compile no code of their own.
 - Every combination is built and tested, not just `default` and
-  `--all-features`. With four features that is the full powerset of sixteen —
+  `--all-features`. With five features that is the full powerset of thirty-two —
   including those that resolve to the same set as another, because what is
   checked is that every combination a consumer can *write* compiles. The CI
   step enumerates the powerset from a feature list rather than spelling the
   combinations out, so adding a feature grows the matrix by construction.
+
+  Since `clap` (#197), `default` and `--all-features` are also no longer the
+  same set, so neither one alone stands in for the other.
+
+  Growth is doubling, and the ceiling is not far off: measured on the last
+  `main` run before `clap`, sixteen combinations took 7.8 min on ubuntu and 9.3
+  on macos, so thirty-two is ~16-19 min inside a ~18-21 min job. A sixth
+  feature would be ~37 min of powerset in a ~40 min job, against the 60-minute
+  per-job cap `python/tests/test_ci_timeouts.py` enforces. At that point the
+  step wants sharding across the job matrix rather than a sixth entry in the
+  array — the enumerate-from-a-list property is what makes that a mechanical
+  change rather than a rewrite.
 - A feature must not be able to compile a differential harness out. Parity
   evidence is the reason the harnesses exist, and a combination that drops it
   still reports green. Where a feature genuinely removes the capability a case

--- a/rust/docs/status-and-parity.md
+++ b/rust/docs/status-and-parity.md
@@ -147,7 +147,8 @@ run`:
 - `termproof::parity` — compares two runs and reports where they disagree.
 - `termproof::before_after` — reports which outcomes flipped.
 - `termproof::selection` — maps a changeset onto recipes via `ci_paths`.
-- `termproof::run_config` — a whole run described by one file.
+- `termproof::run_config` — a whole run described by one file, plus
+  `run_config::cli` under the `clap` feature: the flags that fill one in.
 - `termproof::vocabulary` — a configurable failure detector.
 - `termproof::build_info` — provenance for the binary under test.
 - `terminal::attributed` — a per-cell screen carrying colours, styles and


### PR DESCRIPTION
Closes #197.

`run_config` has modelled a whole run since it landed — `RunConfig`, `Discovery`,
`Selection`, `Execution`, `BinarySource`, `Output`, `Publisher`, `Requirements`,
and `pick(flag, configured, builtin)` for how the three sources of an answer
rank. Nothing populated it from argv, so each Rust consumer wrote that layer
again. This adds it once, behind an opt-in feature.

## The shape

`run_config::cli`, gated on the new default-off `clap` feature, re-exported at
the `run_config` root:

| Function | What it is |
|---|---|
| `clap_command() -> Command` | the standard flags on a bare `termproof` command |
| `augment_args(Command) -> Command` | the same flags added to a command the consumer owns |
| `from_matches(&ArgMatches)` | exactly what the flags said, everything else unset |
| `configured(&ArgMatches)` | the file `--run-config` names, or an empty config |
| `merge(flags, configured, builtin)` | `pick()` over every field, in one place |
| `resolve(&ArgMatches, builtin)` | all of the above in one call |

The issue suggested `clap_command()` / `from_matches(&ArgMatches)`; both exist
with those names. `resolve` is the addition, and it is the one the issue's
complaint actually asks for: `from_matches` alone gives you the flag column, and
a caller left to combine that with a config and a built-in is a caller
re-deriving `pick()` per flag, which is the 200 lines. `augment_args` is the
composability seam — `clap_command()` is defined as `augment_args` over a bare
command, so the two cannot drift.

## Two rules that are asserted, not described

**No flag carries a `default_value`.** `run_config`'s own precedence section
already warned about this: a flag that merely *has* a default is
indistinguishable from one the caller *passed*, and if the two look alike a
config file can never override it, which would make most of the schema dead. So
the built-in arrives as the `builtin: &RunConfig` argument, and
`no_flag_carries_a_default_value` walks `clap_command().get_arguments()` and
fails on any default — structural, so a later flag cannot quietly reintroduce
the bug.

**A flag passed empty is a flag passed.** `--renderer ''` beats a configured
renderer and resolves to `Some("")`. Reading it as unset would add a fourth
state on top of `pick()`'s three and put every consumer back to remembering
which flags treat empty specially. Covered directly by
`a_flag_passed_empty_is_still_a_flag_passed`.

**And one field does not obey that precedence.** `Requirements.uploaded_media`
is a `bool`, so it has no unset state for `pick()` to rank and `merge` ORs the
three layers. It can be raised but never lowered: `require: {uploaded_media:
false}` in a config file is inert against a built-in `true`, and there is no
`--no-require-uploaded-media`. For a requirement that is the safe direction to
fail in, but it is an exception rather than an instance of the rule, so it is
now stated in the module doc and the changelog and pinned by
`a_required_upload_can_be_raised_but_never_lowered`.

For the fields that are a `Vec` or a map rather than an `Option`, empty *is*
unset and the first non-empty of flag / config / built-in wins as a whole. Two
consequences are documented rather than left to be discovered: there is no way
to say "explicitly no excludes" on the command line, which matches the config
file where `exclude: []` is also indistinguishable from an absent key; and a
passed `--env` replaces a configured `env` wholesale rather than merging key by
key, because per-key merging is a fourth precedence rule and this layer exists
to stop those being invented one consumer at a time.

## Reconciled against `termproof.cli`

Where the two name the same thing they use the same flag: `--priority`,
`--recipe-name` (repeatable in both), `--renderer`. Every divergence:

| This layer | `termproof.cli` | Why |
|---|---|---|
| `--run-config PATH` | `--config PATH` is the *plugin registry* (`VerifierConfig`) | Two different config files. Reusing `--config` is the one name collision worth avoiding, and a consumer with both still needs to name each. |
| `--artifact-dir DIR` | `--out DIR` | Not the same thing. `--out` is one directory the report path is also derived from; `RunConfig` separates `artifact_dir`, `report_path` and `result_json_path`, so no flag here carries `--out`'s meaning and taking the name would be exactly the collision above. |
| `--priority` **with** `--recipe-name` is a usage error | the two compose | The one divergence that is not about a name. `termproof.registry.select_recipes` applies priority then names as successive filters, so `--priority P0 --recipe-name smoke` is a legal narrowing there — "smoke, if it is P0". `Selection` holds one arm, so the same pair is an `ArgumentConflict` here. Pinned by `priority_and_recipe_name_do_not_compose_here_though_they_do_in_python`. |
| `--all`, `--changed-files` | — | `Selection` has four arms and Python's CLI exposes two. All four get a flag, in one `ArgGroup`, so "all *and* a priority" is a usage error rather than something this layer has to rank. |
| `--root`, `--repo-marker`, `--exclude`, `--transport`, `--model`, `--effort`, `--binary-installed`, `--binary-build`, `--env`, `--timeout-scale`, `--publisher`, `--publisher-setting`, `--require-uploaded-media`, `--require-media-publisher` | — | Fields `RunConfig` has and Python has no counterpart for. |

`--binary-installed` / `--binary-build CHANGE` in one `ArgGroup` mirror
`BinarySource`'s two arms the way the selection group mirrors `Selection`'s
four: mutually exclusive by construction on both sides, so neither the enum nor
the command line can hold two and there is no validation pass to forget.

## Why Python is unchanged

`run_config` is Rust-only — there is no `termproof.run_config`, and
`conformance/README.md`'s three harnesses are steps, assertions and the evidence
manifest. There is no cross-implementation surface here to extend. This closes
an asymmetry (Rust had no `cli` module at all) rather than opening one, and
`termproof.cli` is an `argparse` *program* where this is a library layer. No
binary is added.

## Feature gating and CI

`clap = ["dep:clap"]`, off by default — the only feature that is. The reasoning
is in `Cargo.toml` and the README: the other four *subtract* from a shape that
was already published, so default-on is what keeps turning one off from being a
break; this one *adds* a shape that never was, so default-off is what keeps it
from being a change.

CI's feature powerset is enumerated from the `FEATURES` array, so adding `clap`
grew it from sixteen combinations to thirty-two by construction. Both halves are
covered: sixteen combinations without `clap`, sixteen with. I ran all 32 locally
(clippy `-D warnings` + `cargo test`) and every one passes.

Both halves are covered: sixteen combinations without `clap`, sixteen with. I
ran all 32 locally (clippy `-D warnings` + `cargo test`) and every one passes.

**On the cost of that doubling.** Measured on run 32429616067, the last `main`
run before this branch: the powerset step is 7.8 min on ubuntu and 9.3 on macos
for sixteen combinations — ~30-35s each — in a job totalling 10.1 and 12.1.
Thirty-two puts the step at ~16-19 min and the job at ~18-21, inside the
existing 45-minute bound, so `timeout-minutes` is unchanged. The workflow
comment now carries those numbers and notes that a *sixth* feature would be
~37 min of powerset in a ~40 min job — past that headroom and near the
60-minute per-job cap `python/tests/test_ci_timeouts.py` enforces — which is
where sharding across the job matrix becomes necessary.

## Verification

- Full Python suite: `uv run python -m unittest discover -s tests` — 830 tests, all pass.
- `cargo fmt --check --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace` — all clean.
- All 32 feature combinations: clippy + test, all pass.
- `cargo deny check` — advisories, bans, licenses, sources all ok. The lockfile
  gains one line (`clap` under the `termproof` entry); `termproof-cli` already
  depended on it, so no new version enters the graph.
- `cargo semver-checks check-release -p termproof` — 196 checks, 196 pass, "no
  semver update required". Not a public-API break: the new items are behind a
  feature that is off by default, so the compared surface is unchanged. No
  version number is touched; the CHANGELOG entry is under `[Unreleased]`.
- Every one of the 23 new tests was broken deliberately and confirmed to go red.
  Reported below, because one of them did not the first time.

## Two corrections to this PR as first pushed

The first push raised the `rust` job's `timeout-minutes` from 45 to 75 to absorb
the doubled powerset, and that turned all three Python unit-test jobs and
`Build, verify TUI evidence and publish it` red — one cause, four jobs.
`python/tests/test_ci_timeouts.py` caps every job in every workflow at 60
minutes, deliberately: a timeout there is a backstop, not a budget, and the
point is to fail in minutes rather than shave an hour off GitHub's six-hour
ceiling (#183). The cap was right and the raise was wrong — I extrapolated from
a warm-cache laptop figure of ~50s per combination instead of reading the CI
history recorded in the docstring of the very test I was breaking. Reverted to
45 in `dfc5e3e`, with the measured numbers written into the comment.

## Review findings addressed

All six minors from the review, plus the nit. Findings 4 and 2 were flagged as
the issue's whole point; both are now disclosed *and* pinned by a test, since
the failure mode for a disclosure is that it silently stops being true.

| # | Finding | What changed |
|---|---|---|
| 4 | Boolean requirements escape `pick()` and it was undisclosed | Stated in the module doc and the changelog entry: `uploaded_media` is a `bool`, so it is ORed and can be raised but never lowered. Behaviour left alone, as the reviewer suggested — a config file quietly switching off an evidence gate is the outcome worth preventing. New test `a_required_upload_can_be_raised_but_never_lowered` pins both halves, including that no lowering flag exists. |
| 2 | `--priority` + `--recipe-name` compose in Python, conflict here, undisclosed | Verified against `registry.py:78-89` — they are successive filters there. Row added to the divergence table in the changelog and in this body; a paragraph in the module doc explains it is the one divergence not visible in a flag *name*. New test `priority_and_recipe_name_do_not_compose_here_though_they_do_in_python`. |
| 5 | Three doc spots now false | Fixed all three: `lib.rs`'s feature section ("first four", plus a `clap` bullet), `engineering-baseline.md` (sixteen → thirty-two, plus where the doubling ceiling is), `CONTRIBUTING.md` (count and list, plus a note that `cargo test --workspace` does not compile this module). |
| 6 | Three new rustdoc warnings in the default build | Fixed by dropping the link syntax, per the reviewer's second option. `cargo doc` is back to 6 warnings on default features and 6 on `--all-features`, matching `main`. |
| 1 | `clap` drags in `derive` | Taken, with a different remedy — see below. |
| 3 | Reserved long names undocumented, collision panics | Taken. The `augment_args` doc now lists all 23 long names in order, the argument ids, and both `ArgGroup` names, and says the collision is a debug-only panic. |
| 7 | `from_matches` panics on foreign matches (nit) | Taken, same doc block: the matches must come from a command this module augmented, and the subcommand path is named as the realistic way in. |

### Finding 1: took the finding, changed the remedy

The reviewer is right that `derive` is dead weight — nothing in the workspace has
a `#[derive(Parser)]`, including `termproof-cli`, which says so in its own module
doc. Dropping it from the workspace pin removes `clap_derive` and `heck` from the
lockfile entirely, and `termproof-cli` stops paying for it too.

Two corrections to the finding's arithmetic and its suggested fix:

- It removes **two** crates, not four. `syn`, `quote` and `proc-macro2` stay
  regardless, because `serde` and `thiserror` need them — measured with
  `cargo tree -p termproof --no-default-features --features clap`: 80 crates
  before, 78 after. One of the two is a proc macro, which is the part worth
  removing.
- I did **not** take `default-features = false, features = ["std"]`. That removes
  nine crates rather than two, and I checked what the other seven buy before
  giving them up. Under `std`-only, `render_help()` returns the empty string —
  every `.help()` string in this module is silently discarded — and errors
  degrade from `the argument '--all' cannot be used with '--priority <PRIORITY>'`
  to `an argument cannot be used with one or more of the other specified
  arguments`. This layer's entire product is a `Command` a consumer calls
  `get_matches()` on; shipping one with a blank `--help` to save seven crates is
  the wrong trade, and a consumer cannot re-enable it from their side. The
  reasoning and both measurements are in the `Cargo.toml` comment.

The README's cost column now reads "`clap`, builder-only (no `clap_derive`)".

## The test that stayed green

`a_consumer_can_add_its_own_flags` survived a mutation that made `augment_args`
throw away the `Command` it was handed and build a fresh one — the test asked
only that the consumer's flag and ours both parse, which they still did, since
`clap` largely ignores `argv[0]`. That is a real hole in the composability
claim: a consumer's name, about, version and subcommands would have been
silently discarded. The test now asserts `command.get_name() == "validator"`,
and goes red under both that mutation and the more obvious "augment_args adds
nothing". Every other test went red on the first attempt.

## Noted, not fixed

`merge` and its `pick_opt` / `pick_list` / `pick_map` helpers are pure and have
no `clap` in them, so they could live in `run_config` proper and serve a
consumer with a hand-rolled parser. They are inside the feature gate here to
keep the default build's public surface untouched; lifting them out is additive
and belongs in its own change.

Six pre-existing `rustdoc` warnings in the crate (`last_error`, `cell_width`,
two on `BUILTIN_TYPES`, two redundant explicit links) are unrelated to this diff
and left alone.
