### PR TITLE
release: a hand-pushed rs-v tag publishes its own crates

### DIFF
--- a/.github/scripts/rust/release-decide.py
+++ b/.github/scripts/rust/release-decide.py
@@ -9,6 +9,10 @@ scheduled workflow runs can be run by hand against any range:
     .github/scripts/rust/release-decide.py --from A --to B # any range
     .github/scripts/rust/release-decide.py --to B          # first-release path
 
+`--at` turns the same command into a description of a release that already
+exists rather than a decision about one — see the flag's help. Everything below
+is about the deciding mode.
+
 The two questions it answers are independent, and both must come back yes.
 
 1. Is there a change worth releasing?
@@ -285,6 +289,14 @@ def main():
         action="store_true",
         help="release even when nothing releasable changed; the version rule still applies",
     )
+    parser.add_argument(
+        "--at",
+        metavar="VERSION",
+        help="the version being released is exactly this — describe the range "
+        "instead of deciding on it. For a tag that already exists, where the "
+        "version is a fact rather than something a bump derives; the notes and "
+        "the reported tag name that version.",
+    )
     args = parser.parse_args()
 
     head = git("rev-parse", args.head).strip()
@@ -309,7 +321,18 @@ def main():
 
     first_release = base is None
 
-    if not commits and not args.force:
+    if args.at:
+        # Describing, not deciding. The caller already has a tag, so asking
+        # whether to release is moot and deriving a bump would name the version
+        # *after* the one that went out. A quiet range is fine here — a release
+        # cut by hand is allowed to be a release nothing would have proposed.
+        release, reason, level, nxt = (
+            True,
+            f"describing the release already tagged at {args.at}; no bump was derived",
+            "none",
+            args.at,
+        )
+    elif not commits and not args.force:
         release, reason, level, nxt = (
             False,
             "no commits since the last release other than the automation's own version bump",

--- a/.github/scripts/rust/verify-published.sh
+++ b/.github/scripts/rust/verify-published.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Confirm that every crate the publish plan names is on crates.io at VERSION.
+#
+# Reads ORDER (space-separated crate names) and VERSION from the environment,
+# the same contract publish.sh has, so the set being checked is the set that
+# was meant to be uploaded. Nothing here names a crate; the caller derives both
+# values from .github/scripts/rust/publish-plan.py.
+#
+# ## Why this exists as its own thing
+#
+# The publish workflow already waits for each crate it uploads to appear on the
+# index, so a *publish that ran* reports its own failures. The gap this closes
+# is the publish that never ran at all: it triggers on a published GitHub
+# release, so a tag that produced no release produces no upload and no red job
+# — only the absence of one, which reads as nothing having gone wrong.
+#
+# Absence is not something the publish workflow can report on. This runs on the
+# tag, at the end of the release path, and asks the registry the only question
+# that matters: is the thing the plan said would ship actually there.
+#
+# ## Polling, and what a timeout means
+#
+# The crates upload is downstream of the release this path publishes, and it
+# runs its own gate first, so it finishes minutes after the binaries do. Hence
+# a poll rather than a single look. A timeout is reported as a failure and
+# names the crates that are missing: at that point either the publish never
+# fired, it failed, or it is still waiting — and all three are states a release
+# should not be left in silently. If the `crates-io` environment ever grows a
+# required reviewer, an approval slower than this window will land here; raise
+# ATTEMPTS rather than deleting the check.
+#
+# ATTEMPTS and INTERVAL are overridable so the same script can be exercised
+# without waiting out the release-sized window.
+set -euo pipefail
+
+: "${ORDER?ORDER must be set to the space-separated publish order (may be empty)}"
+: "${VERSION:?VERSION must be set to the workspace version}"
+
+ATTEMPTS="${ATTEMPTS:-80}"
+INTERVAL="${INTERVAL:-30}"
+INDEX="${INDEX:-https://index.crates.io}"
+
+# Sparse-index layout: crates.io shards by name length, then by prefix.
+index_url() {
+    local name=$1
+    case ${#name} in
+        1) printf '%s/1/%s\n' "$INDEX" "$name" ;;
+        2) printf '%s/2/%s\n' "$INDEX" "$name" ;;
+        3) printf '%s/3/%s/%s\n' "$INDEX" "${name:0:1}" "$name" ;;
+        *) printf '%s/%s/%s/%s\n' "$INDEX" "${name:0:2}" "${name:2:2}" "$name" ;;
+    esac
+}
+
+# The index is what a consumer's `cargo build` resolves against, so it — not
+# the web API — is the thing worth asking. A 404 means the crate has never been
+# published at any version.
+on_index() {
+    local name=$1 body
+    body=$(curl -sSf --max-time 30 "$(index_url "$name")" 2>/dev/null) || return 1
+    jq -e -s --arg v "$VERSION" 'map(.vers) | index($v) != null' >/dev/null <<<"$body"
+}
+
+if [ -z "${ORDER// /}" ]; then
+    # Every member carries `publish = false`. That is a policy recorded in the
+    # manifests, not a fault, and the publish workflow would upload nothing
+    # either — so there is nothing to be missing.
+    echo "::notice::the publish plan names no crates, so there is nothing to verify on crates.io"
+    exit 0
+fi
+
+missing=""
+for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+    missing=""
+    for crate in $ORDER; do
+        on_index "$crate" || missing="$missing $crate"
+    done
+    if [ -z "${missing// /}" ]; then
+        echo "every planned crate is on crates.io at $VERSION: $ORDER"
+        exit 0
+    fi
+    echo "waiting for crates.io ($attempt of $ATTEMPTS) — still missing at $VERSION:$missing"
+    if [ "$attempt" -lt "$ATTEMPTS" ]; then
+        sleep "$INTERVAL"
+    fi
+done
+
+echo "::error::the release is out but these crates are not on crates.io at $VERSION:$missing — the crates publish did not happen. It triggers on a published GitHub release and nothing else, so check that the release exists and was published by an identity whose events start workflows, then look at the Publish crates (Rust) runs."
+exit 1

--- a/.github/workflows/rust-publish-crates.yml
+++ b/.github/workflows/rust-publish-crates.yml
@@ -13,6 +13,14 @@
 # failed partway, re-run this workflow from the release; the publish step is
 # idempotent and will skip what already landed.
 #
+# That single gate is deliberate and is what makes the `crates-io` environment
+# approval hook below possible, so nothing here reaches for the tag instead.
+# The cost is that a tag with no release publishes nothing, silently. Both
+# paths that produce a tag therefore also produce a release —
+# rust-auto-release.yml creates both, and rust-release.yml creates the release
+# when a hand-pushed tag arrives without one — and rust-release.yml ends by
+# checking crates.io for the crates this workflow was supposed to upload.
+#
 # ## Why the upload is its own job
 #
 # The upload runs in the `crates-io` GitHub environment. Entering an

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -61,6 +61,15 @@
 # the fact. A missing token therefore fails this job rather than creating a
 # release that can never publish.
 #
+# One consequence is worth stating plainly, because publish-crates.yml's header
+# says that workflow cannot be hand-triggered into publishing and a reader will
+# generalise it. Dispatching *this* workflow against an `rs-v*` tag takes the
+# same path a tag push does, so it can create a release, and a release is what
+# publishes. That is the intended way to recover a tag whose release is
+# missing, and it is bounded by the same guards: a tag ref, a manifest at
+# exactly that version, no release already there, and the token. A dispatch on
+# a branch reaches none of it — the attach job is gated on the ref being a tag.
+#
 # ## The check at the end
 #
 # Everything above still only proves that the release *path* ran. The failure
