### PR TITLE
before_after: Python moves to Rust's field names, markdown and ordering (#204)

### DIFF
--- a/.github/scripts/rust/verify-package-contents.sh
+++ b/.github/scripts/rust/verify-package-contents.sh
@@ -43,6 +43,7 @@ done
 for forbidden in \
   tests/differential_steps.rs \
   tests/differential_assertions.rs \
+  tests/differential_before_after.rs \
   conformance/
 do
   if grep -q "^${forbidden}" <<<"$LIST"; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,15 @@ languages force a difference, the house pattern is `Option<T>` for a Python
 keyword default and `Err` for a Python `ValueError`.
 
 Parity is asserted, not assumed: `conformance/README.md` is the authority on the
-three differential harnesses and on how to regenerate a corpus. Read it before
+differential harnesses and on how to regenerate a corpus. Read it before
 changing anything a harness compares — regenerating an expected file to make a
 test pass is how a real divergence gets recorded as correct.
+
+Which side is the reference is per-layer, not global. Python is the oracle for
+steps, assertions and the evidence manifest; Rust is for `before_after`, which
+Python was changed to match in #204. A module pair with no harness over it has
+no answer to that question at all, which is how `before_after` drifted on three
+axes at once without a test failing anywhere.
 
 ## Rust has two `Recipe` types and they are not interchangeable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,83 @@ with the pre-1.0 rule that under `0.x` a breaking change bumps the minor digit.
 
 ## [Unreleased]
 
+### Python — Changed (breaking)
+
+- **`before_after` now produces the same report as the Rust module, which
+  changes published report text.** The two were never two bindings of one
+  thing — they were separate implementations that disagreed on the delta field
+  names, on both markdown forms and on the order the deltas came out in
+  ([#204](https://github.com/md-mt/termproof/issues/204)). Python moved to
+  match Rust; nothing changed on the Rust side.
+
+  This is visible wherever a Python report is published — the CI PR comment
+  (`ci_evidence.compose_pr_comment`), `report.ReportGenerator` and
+  `builtin_reporters` all embed `BeforeAfterResult.to_markdown()` verbatim.
+
+  The **empty case**, which is the outcome of most runs:
+
+  ```markdown
+  ## Behavioral Deltas
+
+  None.
+  ```
+
+  is now, on one line:
+
+  ```markdown
+  **Behavioral deltas:** none — before/after outcomes match.
+  ```
+
+  A **populated** section:
+
+  ```markdown
+  ## Behavioral Deltas
+
+  - `login` [default]: PASS -> FAIL
+  ```
+
+  is now:
+
+  ```markdown
+  **Behavioral deltas:**
+
+  - login [default]: PASS -> FAIL
+  ```
+
+  **The deltas are also in a different order**, and that is the substantive
+  half. `compute_deltas` sorted the union of the `(recipe, renderer)` keys, so
+  a report read alphabetically. It now follows `before` order and appends
+  recipes that appear only in `after` — so a report reads in the order the
+  recipes ran rather than a hash order, and two reports either side of a change
+  line up when diffed. For a suite running `smoke`, `login`, `search`, deltas
+  that used to arrive as `login`, `search`, `smoke` now arrive as `smoke`,
+  `login`, `search`.
+
+  `BehaviorDelta`'s four fields were renamed to the Rust spelling, so code
+  reading them has to change: `recipe_name` → `recipe`, `before` →
+  `before_outcome`, `after` → `after_outcome` (`renderer` is unchanged). It
+  also gained `explanation()`, which renders the one-line form the markdown is
+  built from, and the module now exports the `PASS`, `FAIL` and `SKIP`
+  constants Rust exports. No behaviour changed in *which* outcomes are reported
+  as deltas.
+
+  This is a break under `0.x` and it is recorded here rather than bumped; the
+  version is the maintainer's decision.
+
+### Testing
+
+- **A fourth differential harness, for the before/after report.**
+  `conformance/probe_before_after.py` drives the Python module over
+  `conformance/corpus/before_after_cases.json` and records the deltas and the
+  rendered markdown; `crates/termproof/tests/differential_before_after.rs`
+  replays the same cases through the Rust module and compares the whole
+  recording. It exists because the divergence above went unnoticed for two
+  minor releases: each side asserted its own wording in its own unit tests, and
+  no test had ever run both. Ten cases, weighted towards the empty markdown and
+  the three ways an ordering rule can be silently undone. No ratchet — this is
+  a report format, and a partial score for a report format is not a useful
+  number. `conformance/README.md` has the shape and the regeneration command.
+
 ### CI
 
 - **An `rs-v*` tag pushed by hand is now a whole release.** It was not. The

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,13 +1,14 @@
 # Differential harness
 
-Cross-runtime differential harnesses for the layers the port has to match. One
-per layer, each the same two-half shape:
+Cross-runtime differential harnesses for the layers the two implementations
+have to match. One per layer, each the same two-half shape:
 
 | Layer | Oracle | Port | Corpus |
 |---|---|---|---|
 | Steps | `probe_steps.py` | `tests/differential_steps.rs` | `corpus/cases.json` |
 | Assertions | `probe_assertions.py` | `tests/differential_assertions.rs` | `corpus/assertion_cases.json` |
 | Evidence manifest | `probe_evidence_manifest.py` | `tests/differential_evidence_manifest.rs` | `corpus/evidence_manifest.expected.json` |
+| Before/after | `probe_before_after.py` | `tests/differential_before_after.rs` | `corpus/before_after_cases.json` |
 
 They exist because the port claimed corpus parity several times over with green
 local gates, and a differential run against the Python implementation still
@@ -524,3 +525,90 @@ Pass or fail, with the two documents printed on failure. There is no agreement
 ratchet here as there is for steps and assertions: the two implementations
 either write the same document or they do not, and a partial score for a file
 format is not a useful number.
+
+# Before/after
+
+A fourth harness, for the report `before_after` produces from two runs of the
+same suite.
+
+## Shape
+
+| Half | Where | What it does |
+|---|---|---|
+| Oracle | `probe_before_after.py` | Drives the Python `before_after` over `corpus/before_after_cases.json` and records each case's deltas — every field, under the name it carries — and its rendered markdown into `corpus/before_after.expected.json`. |
+| Port | `crates/termproof/tests/differential_before_after.rs` | Replays the same cases through the Rust module and compares the whole recording. |
+
+## Why it exists
+
+These two modules were not two bindings of one thing. They were separate
+implementations, and until #204 they disagreed on three axes at once:
+
+| | Rust | Python (before #204) |
+|---|---|---|
+| delta fields | `recipe`, `renderer`, `before_outcome`, `after_outcome` | `recipe_name`, `renderer`, `before`, `after` |
+| empty markdown | `**Behavioral deltas:** none — before/after outcomes match.` | `## Behavioral Deltas` / blank / `None.` |
+| delta line | `- recipe [renderer]: PASS -> FAIL` | ``- `recipe_name` [renderer]: PASS -> FAIL`` |
+| ordering | `before` order, new arrivals appended | `sorted()` over the key union |
+
+Nothing failed, because each side asserted its own wording in its own unit
+tests and no test had ever run both. It surfaced when a consumer with a
+validator in each language adopted 0.4.1 in both on the same day: the Rust side
+deleted its local copy and the output did not change by a byte, and the Python
+side could not, because adopting would have changed the report a human reviewer
+reads and reordered the deltas in it. Python was changed to match Rust, and
+this harness is what holds the two together from here.
+
+Both halves of the recording matter and for different reasons. The **deltas**
+are the API a consumer's own reporter reads, so the field names decide whether
+upstream can be swapped in for a local copy. The **markdown** is the report a
+human reviewer reads, so a divergence there is visible in published output
+rather than only in a type signature.
+
+## What the corpus measures
+
+Ten cases, chosen for the three axes above rather than for coverage of a wide
+input space — there is not much input space here.
+
+- **The empty case, twice** (`identical`, `both-sides-empty`). "No deltas" is
+  the most common outcome of a before/after run, so it is the string most
+  consumers see most often, and it is the one the two implementations worded
+  most differently.
+- **Each outcome transition** — a regression, a fix, a recipe that stopped
+  running (`PASS -> SKIP`) and one that appeared (`SKIP -> PASS`) — plus the
+  same recipe under two renderers, which is two entries and not one.
+- **Ordering, three ways.** `before-order-then-new-arrivals` pins the rule
+  itself; `before-order-is-not-alphabetical` puts every name in `before` out of
+  alphabetical order, so a `sorted()` anywhere in the pipeline reverses the list
+  rather than leaving it be; `new-arrivals-are-not-sorted-either` does the same
+  for the appended tail. Ordering is the axis a later cosmetic refactor is most
+  likely to undo, and the one a reviewer notices first: they want the deltas in
+  the order the recipes ran.
+
+Each case's `before` and `after` carry only `recipe`, `renderer` and `passed`.
+Those are the three fields this layer reads; both halves fill the rest of a
+`RunResult` with fixed values, so anything else varying would be measuring a
+different module.
+
+## Regenerating the expectations
+
+```sh
+cd /path/to/termproof/python
+TERMPROOF_PYTHON_REPO=$PWD uv run python \
+    ../conformance/probe_before_after.py \
+    > ../conformance/corpus/before_after.expected.json
+```
+
+Only regenerate deliberately: the file is the oracle's testimony, and quietly
+re-recording it turns a failing comparison into a passing one without changing
+any behaviour. If the Rust half is the one that changed, fix the Rust half —
+Rust is the reference for this layer, by the decision recorded in #204.
+
+## Reading the result
+
+```sh
+cargo test -p termproof --test differential_before_after
+```
+
+Pass or fail, with the two recordings printed on failure. As with the evidence
+manifest there is no ratchet: the two implementations either produce the same
+report or they do not.

--- a/conformance/corpus/before_after.expected.json
+++ b/conformance/corpus/before_after.expected.json
@@ -1,0 +1,151 @@
+[
+  {
+    "name": "identical",
+    "deltas": [],
+    "markdown": "**Behavioral deltas:** none \u2014 before/after outcomes match.\n"
+  },
+  {
+    "name": "both-sides-empty",
+    "deltas": [],
+    "markdown": "**Behavioral deltas:** none \u2014 before/after outcomes match.\n"
+  },
+  {
+    "name": "regression",
+    "deltas": [
+      {
+        "recipe": "login",
+        "renderer": "default",
+        "before_outcome": "PASS",
+        "after_outcome": "FAIL",
+        "explanation": "login [default]: PASS -> FAIL"
+      }
+    ],
+    "markdown": "**Behavioral deltas:**\n\n- login [default]: PASS -> FAIL\n"
+  },
+  {
+    "name": "fix",
+    "deltas": [
+      {
+        "recipe": "login",
+        "renderer": "default",
+        "before_outcome": "FAIL",
+        "after_outcome": "PASS",
+        "explanation": "login [default]: FAIL -> PASS"
+      }
+    ],
+    "markdown": "**Behavioral deltas:**\n\n- login [default]: FAIL -> PASS\n"
+  },
+  {
+    "name": "stopped-running",
+    "deltas": [
+      {
+        "recipe": "login",
+        "renderer": "default",
+        "before_outcome": "PASS",
+        "after_outcome": "SKIP",
+        "explanation": "login [default]: PASS -> SKIP"
+      }
+    ],
+    "markdown": "**Behavioral deltas:**\n\n- login [default]: PASS -> SKIP\n"
+  },
+  {
+    "name": "newly-added",
+    "deltas": [
+      {
+        "recipe": "login",
+        "renderer": "default",
+        "before_outcome": "SKIP",
+        "after_outcome": "PASS",
+        "explanation": "login [default]: SKIP -> PASS"
+      }
+    ],
+    "markdown": "**Behavioral deltas:**\n\n- login [default]: SKIP -> PASS\n"
+  },
+  {
+    "name": "two-renderers-one-flipped",
+    "deltas": [
+      {
+        "recipe": "login",
+        "renderer": "beta",
+        "before_outcome": "PASS",
+        "after_outcome": "FAIL",
+        "explanation": "login [beta]: PASS -> FAIL"
+      }
+    ],
+    "markdown": "**Behavioral deltas:**\n\n- login [beta]: PASS -> FAIL\n"
+  },
+  {
+    "name": "before-order-then-new-arrivals",
+    "deltas": [
+      {
+        "recipe": "b",
+        "renderer": "d",
+        "before_outcome": "PASS",
+        "after_outcome": "FAIL",
+        "explanation": "b [d]: PASS -> FAIL"
+      },
+      {
+        "recipe": "a",
+        "renderer": "d",
+        "before_outcome": "PASS",
+        "after_outcome": "FAIL",
+        "explanation": "a [d]: PASS -> FAIL"
+      },
+      {
+        "recipe": "c",
+        "renderer": "d",
+        "before_outcome": "SKIP",
+        "after_outcome": "PASS",
+        "explanation": "c [d]: SKIP -> PASS"
+      }
+    ],
+    "markdown": "**Behavioral deltas:**\n\n- b [d]: PASS -> FAIL\n- a [d]: PASS -> FAIL\n- c [d]: SKIP -> PASS\n"
+  },
+  {
+    "name": "before-order-is-not-alphabetical",
+    "deltas": [
+      {
+        "recipe": "zulu",
+        "renderer": "d",
+        "before_outcome": "PASS",
+        "after_outcome": "FAIL",
+        "explanation": "zulu [d]: PASS -> FAIL"
+      },
+      {
+        "recipe": "yankee",
+        "renderer": "d",
+        "before_outcome": "PASS",
+        "after_outcome": "FAIL",
+        "explanation": "yankee [d]: PASS -> FAIL"
+      },
+      {
+        "recipe": "xray",
+        "renderer": "d",
+        "before_outcome": "PASS",
+        "after_outcome": "FAIL",
+        "explanation": "xray [d]: PASS -> FAIL"
+      }
+    ],
+    "markdown": "**Behavioral deltas:**\n\n- zulu [d]: PASS -> FAIL\n- yankee [d]: PASS -> FAIL\n- xray [d]: PASS -> FAIL\n"
+  },
+  {
+    "name": "new-arrivals-are-not-sorted-either",
+    "deltas": [
+      {
+        "recipe": "zulu",
+        "renderer": "d",
+        "before_outcome": "SKIP",
+        "after_outcome": "PASS",
+        "explanation": "zulu [d]: SKIP -> PASS"
+      },
+      {
+        "recipe": "alpha",
+        "renderer": "d",
+        "before_outcome": "SKIP",
+        "after_outcome": "PASS",
+        "explanation": "alpha [d]: SKIP -> PASS"
+      }
+    ],
+    "markdown": "**Behavioral deltas:**\n\n- zulu [d]: SKIP -> PASS\n- alpha [d]: SKIP -> PASS\n"
+  }
+]

--- a/conformance/corpus/before_after_cases.json
+++ b/conformance/corpus/before_after_cases.json
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "identical",
+    "before": [{"recipe": "login", "renderer": "default", "passed": true}],
+    "after": [{"recipe": "login", "renderer": "default", "passed": true}]
+  },
+  {
+    "name": "both-sides-empty",
+    "before": [],
+    "after": []
+  },
+  {
+    "name": "regression",
+    "before": [{"recipe": "login", "renderer": "default", "passed": true}],
+    "after": [{"recipe": "login", "renderer": "default", "passed": false}]
+  },
+  {
+    "name": "fix",
+    "before": [{"recipe": "login", "renderer": "default", "passed": false}],
+    "after": [{"recipe": "login", "renderer": "default", "passed": true}]
+  },
+  {
+    "name": "stopped-running",
+    "before": [{"recipe": "login", "renderer": "default", "passed": true}],
+    "after": []
+  },
+  {
+    "name": "newly-added",
+    "before": [],
+    "after": [{"recipe": "login", "renderer": "default", "passed": true}]
+  },
+  {
+    "name": "two-renderers-one-flipped",
+    "before": [
+      {"recipe": "login", "renderer": "alpha", "passed": true},
+      {"recipe": "login", "renderer": "beta", "passed": true}
+    ],
+    "after": [
+      {"recipe": "login", "renderer": "alpha", "passed": true},
+      {"recipe": "login", "renderer": "beta", "passed": false}
+    ]
+  },
+  {
+    "name": "before-order-then-new-arrivals",
+    "before": [
+      {"recipe": "b", "renderer": "d", "passed": true},
+      {"recipe": "a", "renderer": "d", "passed": true}
+    ],
+    "after": [
+      {"recipe": "a", "renderer": "d", "passed": false},
+      {"recipe": "b", "renderer": "d", "passed": false},
+      {"recipe": "c", "renderer": "d", "passed": true}
+    ]
+  },
+  {
+    "name": "before-order-is-not-alphabetical",
+    "before": [
+      {"recipe": "zulu", "renderer": "d", "passed": true},
+      {"recipe": "yankee", "renderer": "d", "passed": true},
+      {"recipe": "xray", "renderer": "d", "passed": true}
+    ],
+    "after": [
+      {"recipe": "xray", "renderer": "d", "passed": false},
+      {"recipe": "yankee", "renderer": "d", "passed": false},
+      {"recipe": "zulu", "renderer": "d", "passed": false}
+    ]
+  },
+  {
+    "name": "new-arrivals-are-not-sorted-either",
+    "before": [],
+    "after": [
+      {"recipe": "zulu", "renderer": "d", "passed": true},
+      {"recipe": "alpha", "renderer": "d", "passed": true}
+    ]
+  }
+]

--- a/conformance/probe_before_after.py
+++ b/conformance/probe_before_after.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Oracle half of the before/after differential harness.
+
+Drives the Python :mod:`termproof.before_after` over ``corpus/before_after_cases.json``
+and records, for each case, the deltas it computed — every field, under the
+name it carries — and the markdown it rendered.
+
+It exists because these two modules were *not* two bindings of one thing. They
+were separate implementations that disagreed on the delta field names, on both
+markdown forms and on the order the deltas came out in, and nothing failed:
+each side's unit tests asserted its own wording, and no test had ever run both
+(#204). Python was changed to match Rust, whose ordering rule is the documented
+one, and this is what holds the two together from here.
+
+Both halves of the recording matter and for different reasons. The **deltas**
+are the API a consumer's own reporter reads, so the field names are the thing
+that decides whether upstream can be swapped in for a local copy. The
+**markdown** is the report a human reviewer reads, so a divergence there is
+visible in published output rather than only in a type signature.
+
+The empty case is recorded deliberately. "No deltas" is the most common outcome
+of a before/after run, so it is the string most consumers see most often, and it
+is the one the two implementations worded most differently.
+
+Regenerate deliberately::
+
+    cd /path/to/termproof/python
+    TERMPROOF_PYTHON_REPO=$PWD uv run python \\
+        ../conformance/probe_before_after.py \\
+        > ../conformance/corpus/before_after.expected.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.environ.get("TERMPROOF_PYTHON_REPO", str(Path(__file__).parent.parent / "python")))
+
+from termproof.before_after import build_before_after  # noqa: E402
+from termproof.models import RunResult  # noqa: E402
+
+CASES = Path(__file__).parent / "corpus" / "before_after_cases.json"
+
+
+def _result(spec: dict[str, object]) -> RunResult:
+    """A ``RunResult`` carrying only the three fields this layer reads.
+
+    The rest are filled with fixed values rather than left out: the comparison
+    reads ``recipe_name``, ``renderer`` and ``passed`` and nothing else, so
+    anything varying here would be measuring a different module.
+    """
+    passed = bool(spec["passed"])
+    return RunResult(
+        recipe_name=str(spec["recipe"]),
+        passed=passed,
+        exit_code=0 if passed else 1,
+        duration_seconds=0.0,
+        priority="P0",
+        execution="scripted",
+        renderer=str(spec["renderer"]),
+        score=1.0 if passed else 0.0,
+        steps=[],
+        assertions=[],
+        artifacts={},
+    )
+
+
+def run(case: dict[str, object]) -> dict[str, object]:
+    before = [_result(spec) for spec in case["before"]]  # type: ignore[union-attr]
+    after = [_result(spec) for spec in case["after"]]  # type: ignore[union-attr]
+    result = build_before_after(before, after)
+    return {
+        "name": case["name"],
+        # A list, not a set or a mapping: the order is part of what is compared.
+        "deltas": [
+            {
+                "recipe": delta.recipe,
+                "renderer": delta.renderer,
+                "before_outcome": delta.before_outcome,
+                "after_outcome": delta.after_outcome,
+                "explanation": delta.explanation(),
+            }
+            for delta in result.deltas
+        ],
+        "markdown": result.to_markdown(),
+    }
+
+
+def main() -> None:
+    cases = json.loads(CASES.read_text(encoding="utf-8"))
+    json.dump([run(case) for case in cases], sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/termproof/before_after.py
+++ b/python/termproof/before_after.py
@@ -1,33 +1,77 @@
+"""What changed between two runs of the same suite.
+
+Where :mod:`termproof.parity` asks "do these two agree?", this asks the
+narrower and more actionable question: **which outcomes flipped?**
+
+The usual shape is a change under review verified twice — once against a
+baseline build, once against the candidate — so a reviewer sees exactly which
+behaviours the change altered rather than a wall of results they have to diff
+by eye.
+
+A recipe present in only one pass is reported as ``SKIP`` on the missing side.
+That is a real signal, not a gap to hide: a recipe that stopped running is
+usually more interesting than one that changed verdict, and silently omitting
+it would make a shrinking suite look like a stable one.
+
+This module is the mirror of ``termproof::before_after`` in the Rust crate:
+the field names, the two markdown forms and the ordering rule are the same on
+both sides, because a consumer running a validator in each language reads one
+report format, not two.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 
 from .models import RunResult
 
+#: The run passed.
+PASS = "PASS"
+#: The run failed.
+FAIL = "FAIL"
+#: The recipe did not run on this side.
+SKIP = "SKIP"
+
 
 @dataclass(frozen=True)
 class BehaviorDelta:
-    recipe_name: str
+    """One recipe/renderer whose outcome changed."""
+
+    #: Recipe name.
+    recipe: str
+    #: Renderer the recipe ran under.
     renderer: str
-    before: str
-    after: str
+    #: :data:`PASS`, :data:`FAIL` or :data:`SKIP` before.
+    before_outcome: str
+    #: :data:`PASS`, :data:`FAIL` or :data:`SKIP` after.
+    after_outcome: str
+
+    def explanation(self) -> str:
+        """One line a reviewer can read without context."""
+        return f"{self.recipe} [{self.renderer}]: {self.before_outcome} -> {self.after_outcome}"
 
 
 @dataclass(frozen=True)
 class BeforeAfterResult:
+    """Two runs and what changed between them."""
+
     before: list[RunResult]
     after: list[RunResult]
+    #: Outcomes that differ, in ``before`` order then new arrivals.
     deltas: list[BehaviorDelta]
 
     def to_markdown(self) -> str:
+        """Render the deltas as markdown.
+
+        States "none" explicitly rather than emitting nothing: an empty section
+        and a missing section look identical in a report, and only one of them
+        means the comparison ran.
+        """
         if not self.deltas:
-            return "## Behavioral Deltas\n\nNone.\n"
-        lines = ["## Behavioral Deltas", ""]
+            return "**Behavioral deltas:** none — before/after outcomes match.\n"
+        lines = ["**Behavioral deltas:**", ""]
         for delta in self.deltas:
-            lines.append(
-                f"- `{delta.recipe_name}` [{delta.renderer}]: "
-                f"{delta.before} -> {delta.after}"
-            )
+            lines.append(f"- {delta.explanation()}")
         return "\n".join(lines) + "\n"
 
 
@@ -35,6 +79,7 @@ def build_before_after(
     before: list[RunResult],
     after: list[RunResult],
 ) -> BeforeAfterResult:
+    """Assemble a :class:`BeforeAfterResult` with its deltas computed."""
     return BeforeAfterResult(before=before, after=after, deltas=compute_deltas(before, after))
 
 
@@ -42,15 +87,31 @@ def compute_deltas(
     before: list[RunResult],
     after: list[RunResult],
 ) -> list[BehaviorDelta]:
+    """The outcome changes from *before* to *after*.
+
+    Matched by ``(recipe_name, renderer)``. Ordering follows *before*, with
+    recipes that appear only in *after* appended — so a report reads in a
+    stable order rather than a hash order. Sorting the key union instead would
+    read alphabetically, which is not the order the recipes ran in and is not
+    the order the two reports either side of a change can be diffed in.
+    """
+    before_keys = [_key(result) for result in before]
+    after_keys = [_key(result) for result in after]
+
+    ordered_keys = list(before_keys)
+    for key in after_keys:
+        if key not in before_keys:
+            ordered_keys.append(key)
+
     before_by_key = {_key(result): result for result in before}
     after_by_key = {_key(result): result for result in after}
     deltas: list[BehaviorDelta] = []
-    for key in sorted(before_by_key.keys() | after_by_key.keys()):
-        before_status = _status(before_by_key.get(key))
-        after_status = _status(after_by_key.get(key))
-        if before_status != after_status:
-            recipe_name, renderer = key
-            deltas.append(BehaviorDelta(recipe_name, renderer, before_status, after_status))
+    for key in ordered_keys:
+        before_outcome = _outcome(before_by_key.get(key))
+        after_outcome = _outcome(after_by_key.get(key))
+        if before_outcome != after_outcome:
+            recipe, renderer = key
+            deltas.append(BehaviorDelta(recipe, renderer, before_outcome, after_outcome))
     return deltas
 
 
@@ -58,7 +119,7 @@ def _key(result: RunResult) -> tuple[str, str]:
     return (result.recipe_name, result.renderer)
 
 
-def _status(result: RunResult | None) -> str:
+def _outcome(result: RunResult | None) -> str:
     if result is None:
-        return "SKIP"
-    return "PASS" if result.passed else "FAIL"
+        return SKIP
+    return PASS if result.passed else FAIL

--- a/python/tests/test_before_after.py
+++ b/python/tests/test_before_after.py
@@ -1,0 +1,152 @@
+"""What `before_after` reports, and in what words and what order.
+
+The three things pinned here — the delta field names, both markdown forms and
+the ordering rule — are the three the Python module and ``termproof::before_after``
+disagreed on until #204. They are asserted literally rather than by substring
+so that a change to either side has to be a deliberate one: this is a report a
+human reviewer reads and a consumer's published output.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from termproof.before_after import (
+    FAIL,
+    PASS,
+    SKIP,
+    BehaviorDelta,
+    build_before_after,
+    compute_deltas,
+)
+from termproof.models import RunResult
+
+
+class BehaviorDeltaFieldsTest(unittest.TestCase):
+    """The field names, which are what make the two modules swappable."""
+
+    def test_a_delta_names_the_recipe_renderer_and_both_outcomes(self) -> None:
+        delta = compute_deltas([_run("login", "default", True)], [_run("login", "default", False)])[0]
+        self.assertEqual("login", delta.recipe)
+        self.assertEqual("default", delta.renderer)
+        self.assertEqual(PASS, delta.before_outcome)
+        self.assertEqual(FAIL, delta.after_outcome)
+
+    def test_explanation_is_one_line_a_reviewer_can_read_without_context(self) -> None:
+        delta = BehaviorDelta("login", "default", PASS, FAIL)
+        self.assertEqual("login [default]: PASS -> FAIL", delta.explanation())
+
+
+class DeltaDetectionTest(unittest.TestCase):
+    def test_identical_runs_have_no_deltas(self) -> None:
+        runs = [_run("login", "default", True)]
+        self.assertEqual([], compute_deltas(runs, runs))
+
+    def test_a_regression_is_reported(self) -> None:
+        deltas = compute_deltas([_run("login", "default", True)], [_run("login", "default", False)])
+        self.assertEqual(["login [default]: PASS -> FAIL"], [d.explanation() for d in deltas])
+
+    def test_a_fix_is_reported_too(self) -> None:
+        # Not only regressions: a change that fixes something is a behavioural
+        # delta a reviewer wants to see confirmed.
+        deltas = compute_deltas([_run("login", "default", False)], [_run("login", "default", True)])
+        self.assertEqual(["login [default]: FAIL -> PASS"], [d.explanation() for d in deltas])
+
+    def test_the_same_recipe_under_two_renderers_is_two_entries(self) -> None:
+        deltas = compute_deltas(
+            [_run("login", "alpha", True), _run("login", "beta", True)],
+            [_run("login", "alpha", True), _run("login", "beta", False)],
+        )
+        self.assertEqual(1, len(deltas))
+        self.assertEqual("beta", deltas[0].renderer)
+
+    def test_a_recipe_that_stopped_running_is_a_delta_not_a_gap(self) -> None:
+        # Silently dropping it would make a shrinking suite look stable.
+        deltas = compute_deltas([_run("login", "default", True)], [])
+        self.assertEqual(["login [default]: PASS -> SKIP"], [d.explanation() for d in deltas])
+        self.assertEqual(SKIP, deltas[0].after_outcome)
+
+    def test_a_newly_added_recipe_is_reported(self) -> None:
+        deltas = compute_deltas([], [_run("login", "default", True)])
+        self.assertEqual(["login [default]: SKIP -> PASS"], [d.explanation() for d in deltas])
+
+
+class OrderingTest(unittest.TestCase):
+    """The rule a later cosmetic refactor is most likely to undo.
+
+    A ``sorted()`` over the key union looks tidier and passes every other test
+    in this file. It is wrong: a reviewer wants the deltas in the order the
+    recipes ran, and a report that reshuffles between runs is hard to read and
+    harder to diff.
+    """
+
+    def test_ordering_follows_before_then_new_arrivals(self) -> None:
+        deltas = compute_deltas(
+            [_run("b", "d", True), _run("a", "d", True)],
+            [_run("a", "d", False), _run("b", "d", False), _run("c", "d", True)],
+        )
+        self.assertEqual(["b", "a", "c"], [d.recipe for d in deltas])
+
+    def test_before_order_is_kept_even_when_it_is_not_sorted(self) -> None:
+        # Every name here is out of alphabetical order in `before`, so a sort
+        # anywhere in the pipeline reverses the list rather than leaving it be.
+        deltas = compute_deltas(
+            [_run(name, "d", True) for name in ("zulu", "yankee", "xray")],
+            [_run(name, "d", False) for name in ("xray", "yankee", "zulu")],
+        )
+        self.assertEqual(["zulu", "yankee", "xray"], [d.recipe for d in deltas])
+
+    def test_new_arrivals_keep_their_after_order_rather_than_being_sorted(self) -> None:
+        deltas = compute_deltas([], [_run("zulu", "d", True), _run("alpha", "d", True)])
+        self.assertEqual(["zulu", "alpha"], [d.recipe for d in deltas])
+
+
+class MarkdownTest(unittest.TestCase):
+    """Both forms, byte for byte: this is published report text."""
+
+    def test_no_deltas_says_so_rather_than_rendering_nothing(self) -> None:
+        # An empty section and a missing section look the same in a report, and
+        # only one of them means the comparison ran.
+        result = build_before_after([_run("login", "default", True)], [_run("login", "default", True)])
+        self.assertEqual(
+            "**Behavioral deltas:** none — before/after outcomes match.\n",
+            result.to_markdown(),
+        )
+
+    def test_markdown_lists_every_delta_in_order(self) -> None:
+        result = build_before_after(
+            [_run("b", "d", True), _run("a", "d", True)],
+            [_run("a", "d", False), _run("b", "d", False)],
+        )
+        self.assertEqual(
+            "**Behavioral deltas:**\n\n- b [d]: PASS -> FAIL\n- a [d]: PASS -> FAIL\n",
+            result.to_markdown(),
+        )
+
+
+class BuildBeforeAfterTest(unittest.TestCase):
+    def test_build_keeps_both_sides_alongside_the_deltas(self) -> None:
+        result = build_before_after([_run("a", "d", True)], [_run("a", "d", False)])
+        self.assertEqual(1, len(result.before))
+        self.assertEqual(1, len(result.after))
+        self.assertEqual(1, len(result.deltas))
+
+
+def _run(recipe: str, renderer: str, passed: bool) -> RunResult:
+    return RunResult(
+        recipe_name=recipe,
+        passed=passed,
+        exit_code=0 if passed else 1,
+        duration_seconds=0.0,
+        priority="P0",
+        execution="scripted",
+        renderer=renderer,
+        score=1.0 if passed else 0.0,
+        steps=[],
+        assertions=[],
+        artifacts={},
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rust/crates/termproof/Cargo.toml
+++ b/rust/crates/termproof/Cargo.toml
@@ -23,11 +23,12 @@ categories = [
 ]
 # The differential tests replay `conformance/corpus/`, which lives at the repository
 # root and is deliberately not shipped (~150 KB of recorded oracle output that no
-# consumer of the library needs). Without the corpus these two tests cannot run,
+# consumer of the library needs). Without the corpus these tests cannot run,
 # so they stay out of the tarball too. Every other test here is self-contained.
 exclude = [
     "tests/differential_steps.rs",
     "tests/differential_assertions.rs",
+    "tests/differential_before_after.rs",
 ]
 
 # Features gate public modules, so `docs.rs` must build with all of them on or

--- a/rust/crates/termproof/README.md
+++ b/rust/crates/termproof/README.md
@@ -272,9 +272,10 @@ example against the driver, and the reversal conditions.
 
 ## Package contents
 
-The two differential tests (`tests/differential_steps.rs`,
-`tests/differential_assertions.rs`) are excluded from the published package —
-they replay a corpus that lives at the repository root and is not shipped.
+The corpus-replaying differential tests (`tests/differential_steps.rs`,
+`tests/differential_assertions.rs`, `tests/differential_before_after.rs`) are
+excluded from the published package — they replay a corpus that lives at the
+repository root and is not shipped.
 
 Everything else in `tests/` ships, including the schema snapshot
 (`tests/snapshots/recipe_schema_v1.json`) and its guard

--- a/rust/crates/termproof/tests/differential_before_after.rs
+++ b/rust/crates/termproof/tests/differential_before_after.rs
@@ -1,0 +1,124 @@
+//! Port half of the before/after differential harness.
+//!
+//! Replays `conformance/corpus/before_after_cases.json` through
+//! `termproof::before_after` and compares the whole recording — every delta
+//! field under the name it carries, in the order it came out, plus the rendered
+//! markdown — against what the oracle recorded in
+//! `conformance/corpus/before_after.expected.json`.
+//!
+//! # Why this exists
+//!
+//! Until #204 these were not two bindings of one thing. They were separate
+//! implementations that disagreed on the delta field names, on both markdown
+//! forms and on the order the deltas came out in, and nothing failed: each side
+//! asserted its own wording in its own unit tests and no test ever ran both. A
+//! consumer with a validator in each language could delete its local copy on the
+//! Rust side and not on the Python side, for the same feature — which is what
+//! "shared" was supposed to mean.
+//!
+//! Both halves of the recording are compared and for different reasons. The
+//! **deltas** are the API a consumer's own reporter reads, so the field names
+//! decide whether upstream can be swapped in for a local copy. The **markdown**
+//! is the report a human reviewer reads, so a divergence there is visible in
+//! published output rather than only in a type signature.
+//!
+//! There is no agreement ratchet here, as there is for steps and assertions:
+//! the two implementations either produce the same report or they do not, and a
+//! partial score for a report format is not a useful number.
+//!
+//! ```sh
+//! cargo test -p termproof --test differential_before_after
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use termproof::before_after::build_before_after;
+use termproof::result::{RunResult, RESULT_SCHEMA_VERSION};
+
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../conformance/corpus")
+}
+
+/// A `RunResult` carrying only the three fields this layer reads.
+///
+/// The rest are fixed rather than absent: the comparison reads `recipe_name`,
+/// `renderer` and `passed` and nothing else, so anything varying here would be
+/// measuring a different module.
+fn result(spec: &serde_json::Value) -> RunResult {
+    let passed = spec["passed"].as_bool().expect("passed is a bool");
+    RunResult {
+        result_version: Some(RESULT_SCHEMA_VERSION),
+        recipe_name: spec["recipe"]
+            .as_str()
+            .expect("recipe is a string")
+            .to_string(),
+        passed,
+        exit_code: Some(if passed { 0 } else { 1 }),
+        duration_seconds: 0.0,
+        priority: "P0".to_string(),
+        execution: "scripted".to_string(),
+        renderer: spec["renderer"]
+            .as_str()
+            .expect("renderer is a string")
+            .to_string(),
+        score: if passed { 1.0 } else { 0.0 },
+        steps: vec![],
+        assertions: vec![],
+        artifacts: BTreeMap::new(),
+    }
+}
+
+fn results(specs: &serde_json::Value) -> Vec<RunResult> {
+    specs
+        .as_array()
+        .expect("a side is an array")
+        .iter()
+        .map(result)
+        .collect()
+}
+
+#[test]
+fn the_computed_deltas_match_the_python_recording() {
+    let corpus = corpus_dir();
+    let cases: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(corpus.join("before_after_cases.json")).expect("cases readable"),
+    )
+    .expect("cases are JSON");
+    let expected: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(corpus.join("before_after.expected.json"))
+            .expect("oracle recording readable"),
+    )
+    .expect("oracle recording is JSON");
+
+    let actual: Vec<serde_json::Value> = cases
+        .as_array()
+        .expect("the corpus is an array of cases")
+        .iter()
+        .map(|case| {
+            let outcome = build_before_after(results(&case["before"]), results(&case["after"]));
+            serde_json::json!({
+                "name": case["name"],
+                // A list, not a set or a map: the order is part of what is
+                // compared, and it is the half of this that a cosmetic refactor
+                // is most likely to undo.
+                "deltas": outcome.deltas.iter().map(|delta| serde_json::json!({
+                    "recipe": delta.recipe,
+                    "renderer": delta.renderer,
+                    "before_outcome": delta.before_outcome,
+                    "after_outcome": delta.after_outcome,
+                    "explanation": delta.explanation(),
+                })).collect::<Vec<_>>(),
+                "markdown": outcome.to_markdown(),
+            })
+        })
+        .collect();
+
+    assert_eq!(
+        serde_json::to_string_pretty(&expected).unwrap(),
+        serde_json::to_string_pretty(&serde_json::Value::Array(actual)).unwrap(),
+        "the Rust before/after report diverged from the recorded Python one; \
+         regenerate the oracle only if the Python side is the one that changed \
+         — see conformance/README.md"
+    );
+}