@@ -341,21 +350,47 @@ jobs:
   # It runs on both paths and on a re-run, because it is a question about the
   # registry rather than about this run: once the crates are there the answer
   # comes back in seconds.
+  #
+  # `!cancelled()` rather than the default, and that is the whole point of the
+  # job. `needs: attach` alone carries an implicit `success()`, which would
+  # skip this in exactly the states it exists to describe: a release created
+  # and then a failed upload leaves a red job named *Attach to release* beside
+  # a registry nobody looked at, which is the shape of the incident this
+  # workflow is being fixed for. A cancelled run is the one case with nothing
+  # to say — the release path did not finish and nobody claimed it did.
   verify-crates:
     name: Verify the crates published
     needs: attach
-    if: startsWith(github.ref, 'refs/tags/rs-v')
+    if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/rs-v') }}
     runs-on: ubuntu-latest
     timeout-minutes: 50
     permissions:
       contents: read
-      # `gh run list`, for the failure report below. Read-only.
+      # `gh release view` below, and `gh run list` for the failure report.
       actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
         with:
           toolchain: "1.96.0"
+
+      # Ask the cheap question first. Polling the registry for forty minutes
+      # is only worth it when something is coming; with no release nothing is,
+      # because the publish triggers on nothing else. This is also what keeps
+      # the job fast when it runs after a failed build: seconds, and a message
+      # that names the consequence — a tag went out and shipped nothing —
+      # rather than leaving that to be inferred from a red job further up.
+      - name: A release exists for this tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error::tag '$TAG' has no GitHub release, so no crate was published and none will be — the crates publish triggers on a published release and nothing else. Whatever failed above stopped the release from being created; fix it and re-run this workflow from the tag."
+            exit 1
+          fi
+          echo "release $TAG exists"
 
       # The set comes from the plan, never from a list written here — the same
       # property publish-crates.yml has, and for the same reason: a name

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -275,16 +275,22 @@ jobs:
             exit 1
           fi
 
-          # `$TAG^` so `describe` looks strictly before this release. `--at` is
-          # what keeps the notes at the version that is being released: the
+          # `HEAD`, not `$TAG`, everywhere a revision is resolved. They are the
+          # same commit — this run was started by pushing that tag — but only
+          # one of them is a name that has to have been fetched, and a clone
+          # without tags turns the whole range into a `rev-parse` failure
+          # rather than into the fallback below. `HEAD^` for the same reason,
+          # and so `describe` looks strictly before this release.
+          #
+          # `--at` is what keeps the notes at the version being released: the
           # deciding mode would derive the bump *after* it.
-          BASE="$(git describe --tags --abbrev=0 --match 'rs-v*.*.*' --match 'rs-baseline-v*.*.*' "$TAG^" 2>/dev/null || true)"
+          BASE="$(git describe --tags --abbrev=0 --match 'rs-v*.*.*' --match 'rs-baseline-v*.*.*' HEAD^ 2>/dev/null || true)"
           if [ -n "$BASE" ]; then
             echo "rendering notes for $BASE..$TAG"
-            .github/scripts/rust/release-decide.py --at "$VERSION" --from "$BASE" --to "$TAG^{commit}" > decision.json
+            .github/scripts/rust/release-decide.py --at "$VERSION" --from "$BASE" --to HEAD > decision.json
           else
             echo "no earlier release tag is reachable — rendering notes for the whole history"
-            .github/scripts/rust/release-decide.py --at "$VERSION" --no-auto-base --to "$TAG^{commit}" > decision.json
+            .github/scripts/rust/release-decide.py --at "$VERSION" --no-auto-base --to HEAD > decision.json
           fi
           jq -r .notes decision.json > release-notes.md
           cat release-notes.md

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -40,6 +40,34 @@
 # the release to be created as a draft and published only after this build
 # succeeded. That is a change to publish-crates.yml's trigger contract, not to
 # this file, and it is not made here.
+#
+# ## A tag pushed by hand is a whole release on its own
+#
+# The Auto-release path is not the only way an `rs-v*` tag appears, and for a
+# long time it was the only one that worked. The attach job used to wait for a
+# release and fail when none arrived, which is exactly what a hand-pushed tag
+# produced — and the failure read as an attachment problem. It was not. The
+# crates publish triggers on a *published release*, so with no release there
+# was no upload to crates.io at all, and one red job among several green ones
+# was the entire signal that a release had silently not happened.
+#
+# So the attach job creates the release itself when the wait finds none. The
+# wait is what makes that safe: on the Auto-release path the release is already
+# there long before this job runs, the loop finds it, and nothing is created.
+#
+# That step must use RELEASE_TOKEN, for the reason rust-auto-release.yml's
+# header gives at length: a release created with the default `GITHUB_TOKEN`
+# does not start publish-crates.yml, and nothing can be re-run to fix it after
+# the fact. A missing token therefore fails this job rather than creating a
+# release that can never publish.
+#
+# ## The check at the end
+#
+# Everything above still only proves that the release *path* ran. The failure
+# worth designing against is quieter than a red job: a release that looks
+# finished while no crate shipped. The last job asks crates.io directly whether
+# every crate the publish plan names is there at this version, and fails naming
+# the ones that are not. See .github/scripts/rust/verify-published.sh.
 name: Release (Rust)
 
 on:
@@ -174,12 +202,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Full history and tags. The notes rendered below cover the range from
+      # the previous release tag to this one, and neither the range nor the
+      # tags survive a shallow clone.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # `publish-plan.py` and `release-decide.py` both read `cargo metadata`.
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
+        with:
+          toolchain: "1.96.0"
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
 
       - name: Wait for the release to exist
+        id: wait
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -187,20 +227,86 @@ jobs:
         run: |
           # The tag push that started this build and the release creation are
           # two steps of one workflow, seconds apart, and this job is minutes
-          # behind — so the release is normally already there. It is not there
-          # when a tag was pushed by hand, and then this is a real failure
-          # rather than something to wait out: the archives stay downloadable
-          # as workflow artifacts, and re-running this job after creating the
-          # release will attach them.
+          # behind — so on the Auto-release path the release is already there
+          # and the first check finds it. The loop is what makes the next step
+          # a no-op on that path: by the time it has failed ten times over
+          # 150s, nothing else is going to create this release, and creating
+          # one cannot race the automation into a second.
           for attempt in $(seq 1 10); do
             if gh release view "$TAG" >/dev/null 2>&1; then
               echo "release $TAG exists (check $attempt)"
+              echo "exists=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             sleep 15
           done
-          echo "::error::no GitHub release exists for tag '$TAG' after 150s, so there is nothing to attach the binaries to. They are on this run as workflow artifacts. Create the release, then re-run this job."
-          exit 1
+          echo "no GitHub release exists for tag '$TAG' after 150s — this tag was pushed by hand"
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+
+      # Only reached for a hand-pushed tag. This is the step that makes that
+      # path a complete release rather than a build with nowhere to put its
+      # output: creating and publishing the release is also what triggers
+      # publish-crates.yml, which is the only thing that uploads to crates.io.
+      - name: Create the release the tag push did not
+        if: steps.wait.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Not an optimisation. A release created with the default
+          # `GITHUB_TOKEN` does not start publish-crates.yml — GitHub
+          # suppresses those events — and that workflow uploads on
+          # `release: published` and nothing else, so no re-run could recover
+          # it. Failing here leaves a tag with no release, which is fixable.
+          if [ -z "$RELEASE_TOKEN" ]; then
+            echo "::error::the RELEASE_TOKEN secret is not set, so a release created here could never trigger the crates.io publish and no re-run would fix that. The archives are on this run as workflow artifacts. Add the secret (Contents: read and write), or create the release by hand and re-run this job."
+            exit 1
+          fi
+
+          # The same check publish-crates.yml makes on `release: published`,
+          # made before the release exists rather than after — a release this
+          # job creates and that workflow then refuses would publish nothing,
+          # which is the failure this whole path is here to remove.
+          VERSION="$(.github/scripts/rust/publish-plan.py | jq -r .version)"
+          if [ "$TAG" != "rs-v$VERSION" ]; then
+            echo "::error::tag '$TAG' does not match the workspace version '$VERSION' at this commit — expected 'rs-v$VERSION'. publish-crates.yml would refuse a release on this tag, so none is created. Delete the tag and re-cut it, or bump the version."
+            exit 1
+          fi
+
+          # `$TAG^` so `describe` looks strictly before this release. `--at` is
+          # what keeps the notes at the version that is being released: the
+          # deciding mode would derive the bump *after* it.
+          BASE="$(git describe --tags --abbrev=0 --match 'rs-v*.*.*' --match 'rs-baseline-v*.*.*' "$TAG^" 2>/dev/null || true)"
+          if [ -n "$BASE" ]; then
+            echo "rendering notes for $BASE..$TAG"
+            .github/scripts/rust/release-decide.py --at "$VERSION" --from "$BASE" --to "$TAG^{commit}" > decision.json
+          else
+            echo "no earlier release tag is reachable — rendering notes for the whole history"
+            .github/scripts/rust/release-decide.py --at "$VERSION" --no-auto-base --to "$TAG^{commit}" > decision.json
+          fi
+          jq -r .notes decision.json > release-notes.md
+          cat release-notes.md
+
+          # `--verify-tag` refuses to invent a tag; this one is the ref that
+          # started the run, so it exists. A non-zero exit is treated as a
+          # question rather than a verdict for the same reason publish.sh does
+          # it: the losing side of a race is indistinguishable from a failure
+          # until you look at the result.
+          if ! gh release create "$TAG" --title "$TAG" --notes-file release-notes.md --verify-tag; then
+            if ! gh release view "$TAG" >/dev/null 2>&1; then
+              exit 1
+            fi
+            echo "::notice::release $TAG already existed by the time this ran — nothing was created"
+          fi
+
+          {
+            echo "### Created [$TAG](${{ github.server_url }}/${{ github.repository }}/releases/tag/$TAG)"
+            echo
+            echo "The tag was pushed without a release, so this run created one."
+            echo "Publishing it is what triggers the crates.io publish."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Attach the archives and checksums
         env:
@@ -218,4 +324,66 @@ jobs:
             for f in dist/*.tar.gz.sha256; do
               echo "- \`$(cat "$f")\`"
             done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # The last word on whether the release actually released anything. Every job
+  # above can be green while crates.io has received nothing — that is not a
+  # hypothetical, it is what happened the first time a tag was pushed by hand —
+  # so the path ends by asking the registry rather than by inferring from the
+  # colour of the jobs above it.
+  #
+  # It runs on both paths and on a re-run, because it is a question about the
+  # registry rather than about this run: once the crates are there the answer
+  # comes back in seconds.
+  verify-crates:
+    name: Verify the crates published
+    needs: attach
+    if: startsWith(github.ref, 'refs/tags/rs-v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      contents: read
+      # `gh run list`, for the failure report below. Read-only.
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (2026-08-05)
+        with:
+          toolchain: "1.96.0"
+
+      # The set comes from the plan, never from a list written here — the same
+      # property publish-crates.yml has, and for the same reason: a name
+      # written down is a name that goes stale the first time the publish set
+      # changes, and the failure mode is a check that passes over a crate
+      # nobody uploaded.
+      - name: Every crate the plan names is on crates.io
+        run: |
+          PLAN="$(.github/scripts/rust/publish-plan.py)"
+          ORDER="$(jq -r '.order | join(" ")' <<<"$PLAN")"
+          VERSION="$(jq -r .version <<<"$PLAN")"
+          export ORDER VERSION
+          .github/scripts/rust/verify-published.sh
+
+      # Which of the three ways this fails it was. The distinction is the whole
+      # point: "the publish workflow never ran" and "it ran and failed" look
+      # identical from the registry, and only the first one is invisible in the
+      # run list.
+      - name: What the crates publish did
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            echo "### No crates.io publish for \`$TAG\`"
+            echo
+            echo "Recent \`Publish crates (Rust)\` runs on a published release:"
+            echo
+            gh run list --workflow rust-publish-crates.yml --event release --limit 5 \
+              --json displayTitle,status,conclusion,createdAt,url \
+              --jq '.[] | "- \(.createdAt) \(.status)/\(.conclusion // "—") [\(.displayTitle)](\(.url))"' \
+              || echo "- (could not list runs)"
+            echo
+            echo "No run at all means the release was never published, or was published by an identity whose events do not start workflows."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
   that anything was published, which is the lesson 0.4.1 taught; the crate set
   is derived from the manifests, so nothing here names a crate.
 
+  It runs on `!cancelled()` rather than on the jobs above it succeeding. A
+  `needs:` alone carries an implicit `success()`, which would have skipped the
+  check in exactly the states it exists to describe — a release created and
+  then a failed upload is the same shape as the incident itself. A tag with no
+  release fails it in seconds, naming that as the reason nothing shipped,
+  rather than waiting out a publish that was never triggered.
+
 ## [0.4.1] — 2026-08-20
 
 **This is a patch release that carries breaking changes, on purpose.** The rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,35 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ## [Unreleased]
 
-Nothing yet.
+### CI
+
+- **An `rs-v*` tag pushed by hand is now a whole release.** It was not. The
+  0.4.1 tag was pushed by hand; `rust-release.yml` built the binaries and then
+  waited for a GitHub release that nothing on that path was going to create,
+  and failed after 150 seconds. The failure read as a problem attaching
+  binaries. It was not one — `rust-publish-crates.yml` triggers on a
+  *published release* and nothing else, so crates.io received nothing at all,
+  and one red job among several green ones was the entire signal that a
+  release had silently not happened. 0.4.1 was recovered by creating the
+  release by hand.
+
+  The attach job now creates the release itself when the wait finds none, with
+  notes rendered from the commit range by the same renderer the weekly
+  automation uses (`release-decide.py`, via a new `--at` flag that pins the
+  version to the tag instead of deriving the next one). The wait is what keeps
+  this a no-op on the weekly path, so that path still produces exactly one
+  release. Creating it requires `RELEASE_TOKEN`; its absence fails the job,
+  because a release created with the default token cannot start the crates
+  publish and nothing could be re-run to fix that afterwards.
+
+  Nothing about what triggers the crates publish changed. A published release
+  is still the one gate, and still the only thing that uploads to a registry.
+- **The release path ends by asking crates.io whether the crates shipped.** A
+  new job runs `.github/scripts/rust/verify-published.sh`, which checks that
+  every crate `publish-plan.py` names is on the index at this version and
+  fails naming the ones that are not. Every job being green was never evidence
+  that anything was published, which is the lesson 0.4.1 taught; the crate set
+  is derived from the manifests, so nothing here names a crate.
 
 ## [0.4.1] — 2026-08-20
 

--- a/python/tests/test_rust_release_tag_path.py
+++ b/python/tests/test_rust_release_tag_path.py
@@ -132,6 +132,20 @@ class TagPushCreatesItsOwnReleaseTest(unittest.TestCase):
         self.assertIn("--notes-file release-notes.md", create["run"])
         self.assertIn("--verify-tag", create["run"])
 
+    def test_revisions_resolve_through_head_rather_than_the_tag(self) -> None:
+        """A tag name is a revision only in a clone that fetched tags.
+
+        The step reached for `$TAG^{commit}` first. That is the same commit
+        HEAD already is — the tag push is what started the run — but in a clone
+        without tags it makes `rev-parse` fail outright, which turns what
+        should be the whole-history fallback into an error. The workflow's own
+        checkout does fetch tags; anything else running this shell need not.
+        """
+        create = _step(self.workflow, "attach", "Create the release the tag push did not")
+        self.assertNotIn("$TAG^", create["run"])
+        self.assertIn("--to HEAD", create["run"])
+        self.assertIn("HEAD^", create["run"])
+
     def test_the_attach_job_checks_out_deeply_enough_to_render_notes(self) -> None:
         checkout = next(
             step

--- a/python/tests/test_rust_release_tag_path.py
+++ b/python/tests/test_rust_release_tag_path.py
@@ -1,0 +1,438 @@
+"""Pushing an `rs-v*` tag by hand must produce a whole release.
+
+The 0.4.1 release is the case this file exists for. The tag was pushed by hand;
+`rust-release.yml` built the binaries and then waited for a GitHub release that
+nothing on the tag-push path was going to create, and failed. That failure read
+as an attachment problem. It was not one: `rust-publish-crates.yml` triggers on
+a *published release* and nothing else, so crates.io received nothing at all,
+and the only signal was one red job among several green ones.
+
+Two properties come out of that, and both are asserted here rather than left to
+prose in a workflow header:
+
+1. The tag-push path creates its own release when none exists, the way
+   `python-release.yml` already did — and is a no-op when the weekly automation
+   has already created one, so there is never a second release.
+2. The path ends by asking crates.io whether the crates actually shipped. Every
+   job being green is not evidence of that, which is the whole lesson of 0.4.1.
+
+The script behaviour is exercised against a local file:// index rather than
+crates.io, so these tests are offline and do not depend on what is published.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+RELEASE = WORKFLOWS / "rust-release.yml"
+PUBLISH = WORKFLOWS / "rust-publish-crates.yml"
+SCRIPTS = REPO_ROOT / ".github" / "scripts" / "rust"
+VERIFY = SCRIPTS / "verify-published.sh"
+DECIDE = SCRIPTS / "release-decide.py"
+
+requires_cargo = unittest.skipUnless(shutil.which("cargo"), "cargo is not installed")
+requires_curl = unittest.skipUnless(shutil.which("curl"), "curl is not installed")
+requires_jq = unittest.skipUnless(shutil.which("jq"), "jq is not installed")
+
+
+def _workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _steps(workflow: dict, job: str) -> list[dict]:
+    return workflow["jobs"][job]["steps"]
+
+
+def _step(workflow: dict, job: str, name: str) -> dict:
+    for step in _steps(workflow, job):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"{job} has no step named {name!r}")
+
+
+def _crate_names() -> list[str]:
+    return sorted(p.name for p in (REPO_ROOT / "rust" / "crates").iterdir() if p.is_dir())
+
+
+class TagPushCreatesItsOwnReleaseTest(unittest.TestCase):
+    """The gap 0.4.1 fell into: a tag with no release, and no way to get one."""
+
+    def setUp(self) -> None:
+        self.workflow = _workflow(RELEASE)
+
+    def test_the_wait_records_the_answer_instead_of_failing_on_it(self) -> None:
+        """A missing release is now a branch, not the end of the job.
+
+        The old wait ended in `exit 1`, which is what turned a whole missed
+        release into something that looked like a failed upload.
+        """
+        wait = _step(self.workflow, "attach", "Wait for the release to exist")
+        self.assertEqual("wait", wait["id"])
+        self.assertIn("exists=true", wait["run"])
+        self.assertIn("exists=false", wait["run"])
+        self.assertNotIn("exit 1", wait["run"])
+
+    def test_the_release_is_created_only_when_the_wait_found_none(self) -> None:
+        """This is what stops the weekly path producing two releases.
+
+        The wait is ten checks over 150 seconds. The automation creates its
+        release seconds after pushing the tag and this job is minutes behind
+        it, so on that path the first check finds it and this step never runs.
+        """
+        create = _step(self.workflow, "attach", "Create the release the tag push did not")
+        self.assertEqual("steps.wait.outputs.exists != 'true'", create["if"])
+
+        names = [step.get("name") for step in _steps(self.workflow, "attach")]
+        self.assertLess(
+            names.index("Wait for the release to exist"),
+            names.index("Create the release the tag push did not"),
+            "creating before waiting would race the weekly automation into two releases",
+        )
+
+    def test_creating_the_release_uses_a_token_that_can_trigger_the_publish(self) -> None:
+        """`GITHUB_TOKEN` here would be worse than failing.
+
+        A release created with the default token does not start
+        rust-publish-crates.yml, and that workflow uploads on
+        `release: published` and nothing else — so no re-run could recover it.
+        A missing secret has to fail the job instead.
+        """
+        create = _step(self.workflow, "attach", "Create the release the tag push did not")
+        self.assertEqual("${{ secrets.RELEASE_TOKEN }}", create["env"]["GH_TOKEN"])
+        self.assertEqual("${{ secrets.RELEASE_TOKEN }}", create["env"]["RELEASE_TOKEN"])
+        self.assertIn('if [ -z "$RELEASE_TOKEN" ]; then', create["run"])
+        self.assertIn("::error::the RELEASE_TOKEN secret is not set", create["run"])
+
+    def test_the_tag_is_checked_against_the_manifest_before_a_release_exists(self) -> None:
+        """A release publish-crates.yml would refuse is worse than no release."""
+        create = _step(self.workflow, "attach", "Create the release the tag push did not")
+        self.assertIn("publish-plan.py | jq -r .version", create["run"])
+        self.assertIn('if [ "$TAG" != "rs-v$VERSION" ]; then', create["run"])
+        self.assertLess(
+            create["run"].index('"rs-v$VERSION"'),
+            create["run"].index("gh release create"),
+            "the guard has to run before the release exists, not after",
+        )
+
+    def test_the_notes_come_from_the_same_renderer_the_weekly_path_uses(self) -> None:
+        """An empty body would be a regression against the automated path."""
+        create = _step(self.workflow, "attach", "Create the release the tag push did not")
+        self.assertIn('release-decide.py --at "$VERSION"', create["run"])
+        self.assertIn("--notes-file release-notes.md", create["run"])
+        self.assertIn("--verify-tag", create["run"])
+
+    def test_the_attach_job_checks_out_deeply_enough_to_render_notes(self) -> None:
+        checkout = next(
+            step
+            for step in _steps(self.workflow, "attach")
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+        self.assertEqual(0, checkout["with"]["fetch-depth"])
+
+
+class CratesPublishStaysTheOneGateTest(unittest.TestCase):
+    """The fix must not buy self-sufficiency by widening the publish trigger.
+
+    A published release being the only thing that uploads is what makes the
+    `crates-io` environment approval hook possible, and it is what the publish
+    workflow's header claims about the whole repository.
+    """
+
+    def setUp(self) -> None:
+        self.publish = _workflow(PUBLISH)
+
+    def test_the_publish_still_triggers_only_on_a_published_release(self) -> None:
+        self.assertEqual({"types": ["published"]}, self.publish[True]["release"])
+        self.assertNotIn("push", self.publish[True])
+        self.assertEqual(
+            "github.event_name == 'release' && "
+            "startsWith(github.event.release.tag_name, 'rs-v')",
+            self.publish["jobs"]["publish"]["if"],
+        )
+        self.assertEqual("crates-io", self.publish["jobs"]["publish"]["environment"])
+
+    def test_nothing_in_the_release_workflow_uploads_to_a_registry(self) -> None:
+        text = RELEASE.read_text(encoding="utf-8")
+        self.assertNotIn("cargo publish", text)
+        self.assertNotIn("CARGO_REGISTRY_TOKEN", text)
+
+
+class TheReleasePathEndsByAskingTheRegistryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = _workflow(RELEASE)
+        self.job = self.workflow["jobs"]["verify-crates"]
+
+    def test_it_runs_last_on_the_tag_path(self) -> None:
+        self.assertEqual("attach", self.job["needs"])
+        self.assertEqual("startsWith(github.ref, 'refs/tags/rs-v')", self.job["if"])
+
+    def test_the_crate_set_is_derived_and_never_written_down(self) -> None:
+        step = _step(self.workflow, "verify-crates", "Every crate the plan names is on crates.io")
+        self.assertIn("publish-plan.py", step["run"])
+        self.assertIn("verify-published.sh", step["run"])
+        self.assertIn("export ORDER VERSION", step["run"])
+        self.assertIn("ORDER=\"$(jq -r '.order | join(\" \")' <<<\"$PLAN\")\"", step["run"])
+
+    def test_the_verifier_names_no_crate(self) -> None:
+        text = VERIFY.read_text(encoding="utf-8")
+        named = [name for name in _crate_names() if name in text]
+        self.assertEqual(
+            [],
+            named,
+            "the publish set is a manifest decision; a name written into the "
+            "verifier is a name that goes stale the first time it changes",
+        )
+
+    def test_the_verifier_is_executable(self) -> None:
+        self.assertTrue(bool(VERIFY.stat().st_mode & 0o111), f"{VERIFY} must be executable")
+
+
+@requires_curl
+class VerifyPublishedScriptTest(unittest.TestCase):
+    """Run the real script against a local sparse index laid out on disk.
+
+    `curl` reads `file://` the same way it reads `https://`, so the sharding,
+    the version match and the polling are all exercised without a network and
+    without depending on what happens to be published.
+    """
+
+    VERSION = "9.9.9"
+
+    def _index(self, entries: dict[str, list[str]]) -> str:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, root, True)
+        for name, versions in entries.items():
+            # The layout crates.io uses, and the one the script computes.
+            shard = root / name[:2] / name[2:4]
+            shard.mkdir(parents=True, exist_ok=True)
+            shard.joinpath(name).write_text(
+                "".join(json.dumps({"name": name, "vers": v}) + "\n" for v in versions),
+                encoding="utf-8",
+            )
+        return root.as_uri()
+
+    def _run(self, order: str, index: str, version: str | None = None):
+        return subprocess.run(
+            [str(VERIFY)],
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": os.environ["PATH"],
+                "ORDER": order,
+                "VERSION": version or self.VERSION,
+                "INDEX": index,
+                "ATTEMPTS": "2",
+                "INTERVAL": "0",
+            },
+        )
+
+    def test_it_passes_when_every_crate_is_on_the_index(self) -> None:
+        index = self._index({"alpha-crate": ["9.9.8", self.VERSION], "beta-crate": [self.VERSION]})
+        result = self._run("alpha-crate beta-crate", index)
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("every planned crate is on crates.io", result.stdout)
+
+    def test_it_fails_naming_only_what_did_not_ship(self) -> None:
+        """The point of the check: say which crate is missing, not that one is."""
+        index = self._index({"alpha-crate": [self.VERSION], "beta-crate": ["9.9.8"]})
+        result = self._run("alpha-crate beta-crate", index)
+        self.assertEqual(1, result.returncode)
+        self.assertIn("::error::", result.stdout)
+        error = [line for line in result.stdout.splitlines() if line.startswith("::error::")][0]
+        self.assertIn("beta-crate", error)
+        self.assertNotIn("alpha-crate", error)
+
+    def test_a_crate_absent_from_the_index_entirely_is_missing(self) -> None:
+        """A 404 and a wrong version are the same answer to the same question."""
+        result = self._run("alpha-crate", self._index({}))
+        self.assertEqual(1, result.returncode)
+        self.assertIn("alpha-crate", result.stdout)
+
+    def test_it_polls_rather_than_looking_once(self) -> None:
+        """The publish runs its own gate first, so it lands minutes later."""
+        result = self._run("alpha-crate", self._index({}))
+        waits = [line for line in result.stdout.splitlines() if line.startswith("waiting for")]
+        self.assertEqual(2, len(waits), result.stdout)
+
+    def test_an_empty_publish_set_is_not_a_failure(self) -> None:
+        """Every member held back is a manifest decision, not a missed upload."""
+        result = self._run("", self._index({}))
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("::notice::", result.stdout)
+
+
+@requires_cargo
+class ReleaseNotesForATagThatAlreadyExistsTest(unittest.TestCase):
+    """`--at` is what lets the tag path reuse the weekly path's renderer.
+
+    Without it the script derives the *next* version from the commit range, so
+    notes for a tag that already exists would be headed one release too far
+    ahead — and the compare link would point at a tag nobody cut.
+    """
+
+    def _decide(self, *args: str) -> dict:
+        result = subprocess.run(
+            [str(DECIDE), *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+
+    def test_the_pinned_version_is_the_one_the_notes_carry(self) -> None:
+        decided = self._decide("--at", "9.9.9", "--no-auto-base", "--to", "HEAD")
+        self.assertTrue(decided["release"])
+        self.assertEqual("9.9.9", decided["next_version"])
+        self.assertEqual("rs-v9.9.9", decided["tag"])
+        self.assertEqual("none", decided["bump"])
+        self.assertTrue(decided["notes"].startswith("## termproof 9.9.9\n"))
+
+    def test_the_notes_are_not_empty(self) -> None:
+        """The stated bar for this path: no worse than the weekly one."""
+        notes = self._decide("--at", "9.9.9", "--no-auto-base", "--to", "HEAD")["notes"]
+        self.assertIn("### ", notes)
+        self.assertIn("Binaries for", notes)
+
+    def test_deciding_mode_still_derives_a_bump(self) -> None:
+        """`--at` must not have leaked into the path the weekly release takes."""
+        decided = self._decide("--no-auto-base", "--to", "HEAD")
+        self.assertNotIn("describing", decided["reason"])
+
+
+@requires_cargo
+@requires_jq
+class CreateStepShellTest(unittest.TestCase):
+    """Run the create step's own shell, with `gh` stubbed out.
+
+    Everything else in this file reads the workflow. This runs it: the step's
+    `run:` block is lifted out of the YAML and executed against a fake `gh`
+    that records its arguments, so the branch that was missing when 0.4.1 was
+    cut is exercised without a tag, a release or a registry anywhere near it.
+
+    The tag is derived from the manifest rather than written down, so this
+    tests the guard rather than a version.
+    """
+
+    #: Written by the step into the working directory, the way CI does.
+    ARTIFACTS = ("decision.json", "release-notes.md")
+
+    STUB = """\
+#!/usr/bin/env bash
+echo "gh $*" >> "{log}"
+case "$1 $2" in
+  "release create") exit {create_rc} ;;
+  "release view") exit {view_rc} ;;
+esac
+exit 0
+"""
+
+    def setUp(self) -> None:
+        for name in self.ARTIFACTS:
+            path = REPO_ROOT / name
+            if path.exists():
+                self.skipTest(f"{name} already exists in the working tree")
+            self.addCleanup(path.unlink, True)
+
+        workflow = _workflow(RELEASE)
+        step = _step(workflow, "attach", "Create the release the tag push did not")
+        self.body = (
+            step["run"]
+            .replace("${{ github.server_url }}", "https://github.com")
+            .replace("${{ github.repository }}", "md-mt/termproof")
+        )
+        plan = subprocess.run(
+            [str(SCRIPTS / "publish-plan.py")],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.version = json.loads(plan.stdout)["version"]
+
+    def _run(self, tag: str, token: str = "stub-token", create_rc: int = 0, view_rc: int = 1):
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        log = tmp / "gh.log"
+        stub = tmp / "gh"
+        stub.write_text(
+            self.STUB.format(log=log, create_rc=create_rc, view_rc=view_rc), encoding="utf-8"
+        )
+        stub.chmod(0o755)
+        summary = tmp / "summary.md"
+        summary.write_text("", encoding="utf-8")
+        script = tmp / "step.sh"
+        script.write_text(self.body, encoding="utf-8")
+
+        # `bash -e` is what GitHub runs a `run:` block under.
+        result = subprocess.run(
+            ["bash", "-e", str(script)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "PATH": f"{tmp}{os.pathsep}{os.environ['PATH']}",
+                "TAG": tag,
+                "RELEASE_TOKEN": token,
+                "GH_TOKEN": token,
+                "GH_REPO": "md-mt/termproof",
+                "GITHUB_REPOSITORY": "md-mt/termproof",
+                "GITHUB_STEP_SUMMARY": str(summary),
+            },
+        )
+        return result, (log.read_text(encoding="utf-8") if log.exists() else "")
+
+    def test_it_creates_the_release_from_the_tag_alone(self) -> None:
+        result, log = self._run(f"rs-v{self.version}")
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(
+            f"gh release create rs-v{self.version} --title rs-v{self.version} "
+            "--notes-file release-notes.md --verify-tag",
+            log,
+        )
+
+    def test_the_notes_it_writes_are_the_rendered_ones(self) -> None:
+        result, _ = self._run(f"rs-v{self.version}")
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        notes = (REPO_ROOT / "release-notes.md").read_text(encoding="utf-8")
+        self.assertTrue(notes.startswith(f"## termproof {self.version}\n"), notes[:80])
+        self.assertIn("Binaries for", notes)
+
+    def test_no_token_means_no_release(self) -> None:
+        """Better a tag with no release than a release that can never publish."""
+        result, log = self._run(f"rs-v{self.version}", token="")
+        self.assertEqual(1, result.returncode)
+        self.assertIn("::error::the RELEASE_TOKEN secret is not set", result.stdout)
+        self.assertEqual("", log, "nothing may be created without a usable token")
+
+    def test_a_tag_the_publish_would_refuse_creates_nothing(self) -> None:
+        result, log = self._run("rs-v9.9.9")
+        self.assertEqual(1, result.returncode)
+        self.assertIn("does not match the workspace version", result.stdout)
+        self.assertEqual("", log)
+
+    def test_losing_a_race_to_create_is_not_a_failure(self) -> None:
+        result, log = self._run(f"rs-v{self.version}", create_rc=1, view_rc=0)
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("::notice::", result.stdout)
+        self.assertIn("release view", log)
+
+    def test_a_create_that_really_failed_still_fails(self) -> None:
+        result, _ = self._run(f"rs-v{self.version}", create_rc=1, view_rc=1)
+        self.assertEqual(1, result.returncode)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_rust_release_tag_path.py
+++ b/python/tests/test_rust_release_tag_path.py
@@ -181,6 +181,36 @@ class CratesPublishStaysTheOneGateTest(unittest.TestCase):
         self.assertNotIn("cargo publish", text)
         self.assertNotIn("CARGO_REGISTRY_TOKEN", text)
 
+    def test_the_release_workflow_is_reachable_only_by_tag_or_by_hand(self) -> None:
+        """It mints releases now, so what can start it is part of the contract.
+
+        Neither of the two ways to widen this is dangerous on its own — a pull
+        request's `github.ref` is `refs/pull/N/merge`, which the attach job's
+        guard rejects, and the tag-versus-manifest check inside the create step
+        would exit before `gh` for any ref that is not `rs-v<version>`. That is
+        defence in depth working. It is worth making deliberate rather than
+        incidental, because both layers were added for the tag path and neither
+        was written with a wider trigger in mind.
+        """
+        release = _workflow(RELEASE)
+        self.assertEqual({"push", "workflow_dispatch"}, set(release[True]))
+        self.assertEqual(["rs-v*.*.*"], release[True]["push"]["tags"])
+
+    def test_the_jobs_that_touch_a_release_are_gated_on_a_tag_ref(self) -> None:
+        """A `workflow_dispatch` on a branch must reach neither of them.
+
+        Dispatching against a *tag* deliberately does reach them — that is the
+        recovery path for a tag whose release went missing — so this pins the
+        ref guard rather than the event.
+        """
+        release = _workflow(RELEASE)
+        self.assertEqual(
+            "startsWith(github.ref, 'refs/tags/rs-v')", release["jobs"]["attach"]["if"]
+        )
+        self.assertIn(
+            "startsWith(github.ref, 'refs/tags/rs-v')", release["jobs"]["verify-crates"]["if"]
+        )
+
 
 class TheReleasePathEndsByAskingTheRegistryTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -189,7 +219,33 @@ class TheReleasePathEndsByAskingTheRegistryTest(unittest.TestCase):
 
     def test_it_runs_last_on_the_tag_path(self) -> None:
         self.assertEqual("attach", self.job["needs"])
-        self.assertEqual("startsWith(github.ref, 'refs/tags/rs-v')", self.job["if"])
+
+    def test_it_still_runs_when_something_above_it_failed(self) -> None:
+        """`needs:` alone carries an implicit `success()`, which is backwards.
+
+        A release created and then a failed upload leaves a red job named
+        *Attach to release* beside a registry nobody looked at — the exact
+        shape of the incident this workflow is being fixed for. The states
+        worth describing are the ones where something above did not succeed,
+        so the guard has to say so explicitly. A cancelled run is the one case
+        with nothing to report.
+        """
+        self.assertEqual(
+            "${{ !cancelled() && startsWith(github.ref, 'refs/tags/rs-v') }}", self.job["if"]
+        )
+
+    def test_no_release_fails_fast_instead_of_polling_for_forty_minutes(self) -> None:
+        """With no release nothing is coming, because nothing else publishes."""
+        names = [step.get("name") for step in _steps(self.workflow, "verify-crates")]
+        self.assertLess(
+            names.index("A release exists for this tag"),
+            names.index("Every crate the plan names is on crates.io"),
+            "the cheap question comes first",
+        )
+        step = _step(self.workflow, "verify-crates", "A release exists for this tag")
+        self.assertIn('gh release view "$TAG"', step["run"])
+        self.assertIn("::error::tag '$TAG' has no GitHub release", step["run"])
+        self.assertIn("exit 1", step["run"])
 
     def test_the_crate_set_is_derived_and_never_written_down(self) -> None:
         step = _step(self.workflow, "verify-crates", "Every crate the plan names is on crates.io")

--- a/rust/docs/publishing.md
+++ b/rust/docs/publishing.md
@@ -95,6 +95,24 @@ that would produce a broken release:
 
 It authenticates with the `CARGO_REGISTRY_TOKEN` repository secret.
 
+**A `workflow_dispatch` run of *that* workflow is always a dry run.** There is
+no input to flip. The only path that uploads is a published release, so
+`rust-publish-crates.yml` cannot be hand-triggered into publishing by mistake.
+Use dispatch to rehearse.
+
+Read that as a statement about one workflow, not about the system. Since
+`rust-release.yml` learned to create a release, **dispatching *Release (Rust)*
+against an `rs-v*` tag is the one hand-trigger that can lead to a publish** —
+it takes the same path a tag push does, so if that tag has no release it gets
+one, and the release is what publishes. That is deliberate: it is the recovery
+action for a tag whose release is missing. It is also bounded — it needs write
+access, an existing `rs-v*` tag, a manifest at exactly that version, and no
+release already there. Dispatching it on a branch reaches none of this; the
+attach job is gated on the ref being a tag.
+
+The publish workflow also runs on every pull request, as a dry run, so it is
+exercised before a release depends on it.
+
 ### The other path: push the tag and let the release be made for you
 
 `release: published` is the only trigger, so a tag on its own uploads nothing.
@@ -134,12 +152,11 @@ registry that received nothing, which is what the missing-release bug produced
 and what no amount of reading the run list makes obvious. This is the one check
 that cannot be satisfied by the release path merely having run.
 
-**A `workflow_dispatch` run is always a dry run.** There is no input to flip.
-The only path that uploads is a published release, so the workflow cannot be
-hand-triggered into publishing by mistake. Use dispatch to rehearse.
-
-The workflow also runs on every pull request, as a dry run, so it is exercised
-before a release depends on it.
+It runs on `!cancelled()` rather than on the jobs above it succeeding, because
+the states worth describing are the ones where something above it did not. A
+tag with no release at all fails it in seconds, naming that as the reason
+nothing shipped, rather than spending forty minutes waiting for a publish that
+was never triggered.
 
 ### The `crates-io` environment
 

--- a/rust/docs/publishing.md
+++ b/rust/docs/publishing.md
@@ -95,6 +95,45 @@ that would produce a broken release:
 
 It authenticates with the `CARGO_REGISTRY_TOKEN` repository secret.
 
+### The other path: push the tag and let the release be made for you
+
+`release: published` is the only trigger, so a tag on its own uploads nothing.
+That used to make a hand-pushed tag a half-release: the binaries built,
+`rust-release.yml` waited for a release that no one was going to create, and
+the one red job it produced read as a failed upload rather than as a release
+that never happened. crates.io received nothing, and nothing said so.
+
+`rust-release.yml` closes that itself. Its attach job waits for the release as
+before, and creates one when the wait comes up empty — with notes rendered from
+the commit range by `release-decide.py --at`, the same renderer the weekly path
+uses. On the weekly path the release is already there when the wait runs, so
+nothing is created and there is still exactly one release.
+
+Creating it needs `RELEASE_TOKEN`, and its absence fails the job rather than
+producing a release with the default token: a release created that way does not
+start this workflow, and because a `workflow_dispatch` run here is a dry run,
+no re-run could ever publish it. See the header of `rust-auto-release.yml`.
+
+So the whole of cutting a Rust release by hand is:
+
+```sh
+git tag -a rs-v<version> -m rs-v<version> <commit>
+git push origin rs-v<version>
+```
+
+### Confirming the crates actually shipped
+
+`rust-release.yml` ends with a job that asks crates.io whether every crate
+`publish-plan.py` names is on the index at this version, and fails naming the
+ones that are not
+(`.github/scripts/rust/verify-published.sh`). It runs on both release paths.
+
+It exists because the failure worth defending against is not a red job. It is a
+release page that looks finished — tag, notes, three binaries — beside a
+registry that received nothing, which is what the missing-release bug produced
+and what no amount of reading the run list makes obvious. This is the one check
+that cannot be satisfied by the release path merely having run.
+
 **A `workflow_dispatch` run is always a dry run.** There is no input to flip.
 The only path that uploads is a published release, so the workflow cannot be
 hand-triggered into publishing by mistake. Use dispatch to rehearse.
@@ -303,7 +342,10 @@ file is copied into each crate directory; keep the copies in sync with the root
 - `.github/workflows/rust-publish-crates.yml` — the only thing that uploads to a
   registry.
 - `.github/workflows/rust-release.yml` — builds and attests the `termproof`
-  binary for tagged releases. It does not publish to crates.io. It has run
+  binary for tagged releases, creates the GitHub release when a tag arrives
+  without one, and checks the registry at the end. It does not publish to
+  crates.io — creating the release is what asks `rust-publish-crates.yml` to.
+  It has run
   successfully on every release tag through `0.3.4`: `v0.2.1` to `v0.3.3` in
   the separate Rust repository this workspace came from, and `rs-v0.3.4`, the
   first `rs-v*` tag cut here. Each attaches the three per-platform archives and


### PR DESCRIPTION
Closes #191.

## The gap

`rs-v0.4.1` was pushed by hand. `rust-release.yml` built the three binaries and then waited for a GitHub release that nothing on the tag-push path was going to create, waited 150 seconds, and failed with *"no GitHub release exists for tag 'rs-v0.4.1' … Create the release, then re-run this job."*

That reads as a problem attaching binaries. It was not one. `rust-publish-crates.yml` triggers on a **published release** and nothing else, so crates.io received nothing at all — and one red job among several green ones was the entire signal that a release had silently not happened. It was recovered by hand: creating the release fired the crates publish and let the attach job succeed on re-run.

Python never had this problem, though not by sharing this shape: `python-release.yml` creates its own release from the tag *and* uploads to PyPI as a later step of the same job, gated on the tag ref. Its tag path is self-sufficient because everything happens in one job. Rust's indirection through a release event is deliberate and is what makes the `crates-io` environment gate possible — so the fix is to make the tag path produce that release, not to collapse the two designs.

## What changed

**`rust-release.yml` — the attach job creates the release when the wait finds none.**
The existing wait loop is what makes this safe rather than something added beside it: it now records `exists=true|false` instead of ending in `exit 1`, and the create step is gated on that output. On the weekly path the release is created seconds after the tag push and this job is minutes behind, so the first check finds it and nothing is created — still exactly one release. By the time the loop has failed ten times over 150s, nothing else is going to create it.

The step must use `RELEASE_TOKEN`, and **its absence fails the job rather than falling back**. This is the crux: a release created with the default `GITHUB_TOKEN` does not start `rust-publish-crates.yml`, and because a `workflow_dispatch` run there is a dry run by design, no re-run could ever publish it. A tag with no release is recoverable; a release that can never publish is not. It also re-checks the tag against `publish-plan.py`'s version *before* creating anything, so it cannot mint a release the publish workflow would refuse.

**Notes come from the same renderer the weekly path uses.** `release-decide.py` grows one flag, `--at VERSION`: describe the range instead of deciding on it. Without it the script derives the *next* version from the commits, so notes for a tag that already exists would be headed one release too far ahead with a compare link to a tag nobody cut — locally, `--from rs-v0.4.0 --to rs-v0.4.1` decides `0.5.0`. Nothing else about the deciding mode moves.

**The path ends by asking crates.io.** A new `verify-crates` job runs `.github/scripts/rust/verify-published.sh`, which polls the sparse index for every crate `publish-plan.py` names at this version and fails naming the ones that are not there. It runs on both release paths. The failure mode worth designing against is not a red job — it is a release page that looks finished beside a registry that received nothing, and no amount of reading the run list makes that obvious. A follow-up step reports what the `Publish crates (Rust)` runs did, because "never ran" and "ran and failed" look identical from the registry and only the first is invisible.

## Constraints

- **No double release.** Creation is gated on the wait's output, and the wait outlasts the automation's own create by two orders of magnitude. Asserted in `test_the_release_is_created_only_when_the_wait_found_none`, including step ordering.
- **The publish trigger is unchanged.** `release: published`, no `push:`, same `if:` on the publish job, same `crates-io` environment. Asserted in `CratesPublishStaysTheOneGateTest`.
- **Nothing else uploads to a registry.** Asserted: `rust-release.yml` contains no `cargo publish` and no `CARGO_REGISTRY_TOKEN`.
- **No crate is named.** The verifier is asserted against the actual crate directory names; the set is derived from `publish-plan.py`, like everywhere else.
- **Notes are not a regression.** Rendered by `release-decide.py`, asserted non-empty and sectioned.

## How I verified the tag path without cutting a release

Four layers, all offline or read-only.

**1. Ran the create step's actual shell, with `gh` stubbed.** `CreateStepShellTest` lifts the step's `run:` block out of the YAML and executes it under `bash -e` — what GitHub uses — against a fake `gh` that records its arguments. Six branches:

| scenario | result |
|---|---|
| happy path | `gh release create rs-v0.4.1 --title rs-v0.4.1 --notes-file release-notes.md --verify-tag`, exit 0 |
| `RELEASE_TOKEN` empty | exit 1, the error, **zero `gh` calls** |
| tag disagrees with manifest | exit 1, **zero `gh` calls** |
| create loses a race, release exists | exit 0, `::notice::`, no failure |
| create genuinely fails | exit 1 |
| notes on disk | start `## termproof 0.4.1` |

The tag is derived from the manifest rather than written down, so it tests the guard and not a version.

**2. Rendered the notes 0.4.1 should have had.** Running the workflow's own command against the real `rs-v0.4.0..rs-v0.4.1` range produces the correct heading, the conventional-commit sections, and `compare/rs-v0.4.0...rs-v0.4.1`:

```
## termproof 0.4.1

### Breaking changes

- **svg:** one source of truth for the SVG geometry defaults, on a Linux-safe font stack (#195) (`e4e3de2f`)
...
**Full changelog:** https://github.com/md-mt/termproof/compare/rs-v0.4.0...rs-v0.4.1
```

**3. Ran the verifier against a local `file://` sparse index.** `curl` reads `file://` like `https://`, so `VerifyPublishedScriptTest` builds the crates.io shard layout in a tmpdir and exercises sharding, version matching, polling, and the empty-plan case with no network and no dependency on what is published. Separately, against real crates.io: the live plan set at `0.4.1` passes; `99.99.99` and a held-back crate both fail naming exactly what is missing.

**4. Mutation-tested the workflow assertions.** Dropping the wait guard, swapping `secrets.RELEASE_TOKEN` for `github.token`, and deleting the `verify-crates` job each turn the suite red (1 error, 1 failure, 4 errors). The tests are not vacuous.

Also: full Python suite green (885 tests), `check_version.py`, `check_schema_copies.py`, `run_stdlib_tests.py` (159) all pass, `shellcheck` clean on the new script.

## Not done here

`publish.sh` and `verify-published.sh` each carry their own eight-line sparse-index URL helper. Factoring it into a shared file would be a structural change to the publish path in a behavioural diff; worth doing, separately.

## Follow-up in this PR

CI caught a real bug in the first commit, which is the payoff for testing the step's shell rather than only reading the YAML. The step resolved revisions through `$TAG^{commit}`. That is the same commit HEAD already is — the tag push started the run — but it is a name that has to have been fetched, so in a clone without tags `rev-parse` failed outright instead of falling through to the whole-history branch. `5bba742` moves both revisions to `HEAD` / `HEAD^`, verified against a `git clone --no-tags --depth 1`, where the fallback now renders notes and the release is created.

CI on the final commit: 19 passed, 1 skipped — the skip being `Publish`, which is exactly the property that the publish job still runs only on a published release.

## Review round (`0fa3154`)

**Finding 1 — the registry check was skipped exactly when it mattered.** Correct and the sharpest finding here. `needs: attach` carries an implicit `success()`, so a release created followed by a failed upload — the same shape as the incident — left a red *Attach to release* beside a registry nobody looked at. Now `if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/rs-v') }}`.

That makes the job reachable after a failed build, where 40 minutes of polling buys nothing, so it asks the cheap question first: a new step checks the release exists and fails in seconds if not — naming the consequence, *a tag went out and shipped nothing*, rather than waiting out a publish that was never triggered. Both mutations (reverting the guard, deleting the fast-fail step) now turn the suite red; neither did before.

**Finding 2 — dispatch is no longer always a dry run at the system level.** Also correct. Said plainly in `rust/docs/publishing.md` and in `rust-release.yml`'s header: dispatching *Release (Rust)* against a tag is the one hand-trigger that can lead to a publish, deliberately, as the recovery action for a tag whose release is missing — bounded by the tag ref, the manifest match, the absence of a release, and the token. Fixing this also moved the dry-run paragraph back under the heading it describes; an earlier insertion in this branch had orphaned it under "Confirming the crates actually shipped".

**Finding 3 — taken.** Two assertions pinning `rust-release.yml`'s triggers and the tag-ref guards on `attach` and `verify-crates`. Both of your mutations were silent before and fail now. Your reading is right that the version guard inside the create step is what carries the safety; this makes the outer layer deliberate rather than incidental.

**Finding 4 — declined, with a reason.** A hard `args.at != current` exit would break the flag's stated purpose. `--at` describes a release that already exists, and the useful hand invocation is regenerating notes for an *older* tag from a current checkout — where `cargo metadata` reads the working tree's manifest and the two versions legitimately differ. There is also no surprise to guard against: the caller passed the version explicitly and gets notes headed at it. The one caller that must not diverge already checks, before `gh` is invoked.

**Finding 5 — declined, with a reason.** Agreed on the smell, but every fix I costed is worse than the problem. A `git worktree` writes into the shared git common directory and leaves a stale registration if a test dies; a clone per test is slow and loses the history the notes range needs; running with `cwd=tmp` breaks the relative script and manifest paths the step legitimately uses. Changing the workflow to write elsewhere would be changing production for a test. The `setUp` skip plus `addCleanup` covers the realistic case, and as you say the current form is honest about running the real thing.

**Finding 6 — fixed, in the PR body above.** You are right and the correction matters in the direction you name: PyPI is uploaded by a step in the same job, gated on the tag ref, not by a release event. Rust's indirection through `release: published` is the thing that makes the environment gate possible, so the two paths are self-sufficient for different reasons. The CHANGELOG entry makes no claim about Python, so nothing there needed changing.

**Outside this PR, noted:** `"Nothing else in this repository uploads to a registry"` is loose as written — `python-release.yml` uploads to PyPI. Pre-existing, plainly meant as "to crates.io", and left alone.