--- a/rust/docs/publishing.md
+++ b/rust/docs/publishing.md
@@ -325,10 +325,11 @@ The published tarballs are deliberately smaller than the repository:
   oracle expectations (~150 KB). It lives at the repository root, outside every
   crate directory, so it is never packaged. It is a measurement artefact for
   contributors, not something a consumer of the library needs.
-- **`crates/termproof/tests/differential_steps.rs` and
-  `differential_assertions.rs`** — excluded explicitly. They replay
-  `conformance/corpus/`, so without it they cannot run; shipping tests that cannot
-  run is worse than not shipping them. Run them from a repository checkout.
+- **`crates/termproof/tests/differential_steps.rs`,
+  `differential_assertions.rs` and `differential_before_after.rs`** — excluded
+  explicitly. They replay `conformance/corpus/`, so without it they cannot run;
+  shipping tests that cannot run is worse than not shipping them. Run them from
+  a repository checkout.
 - **`specs/`, `docs/`, `.github/`** — repository root, never packaged.
 
 Everything else the crate needs at build time is inside its own directory, and

--- a/rust/docs/status-and-parity.md
+++ b/rust/docs/status-and-parity.md
@@ -27,21 +27,32 @@ moving as it approaches parity.
 
 ## The differential harness
 
-The step and assertion layers are measured against corpora recorded from the
-Python implementation. Each layer has its own harness, each the same two-half
-shape: a Python probe drives the oracle over a checked-in corpus, and a Rust
-test replays the same cases through the port and reports agreement.
+Three layers are measured against corpora recorded from the Python
+implementation. Each layer has its own harness, each the same two-half shape: a
+Python probe drives its side over a checked-in corpus, and a Rust test replays
+the same cases and compares. (A fourth harness, for the evidence manifest,
+builds its scenario in code rather than from a corpus — see
+[`conformance/README.md`](../../conformance/README.md).)
 
 | Layer | Oracle | Port | Corpus |
 |---|---|---|---|
 | Steps | `conformance/probe_steps.py` | `crates/termproof/tests/differential_steps.rs` | `conformance/corpus/cases.json` |
 | Assertions | `conformance/probe_assertions.py` | `crates/termproof/tests/differential_assertions.rs` | `conformance/corpus/assertion_cases.json` |
+| Before/after | `conformance/probe_before_after.py` | `crates/termproof/tests/differential_before_after.rs` | `conformance/corpus/before_after_cases.json` |
 
-The harnesses assert a **floor rather than equality**: agreement can rise but
-must never fall, and panics and cases that never return are asserted at zero
-rather than ratcheted. Full agreement is deliberately **not** required — the
-remaining gaps are open decisions that are not the port's to make (see
-[Known defects and divergences](#known-defects-and-divergences) below).
+The step and assertion harnesses assert a **floor rather than equality**:
+agreement can rise but must never fall, and panics and cases that never return
+are asserted at zero rather than ratcheted. Full agreement is deliberately
+**not** required — the remaining gaps are open decisions that are not the port's
+to make (see [Known defects and divergences](#known-defects-and-divergences)
+below).
+
+The before/after harness has no ratchet and demands equality: it compares a
+report format rather than scoring a corpus, and a partial score for a report
+format is not a useful number. Its direction is also the other way round —
+Rust is the reference and Python was changed to match it (#204), because the
+Rust module is the newer of the two and carries the documented ordering
+rationale.
 
 ## Step layer
 


### PR DESCRIPTION
Closes #204.

## tl;dr

Python's `before_after` now produces the same report as Rust's — same delta
field names, same markdown in both forms, same ordering. Rust is unchanged. A
fourth differential harness compares the two from here, because the divergence
survived two minor releases without a test failing anywhere.

**This changes published report text.** `CHANGELOG.md` shows the empty case and
a populated delta line before and after. No version bump — that is the
maintainer's call.

The drift audit the issue asks for is at the bottom: **six other module pairs**
have drifted the same way, one of them in a document both implementations write
to disk.

## What changed

`python/termproof/before_after.py`, to match `rust/crates/termproof/src/before_after.rs`:

| | was | is |
|---|---|---|
| delta fields | `recipe_name`, `renderer`, `before`, `after` | `recipe`, `renderer`, `before_outcome`, `after_outcome` |
| empty markdown | `## Behavioral Deltas` / blank / `None.` | `**Behavioral deltas:** none — before/after outcomes match.` |
| delta line | ``- `recipe_name` [renderer]: PASS -> FAIL`` | `- recipe [renderer]: PASS -> FAIL` |
| ordering | `sorted()` over the key union | `before` order, new arrivals appended |

`BehaviorDelta` also gained `explanation()` and the module exports `PASS`,
`FAIL`, `SKIP` — both of which Rust already had, and the first of which is what
the markdown is built from on both sides now.

**Ordering is the substantive one**, and the reasoning came across with the
behaviour rather than only the code: the docstring on `compute_deltas` says
*why* it does not sort, in `compute_deltas`, where the next person to reach for
`sorted()` will read it. A reviewer wants deltas in the order the recipes ran,
and two reports either side of a change line up when diffed.

Which outcomes count as deltas did not change. Neither did anything in Rust.

## Tests

`python/tests/test_before_after.py`, 14 cases mirroring the Rust module's own
unit tests, plus three that exist specifically for the ordering rule — it is the
one a later cosmetic refactor would silently undo, because `sorted()` looks
tidier and passes every other test in the file.

Each new test was verified red by breaking the thing it guards, one mutation at
a time, on the real module:

| mutation | result |
|---|---|
| ordering back to `sorted()` over the key union | `FAILED (failures=4)` |
| empty markdown back to the `## Behavioral Deltas` form | `FAILED (failures=1)` |
| delta line back to the backticked form | `FAILED (failures=6)` |
| `recipe` renamed back to `recipe_name` | `FAILED (errors=4)` |
| populated-section heading back to `## Behavioral Deltas` | `FAILED (failures=1)` |

Nothing stayed green. Full suite: **904 passed** (was 890), `ruff` and `mypy`
clean.

## Conformance

I added a **fourth harness pair** rather than extending
`probe_evidence_manifest.py` / `differential_evidence_manifest.rs`, for two
reasons:

1. That pair compares the document `EvidenceCollector::publish` writes and the
   files it wrote. A before/after report is not produced by a publish, so it is
   not a surface that pair should be comparing.
2. `differential_evidence_manifest.rs` is `#![cfg(feature = "evidence")]`.
   Putting `before_after` in it would make a feature able to compile this
   comparison out, which `rust/docs/engineering-baseline.md` explicitly forbids
   — "a feature must not be able to compile a differential harness out". The new
   harness is ungated, as `before_after` itself is.

- `conformance/probe_before_after.py` drives the Python module over
  `conformance/corpus/before_after_cases.json` and records every delta field
  under the name it carries, in order, plus the rendered markdown.
- `rust/crates/termproof/tests/differential_before_after.rs` replays the same
  cases through Rust and compares the whole recording. No ratchet — this is a
  report format, and a partial score for a report format is not a useful number.
- Ten cases: the empty markdown twice, each outcome transition, two renderers,
  and three separate ordering cases (`before` order out of alphabetical order,
  the appended tail, and the rule itself), so a `sorted()` anywhere in either
  pipeline reverses a list rather than leaving it be.
- Direction is documented in `conformance/README.md`: **Rust is the reference
  for this layer**, which is the opposite of the other three. If the halves
  disagree, fix Rust's side only if Rust is what changed.

I verified the corpus actually discriminates by re-running the oracle under each
mutation above and diffing against the checked-in expectation: `sorted()`
ordering differs by 30 lines, the empty markdown by 4, and the field rename
makes the probe fail outright. All three are red signals through the Rust half
too — the first two as a document mismatch, the third as a compile error.

Doc and packaging surfaces updated with the fourth harness:
`conformance/README.md`, `rust/docs/status-and-parity.md`,
`rust/docs/publishing.md`, `rust/crates/termproof/README.md`, the crate's
`exclude` list and `.github/scripts/rust/verify-package-contents.sh` (it replays
the root corpus, so it must not ship), and the harness note in `AGENTS.md`.

## What I could not verify locally

**Rust tests do not execute in this sandbox.** Every locally built native binary
is `SIGKILL`ed on start — including a `rustc` hello-world and every pre-existing
test binary in this tree, so it is environmental and not this change. What I did
run: `cargo build`, `cargo fmt --check --all` (clean), `cargo clippy --workspace
--all-targets --all-features -- -D warnings` (clean), and
`cargo test --test differential_before_after --no-run` (compiles).

So `differential_before_after` has been compiled but not executed. Its
correctness rests on the Rust module being unchanged and on the oracle recording
having been produced by a Python module that now mirrors it line for line;
key-ordering is safe because `preserve_order` is off workspace-wide, so both
sides of the `assert_eq!` serialise through the same `BTreeMap`-backed
`serde_json::Map`. Please treat CI's run of that one test as the real signal.

## `cargo semver-checks`

I do not expect this to trip it: nothing in the Rust public API changed. The
break is on the Python side — `BehaviorDelta`'s four field names — and it is a
break, recorded in `CHANGELOG.md` under `Python — Changed (breaking)` rather
than bumped. Per the brief, the version consequence is the maintainer's.

---

## Drift audit: has any other module pair drifted the same way?

Yes. Six, ordered by how much a consumer would notice. **None is touched by this
PR** — each wants its own issue.

The pattern to look for is not "the two files differ". It is: *the same named
concept, produced by both implementations, that a consumer or a reader compares
across them, with no harness over it.* `before_after` was only caught because
someone adopted both halves on the same day, which is not a detection strategy.

### 1. `result_version` is written by Rust and does not exist in Python — highest severity

`rust/crates/termproof/src/result.rs` defines `RESULT_SCHEMA_VERSION`, and
`runner.rs:162` stamps `result_version: Some(RESULT_SCHEMA_VERSION)` onto every
`RunResult` it produces, so every Rust `result.json` carries the key. Python's
`models.RunResult` has no such field and `grep -rn result_version
python/termproof/` returns nothing.

This is the worst shape of the four in the issue's table, because it is not a
report a human reads — it is **a document both implementations write to disk and
both read back**. Rust also has a whole readability window around it
(`OLDEST_READABLE_RESULT_VERSION`, `is_readable`, a typed refusal of a
future-version payload) that Python has no counterpart for, so Python will
happily parse a payload Rust would refuse, and the first bump of
`RESULT_SCHEMA_VERSION` is when that stops being theoretical. Nothing compares
the two documents today.

### 2. `build_info` — the same three axes as `before_after`, plus a mode

| | Rust | Python |
|---|---|---|
| change identifier | `change_id` | `source_ref` |
| commit | `commit_hash` | `git_commit` |
| timestamp | `build_timestamp: Option<String>` | `timestamp: str`, required |
| the command | *absent* | `command: list[str]` |
| binary path | `binary_path: String` | `binary_path: str \| None` |
| modes | `installed`, `source`, **`package`** | `installed`, `source` |
| constructors | `from_installed`, `from_source_build` | `from_command`, `from_binary`, `from_source_build` |
| serialisation | *none* | `to_dict()`, 9 keys incl. `provenance_verified` |

The mode row is behavioural, not cosmetic: `MODE_PACKAGE` verifies in Rust and
falls through to `return False` in Python, so the same packaged binary is
provenance-verified by one implementation and not the other. `to_dict()` is also
the shape of finding 1 — a Python-only serialisation of a shared concept, with
nothing holding its keys to anything.

### 3. `report` / `evidence::report` — the aggregate markdown

The table, the header and the `<details>` blocks match. Three things do not:

- **Rust's `generate_markdown(results)` takes no `build_info` and no
  `before_after`.** Python's takes both and emits a `## Build Provenance`
  section and the delta section. A Rust aggregate report structurally cannot
  contain either. This is the same "adoptable in one language, not the other"
  shape as #204.
- **Empty artifact values.** Python's `_evidence_links` skips a falsy value;
  Rust's `evidence_links` renders `[screenshot]()` for `Some("")`.
- **Score rounding.** `{:.2}` rounds half away from zero, `:.2f` rounds half to
  even, so a score of exactly `0.125` prints `0.13` in Rust and `0.12` in
  Python. Narrow, but it is a published number.

### 4. `run_cache` / `cache` — the key inputs disagree

Python's `_cache_key` folds the whole `EvidenceConfig` into the digest, with a
comment explaining that this is deliberate so a rendering knob added later
invalidates cached runs without anyone remembering. Rust's `cache_key` has no
evidence component at all — partly downstream of finding 5. They also disagree
on the missing-recipe case: Python returns `None` (do not cache), Rust hashes
`b"<missing>"` and returns a key. Lower severity, because a cache directory is
not a shared artifact — but "same recipe, same options, different hit/miss" is
still surprising.

### 5. `config` — `VerifierConfig` is a different type in each language

Python's carries `EvidenceConfig`, `SvgRenderConfig`, `PngRenderConfig` and
`VideoConfig`; Rust's has `GlobalDefaults` and `DockerBackendConfig` and none of
the evidence rendering sections. Both read the same cascading config files and
the same legacy `tui-verifier` paths, so a `evidence:` block that is load-bearing
for one implementation is silently inert in the other. Arguably a feature gap
rather than drift, which is why it is down here — but it is the root of finding 4.

### 6. `selection` — same names, different engine

Same function names and same intent. Rust bundles `always` / `harness_paths` /
`root_marker` into a `SelectionConfig` struct where Python takes keyword
arguments — that is a language difference and fine. What is not: Rust globs
through `globset` with `literal_separator(false)` and **skips a pattern that
fails to compile**, where Python uses `fnmatch`, which has no compile step and
no such skip. A `ci_paths` entry that is a valid `fnmatch` pattern and an invalid
`globset` one selects in Python and is dropped in Rust. Lowest confidence of the
six — I did not construct the pattern that separates them.

### Not a finding, but adjacent

Rust's `before_after::Comparable` trait — which exists so a consumer whose
results carry extra fields need not convert to `RunResult` and back — has no
Python counterpart. Python is duck-typed and already works this way at runtime,
but the annotations say `list[RunResult]`, so a type-checked consumer cannot
express it. Deliberately left out of this change: it is an addition, not a
divergence, and it is not in the issue's table.
